### PR TITLE
Use the same time format for parsing commit.

### DIFF
--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -14,7 +14,7 @@ end
 # commit d6b31251e20597842afa386f12f32013e3c13f21
 MIN_HOMEBREW_COMMIT_DATE = Time.parse "Fri Nov 27 16:40:16 2015 +0000"
 HOMEBREW_REPOSITORY.cd do
-  if MIN_HOMEBREW_COMMIT_DATE > Time.at(`git show -s --format=%ct`.to_i)
+  if MIN_HOMEBREW_COMMIT_DATE > Time.parse(`git show -s --format=%cd`)
     odie "Your Homebrew is outdated. Please run `brew update`."
   end
 end


### PR DESCRIPTION
Otherwise you can see issues with timezones. CC @zawaideh who I'm pretty sure just hit this.