### PR TITLE
extend installed? with Error check

### DIFF
--- a/bin/brewdle
+++ b/bin/brewdle
@@ -45,7 +45,7 @@ end
 
 def installed?(name)
   installed = `brew list #{name} -v`
-  if installed.length > 0
+  if installed.length > 0 && !installed.match(/\AError/)
     return installed.split(' ').last
   end
 end


### PR DESCRIPTION
homebrew returns a string like 'Error: No such keg: /usr/local/Cellar/kegname',  if a keg is not present. so 
installed? would return true if the requested dependency is not installed.
