### PR TITLE
Fix shebang so brew bundle works on Linux

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,9 @@ Bundler for non-Ruby dependencies from Homebrew
 
 ## Requirements
 
-[Homebrew](http://github.com/Homebrew/homebrew) is used for installing the dependencies, it only works on OS X and so does this tool.
+[Homebrew](http://github.com/Homebrew/homebrew) or [Linuxbrew](https://github.com/homebrew/linuxbrew) are used for installing the dependencies.
+Linuxbrew is a fork of Homebrew for Linux, while Homebrew only works on Mac OS X.
+This tool is primarily developed for use with Homebrew on Mac OS X but should work with Linuxbrew on Linux, too.
 
 [brew tap](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md) is new feature in Homebrew 0.9, adds more GitHub repos to the list of available formulae.
 

--- a/cmd/brew-bundle
+++ b/cmd/brew-bundle
@@ -1,4 +1,7 @@
-#!/usr/bin/env ruby -W0
+#!/usr/bin/env ruby
+
+# Set verbosity level to 0
+$VERBOSE = nil
 
 # Ruby version check
 unless RUBY_VERSION.split(".").first.to_i >= 2

--- a/lib/bundle/utils.rb
+++ b/lib/bundle/utils.rb
@@ -17,15 +17,15 @@ module Bundle
   end
 
   def self.brew_installed?
-    @@brew ||= Kernel.system("brew --version &>/dev/null")
+    @@brew ||= Kernel.system("brew --version >/dev/null 2>&1")
   end
 
   def self.cask_installed?
-    @@cask ||= Kernel.system("brew cask --version &>/dev/null")
+    @@cask ||= Kernel.system("brew cask --version >/dev/null 2>&1")
   end
 
   def self.services_installed?
-    @@services ||= Kernel.system("brew services --help &>/dev/null")
+    @@services ||= Kernel.system("brew services --help >/dev/null 2>&1")
   end
 
   def self.brewfile


### PR DESCRIPTION
See the discussion in https://github.com/Homebrew/homebrew-bundle/issues/1.

This pull request fixes the shebang in `/cmd/brew-bundle` so that it can run on Linux. In Linux, the `#!/usr/bin/env` shebang previously tried to run the executable "ruby -W0", which returned the error:

    /usr/bin/env: ruby -W0: No such file or directory

(See, for example, [Bash trace mode (bash -x) in the shebang](http://stackoverflow.com/q/24032641/2571049) on Stack Overflow.)

By changing this to `#!/bin/sh` and making the call to ruby with `exec ruby -x "$0" "$@"`, this problem is solved.

`man ruby` tells us for the flag `-x` that:

>      -x[directory]  Tells Ruby that the script is embedded in a message.  Leading garbage will be discarded until the first line that starts with ``#!'' and con-
                    tains the string, ``ruby''.  Any meaningful switches on that line will be applied.  The end of the script must be specified with either EOF,
                    ^D (control-D), ^Z (control-Z), or the reserved word __END__.  If the directory name is specified, Ruby will switch to that directory before
                    executing script.

This is why `/cmd/brew-bundle` now has `__END__` at the end of the file.

I've tested this on both Mac (10.10.5) and Ubuntu (14.04).