### PR TITLE
brew_dumper: handle missing keg in JSON.

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -74,6 +74,7 @@ module Bundle
       else
         keg = installed.detect { |k| f["linked_keg"] == k["version"] }
       end
+      keg ||= {}
       args = keg["used_options"].map { |option| option.gsub(/^--/, "") }
       args << "HEAD" if keg["version"] == "HEAD"
       args << "devel" if keg["version"].gsub(/_\d+$/, "") == f["versions"]["devel"]


### PR DESCRIPTION
Closes #121.