### PR TITLE
Use Enumerable#find_all instead of #each

### DIFF
--- a/bin/brewdle
+++ b/bin/brewdle
@@ -13,12 +13,9 @@ command :install do |c|
   c.action do |args, options|
 
     begin
-      dependencies = []
-      File.open(File.join(Dir.pwd, 'Brewfile')).each { |line|
+      dependencies = File.open(File.join(Dir.pwd, 'Brewfile')).find_all { |line|
         line.chomp!
-        if line.length > 0 && !comment?(line)
-          dependencies << line
-        end
+        line.length > 0 && !comment?(line)
       }
     rescue
       puts 'No Brewfile found'


### PR DESCRIPTION
Hey @andrew, just refactoring the code to determine the list of dependencies a bit _(no functional changes to the script whatsoever)_.

This change simplifies the Ruby code a wee bit, as we don't have to create & build up the array of dependencies ourselves!

Cheers!
