### PR TITLE
BrewDumper: handle bad keg JSON more strictly.

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -70,21 +70,28 @@ module Bundle
     def self.formula_inspector(f)
       installed = f["installed"]
       if f["linked_keg"].nil?
-        keg = installed[-1]
+        keg = installed.last
       else
         keg = installed.detect { |k| f["linked_keg"] == k["version"] }
       end
-      keg ||= {}
-      args = keg["used_options"].map { |option| option.gsub(/^--/, "") }
-      args << "HEAD" if keg["version"] == "HEAD"
-      args << "devel" if keg["version"].gsub(/_\d+$/, "") == f["versions"]["devel"]
-      args.uniq!
+
+      if keg
+        args = keg["used_options"].to_a.map { |option| option.gsub(/^--/, "") }
+        args << "HEAD" if keg["version"] == "HEAD"
+        args << "devel" if keg["version"].to_s.gsub(/_\d+$/, "") == f["versions"]["devel"]
+        args.uniq!
+        version = keg["version"]
+      else
+        args = []
+        version = nil
+      end
+
       {
         :name => f["name"],
         :full_name => f["full_name"],
         :aliases => f["aliases"],
         :args => args,
-        :version => keg["version"],
+        :version => version,
         :dependencies => f["dependencies"],
         :requirements => f["requirements"],
       }

--- a/spec/brewdumper_spec.rb
+++ b/spec/brewdumper_spec.rb
@@ -43,6 +43,29 @@ describe Bundle::BrewDumper do
     end
   end
 
+  context "when Homebrew returns JSON with a malformed linked_keg" do
+    before do
+      Bundle::BrewDumper.reset!
+      allow(Bundle).to receive(:brew_installed?).and_return(true)
+      allow(Bundle::BrewDumper).to receive(:`).and_return('[{"name":"foo","full_name":"homebrew/tap/foo","desc":"","homepage":"","oldname":null,"aliases":[],"versions":{"stable":"1.0","bottle":false},"revision":0,"installed":[{"version":"1.0","used_options":[],"built_as_bottle":null,"poured_from_bottle":true}],"linked_keg":"fish","keg_only":null,"dependencies":[],"conflicts_with":[],"caveats":null,"requirements":[],"options":[],"bottle":{}}]')
+    end
+    subject { Bundle::BrewDumper }
+
+    it "returns no version" do
+      expect(subject.formulae).to contain_exactly *[
+        {
+          :name => "foo",
+          :full_name => "homebrew/tap/foo",
+          :aliases => [],
+          :args => [],
+          :version => nil,
+          :dependencies => [],
+          :requirements => [],
+        },
+      ]
+    end
+  end
+
   context "formulae `foo` and `bar` are installed" do
     before do
       Bundle::BrewDumper.reset!


### PR DESCRIPTION
If we didn't get a keg back then ensure we don't try to read it in any form. Also, tweak how we read it so bad or missing data won't make it explode.

Closes https://github.com/Homebrew/homebrew-bundle/issues/125