### PR TITLE
Make `brewdler` output more `bundler`-like

### DIFF
--- a/bin/brewdle
+++ b/bin/brewdle
@@ -25,9 +25,12 @@ command :install do |c|
     end
 
     dependencies.each do |dependency|
-      installed_version = installed?(dependency)
-      puts "#{installed_version ? 'Using' : 'Installing'}: #{dependency} #{installed_version}"
-      install(dependency) unless installed_version
+      if installed?(dependency)
+        puts "Using #{dependency} (#{installed_version(dependency)})"
+      else
+        puts "Installing #{dependency} (#{formula_version(dependency)})"
+        install(dependency)
+      end
     end
 
     puts "All dependencies installed"
@@ -44,10 +47,18 @@ def install(name)
 end
 
 def installed?(name)
-  installed = `brew list #{name} -v`
-  if installed.length > 0 && !installed.match(/\AError/)
-    return installed.split(' ').last
-  end
+  installed_version = `brew list --versions #{name}`.chomp
+  !installed_version.empty?
+end
+
+def installed_version(name)
+  installed_version = `brew list --versions #{name}`.chomp
+  installed_version.match(/#{name} ([^\s]+)/)[1]
+end
+
+def formula_version(name)
+  formula_version = `brew info #{name}`
+  formula_version.split($/).first.match(/#{name}: stable ([^\s,]+)/)[1]
 end
 
 def comment?(line)


### PR DESCRIPTION
Hey @andrew, great little utility... it's definitely scratching one of my itches!  :smiley:

This pull request makes the output generated by `brewdle` more like the output generated by `bundle`, especially w.r.t. the version numbers of the formulae.

So for brew formulae that are already installed:

```
Using ack (1.96)
```

And for brew formulae that are missing:

```
Installing tree (1.6.0)
```

So you get something like this:

``` shell
$ brewdle install 
Using ack (1.96)
Using tree (1.6.0)
Using ttyrec (1.0.8)
Using mongodb (2.2.2-x86_64)
All dependencies installed
$ brew remove tree
Uninstalling /usr/local/Cellar/tree/1.6.0...
$ brewdle install 
Using ack (1.96)
Installing tree (1.6.0)
==> ...
Using ttyrec (1.0.8)
Using mongodb (2.2.2-x86_64)
All dependencies installed
$ brewdle install
Using ack (1.96)
Using tree (1.6.0)
Using ttyrec (1.0.8)
Using mongodb (2.2.2-x86_64)
All dependencies installed
$ _
```

Thanks for your consideration!
