### PR TITLE
Expand the path of the `--file` argument

### DIFF
--- a/lib/bundle/utils.rb
+++ b/lib/bundle/utils.rb
@@ -33,8 +33,13 @@ module Bundle
       file = "#{ENV["HOME"]}/.Brewfile"
     else
       file = ARGV.value("file")
-      file = "/dev/stdin" if file == "-"
-      file ||= "Brewfile"
+      if file == "-"
+        file = "/dev/stdin"
+      elsif file.nil?
+        file = "Brewfile"
+      else
+        file = File.expand_path(file)
+      end
     end
     File.read(file)
   rescue Errno::ENOENT


### PR DESCRIPTION
`brew bundle --file=~/Brewfile` didn't work because the `~` was not expanded.

Now we expand the whole path so that people can pass more idiomatic paths to
`brew bundle.`

About tests: I couldn't find any tests for the functions in `utils.rb`. I don't know what this project's policy on tests for the functions in that file is (maybe I missed something!) but if you'd like, I can add unit tests for at least `Bundle.brewfile`.