### PR TITLE
Rename command to `brew-bundler.rb`.

### DIFF
--- a/cmd/brew-bundle
+++ b/cmd/brew-bundle
@@ -1,98 +1,25 @@
-#!/usr/bin/env ruby
-
-# Set verbosity level to 0
-$VERBOSE = nil
-
-# Ruby version check
-unless RUBY_VERSION.split(".").first.to_i >= 2
-  abort "Ruby 2.0 or above is required. You can install it with `brew install ruby`."
-end
-
-# Load Homebrew Library
-require "pathname"
-HOMEBREW_LIBRARY_PATH = Pathname.new(ENV["HOMEBREW_LIBRARY_PATH"])
-$LOAD_PATH.unshift HOMEBREW_LIBRARY_PATH
-require "global"
-
-# Homebrew version check
-# commit f3cf43acfc764acba84fa20b4c42a3e0b5382589
-MIN_HOMEBREW_COMMIT_DATE = Time.parse "Wed Oct 14 17:26:41 2015 +0800"
-HOMEBREW_REPOSITORY.cd do
-  if MIN_HOMEBREW_COMMIT_DATE > Time.at(`git show -s --format=%ct`.to_i)
-    odie "Your Homebrew is outdated. Please run `brew update`."
-  end
-end
-
-BUNDLE_ROOT = File.expand_path "#{File.dirname(__FILE__)}/.."
-BUNDLE_LIB = Pathname.new(BUNDLE_ROOT)/"lib"
-
-$LOAD_PATH.unshift(BUNDLE_LIB)
-
-require "bundle"
-
-usage = <<-EOS.undent
-  brew bundle [-v|--verbose] [--file=<path>|--global]
-  brew bundle dump [--force] [--file=<path>|--global]
-  brew bundle cleanup [--force] [--file=<path>|--global]
-  brew bundle check [--file=<path>|--global]
-  brew bundle [--version]
-  brew bundle [-h|--help]
-
-  Usage:
-  Bundler for non-Ruby dependencies from Homebrew
-
-  brew bundle            install or upgrade all dependencies in a Brewfile
-  brew bundle dump       write all installed casks/formulae/taps into a Brewfile
-  brew bundle cleanup    uninstall all dependencies not listed in a Brewfile
-  brew bundle check      check if all dependencies are installed in a Brewfile
-
-  Options:
-  -v, --verbose          print verbose output
-  --force                uninstall dependencies or overwrite existing Brewfile
-  --file=<path>          set Brewfile path
-  --global               set Brewfile path to $HOME/.Brewfile
-  -h, --help             show this help message and exit
-  --version              show the version of homebrew-bundle
-EOS
-
-if ARGV.include?("--version")
-  puts Bundle::VERSION
-  exit 0
-end
-
-if ARGV.flag?("--help")
-  puts usage
-  exit 0
-end
-
-begin
-  case ARGV.named[0]
-  when nil, "install"
-    Bundle::Commands::Install.run
-  when "dump"
-    Bundle::Commands::Dump.run
-  when "cleanup"
-    Bundle::Commands::Cleanup.run
-  when "check"
-    Bundle::Commands::Check.run
+#!/bin/bash
+check_ruby() {
+  local RUBY="$1"
+  if [ -n "$RUBY" ] && [ "$("$RUBY" -e "puts RUBY_VERSION.split('.')[0]")" = "2" ]
+  then
+    HOMEBREW_BUNDLE_RUBY="$RUBY"
   else
-    abort usage
-  end
-rescue SystemExit
-  puts "Kernel.exit" if ARGV.verbose?
-  raise
-rescue Interrupt
-  puts # seemingly a newline is typical
-  exit 130
-rescue RuntimeError, SystemCallError => e
-  raise if e.message.empty?
-  onoe e
-  puts e.backtrace if ARGV.debug?
+    false
+  fi
+}
+
+if ! check_ruby "$HOMEBREW_RUBY_PATH" && ! check_ruby "ruby"
+then
+  echo "Ruby 2.0 or above is required. You can install it with `brew install ruby`." >&2
   exit 1
-rescue Exception => e
-  onoe e
-  puts "#{Tty.white}Please report this bug:"
-  puts "    #{Tty.em}https://github.com/Homebrew/homebrew-bundle/issues/#{Tty.reset}"
-  puts e.backtrace
-  exit 1
-end
+fi
+
+COMMAND="$(basename "${BASH_SOURCE[0]}" | tr "-" " ")"
+if [ "$COMMAND" != "brew bundle" ]
+then
+  echo "Warning: the '$COMMAND' command has been renamed to 'brew bundle'." >&2
+fi
+
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$HOMEBREW_BUNDLE_RUBY" "$BASE_PATH/cmd/brew-bundle.rb" $@

