### PR TITLE
Check that all required formulae exist before processing the dependencies

### DIFF
--- a/bin/brewdle
+++ b/bin/brewdle
@@ -21,16 +21,25 @@ command :install do |c|
       puts 'No Brewfile found'
     end
 
-    dependencies.each do |dependency|
-      if installed?(dependency)
-        puts "Using #{dependency} (#{installed_version(dependency)})"
-      else
-        puts "Installing #{dependency} (#{formula_version(dependency)})"
-        install(dependency)
+    missing_formulae = dependencies.find_all { |dependency|
+      !formula_exists?(dependency)
+    }
+
+    if missing_formulae.empty?
+      dependencies.each do |dependency|
+        if installed?(dependency)
+          puts "Using #{dependency} (#{installed_version(dependency)})"
+        else
+          puts "Installing #{dependency} (#{formula_version(dependency)})"
+          install(dependency)
+        end
       end
+      puts "All dependencies installed"
+    else
+      puts "Non-existent formula/e: #{missing_formulae.join(', ')}"
+      puts "(please check spelling in Brewfile, and/or run 'brew update')"
     end
 
-    puts "All dependencies installed"
   end
 end
 
@@ -41,6 +50,11 @@ def install(name)
   else
     puts "Error: No available formula for #{name}"
   end
+end
+
+def formula_exists?(name)
+  formula_location = File.join(`brew --prefix`.chomp, 'Library', 'Formula', name + ".rb")
+  File.exists? formula_location
 end
 
 def installed?(name)


### PR DESCRIPTION
Hey @andrew, the changes in this pull request deal with situations where a dependency listed in the `Brewfile` is misspelled or non-existent _(ie. no corresponding Homebrew formula can be found)_.

Before processing any of the dependencies listed in a Brewfile, brewdler will now check that the currently installed version of homebrew includes a formula for every single dependency.

This avoids confusing error messages downstream when brewdler is trying to execute the `brew list` or the `brew info` command for a dependency that doesn't have a corresponding brew formula.

Thanks, @pvdb

EDIT - BTW, the [whitespace-suppressed diff](https://github.com/andrew/brewdler/pull/8/files?w=1) is easier on the eye :smile:
