### PR TITLE
bug_fix: full_name instead of name for brew bundle dump

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -16,10 +16,10 @@ module Bundle
     def to_s
       @formulae.map do |f|
         if f[:args].empty?
-          "brew '#{f[:full_name]}'"
+          "brew '#{f[:name]}'"
         else
           args = f[:args].map { |arg| "'#{arg}'" }.join(", ")
-          "brew '#{f[:full_name]}', args: [#{args}]"
+          "brew '#{f[:name]}', args: [#{args}]"
         end
       end.join("\n")
     end


### PR DESCRIPTION
When I tried 'brew bundle dump', I was just getting empty strings for all of the regular brew packages. This seems to fix it. I did not trigger the else condition but outputting the file showed that full_name was nil.