--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+
+# Set verbosity level to 0
+$VERBOSE = nil
+
+# Ruby version check
+unless RUBY_VERSION.split(".").first.to_i >= 2
+  abort "Ruby 2.0 or above is required. You can install it with `brew install ruby`."
+end
+
+# Load Homebrew Library
+require "pathname"
+HOMEBREW_LIBRARY_PATH ||= Pathname.new(ENV["HOMEBREW_LIBRARY_PATH"])
+$LOAD_PATH.unshift HOMEBREW_LIBRARY_PATH
+require "global"
+
+# Homebrew version check
+# commit f3cf43acfc764acba84fa20b4c42a3e0b5382589
+MIN_HOMEBREW_COMMIT_DATE = Time.parse "Wed Oct 14 17:26:41 2015 +0800"
+HOMEBREW_REPOSITORY.cd do
+  if MIN_HOMEBREW_COMMIT_DATE > Time.at(`git show -s --format=%ct`.to_i)
+    odie "Your Homebrew is outdated. Please run `brew update`."
+  end
+end
+
+BUNDLE_ROOT = File.expand_path "#{File.dirname(__FILE__)}/.."
+BUNDLE_LIB = Pathname.new(BUNDLE_ROOT)/"lib"
+
+$LOAD_PATH.unshift(BUNDLE_LIB)
+
+require "bundle"
+
+usage = <<-EOS.undent
+  brew bundle [-v|--verbose] [--file=<path>|--global]
+  brew bundle dump [--force] [--file=<path>|--global]
+  brew bundle cleanup [--force] [--file=<path>|--global]
+  brew bundle check [--file=<path>|--global]
+  brew bundle [--version]
+  brew bundle [-h|--help]
+
+  Usage:
+  Bundler for non-Ruby dependencies from Homebrew
+
+  brew bundle            install or upgrade all dependencies in a Brewfile
+  brew bundle dump       write all installed casks/formulae/taps into a Brewfile
+  brew bundle cleanup    uninstall all dependencies not listed in a Brewfile
+  brew bundle check      check if all dependencies are installed in a Brewfile
+
+  Options:
+  -v, --verbose          print verbose output
+  --force                uninstall dependencies or overwrite existing Brewfile
+  --file=<path>          set Brewfile path
+  --global               set Brewfile path to $HOME/.Brewfile
+  -h, --help             show this help message and exit
+  --version              show the version of homebrew-bundle
+EOS
+
+if ARGV.include?("--version")
+  puts Bundle::VERSION
+  exit 0
+end
+
+if ARGV.flag?("--help")
+  puts usage
+  exit 0
+end
+
+begin
+  case ARGV.named[0]
+  when nil, "install"
+    Bundle::Commands::Install.run
+  when "dump"
+    Bundle::Commands::Dump.run
+  when "cleanup"
+    Bundle::Commands::Cleanup.run
+  when "check"
+    Bundle::Commands::Check.run
+  else
+    abort usage
+  end
+rescue SystemExit
+  puts "Kernel.exit" if ARGV.verbose?
+  raise
+rescue Interrupt
+  puts # seemingly a newline is typical
+  exit 130
+rescue RuntimeError, SystemCallError => e
+  raise if e.message.empty?
+  onoe e
+  puts e.backtrace if ARGV.debug?
+  exit 1
+rescue Exception => e
+  onoe e
+  puts "#{Tty.white}Please report this bug:"
+  puts "    #{Tty.em}https://github.com/Homebrew/homebrew-bundle/issues/#{Tty.reset}"
+  puts e.backtrace
+  exit 1
+end


### PR DESCRIPTION
This means it'll use the Homebrew Ruby rather than whatever Ruby is in your path. This also means if you're using it to e.g. install some project dependencies to install a Ruby that does not already exist then
you do not need to do e.g. `RBENV_VERSION=system` first.

If we want to make it easier for people to run e.g. on 10.9 with an old Ruby (although I think it might be worth waiting for user requests first) we can loosen the `HOMEBREW_DEVELOPER` check in https://github.com/Homebrew/homebrew/pull/45816 to not require `HOMEBREW_DEVELOPER` to be set.

CC @xu-cheng for thoughts.