### PR TITLE
Uninstall to handle version conflicts

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -7,8 +7,13 @@ module Bundle
     end
 
     def self.install(name, options = {})
-      result = new(name, options).install_or_upgrade
-      result = BrewServices.restart(name) if result && options[:restart_service]
+      if options[:uninstall]
+        result = new(name, options).uninstall!
+        result = BrewServices.stop(name) if result && options[:stop_service]
+      else
+        result = new(name, options).install_or_upgrade
+        result = BrewServices.restart(name) if result && options[:restart_service]
+      end
       result
     end
 
@@ -28,6 +33,12 @@ module Bundle
       else
         install!
       end
+    end
+
+    def uninstall!
+      puts "Uninstalling #{@name} formula." if ARGV.verbose?
+      success = Bundle.system("brew", "uninstall", @full_name, *@args)
+      success
     end
 
     def self.formula_installed_and_up_to_date?(formula)

--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -5,6 +5,11 @@ module Bundle
       Bundle.system "brew", "services", "restart", name
     end
 
+    def self.stop(name)
+      ensure_brew_services_installed!
+      Bundle.system "brew", "services", "stop", name
+    end
+
     def self.ensure_brew_services_installed!
       unless Bundle.services_installed?
         Bundle.system "brew", "tap", "homebrew/services"


### PR DESCRIPTION
The high level problem I'd love to see `brew bundle` solve is working with version'd taps. A project may depend on a specific version of mysql. At the moment, homebrews main method of installing older versions of a formula is to use the `homebrew-versions` tap. However, you can only have one version of each of these installed at the same time. If you just add `homebrew/versions/mysql56` to your Brewfile, you'll run into conflicts if the user already has `mysql` installed.

While its still not ideal, it'd be great if `brew bundle` could resolve this conflict by removing any conflicting versions and installing the specific version required to use the project.

``` ruby
brew "mysql", uninstall: true, stop_service: true
brew "homebrew/versions/mysql56", restart_service: true
```

The current implementation attached is pretty terrible. I'm all for rewriting it or doing this completely differently. Just wanted to a discussion going with some sort of proposed approach.

To: @mikemcquaid 