### PR TITLE
"cask" description raises an error

### DIFF
--- a/lib/brewdler/cask_installer.rb
+++ b/lib/brewdler/cask_installer.rb
@@ -1,7 +1,7 @@
 module Brewdler
   class CaskInstaller
     def self.install(name)
-      if system 'brew cask info'
+      if system 'brew cask > /dev/null'
         `brew cask install #{name}`
       else
         raise "Unable to install #{name}. Homebrew-cask is not currently installed on your system"


### PR DESCRIPTION
In my environment (2012 MBP Retina 15' and OSX Mavericks), 
"cask" description in Brewfile always raises an error and I cannot install any casks.

In Brewfile:  

> cask 'google-chrome'

and exec "brewdle install", I got below error:

> Error: This command requires a cask's name
> error: Unable to install google-chrome. Homebrew-cask is not currently installed on your system. Use --trace to view backtrace

It seems to me that latest Homebrew-cask cannot accept 'brew cask info' command without an cask's name.
I changed it to just "brew cask" command.
