### PR TITLE
cask dumper: chomp the trailing " (!)"

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -4,7 +4,7 @@ module Bundle
 
     def initialize
       if Bundle.cask_installed?
-        @casks = `brew cask list`.split
+        @casks = `brew cask list -1`.split("\n").map { |cask| cask.chomp " (!)" }
       else
         @casks = []
       end


### PR DESCRIPTION
Cask would add ` (!)` into cask name if the cask is not availabled or
some temporary errors.