### PR TITLE
Require bundler explicitly

### DIFF
--- a/spec/brew_installer_spec.rb
+++ b/spec/brew_installer_spec.rb
@@ -6,7 +6,7 @@ describe Bundle::BrewInstaller do
   let(:installer) { Bundle::BrewInstaller.new(formula, options) }
 
   def do_install
-    Bundler.with_clean_env { installer.install_or_upgrade }
+    installer.install_or_upgrade
   end
 
   context "restart_service option is true" do

--- a/spec/check_command_spec.rb
+++ b/spec/check_command_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Bundle::Commands::Check do
   def do_check
-    Bundler.with_clean_env { Bundle::Commands::Check.run }
+    Bundle::Commands::Check.run
   end
 
   context "when dependencies are satisfied" do

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -21,9 +21,7 @@ describe Bundle::Commands::Cleanup do
 
     it "computes which casks to uninstall" do
       allow(Bundle::CaskDumper).to receive(:casks).and_return(%w[123 456])
-      Bundler.with_clean_env do
-        expect(Bundle::Commands::Cleanup.casks_to_uninstall).to eql(%w[456])
-      end
+      expect(Bundle::Commands::Cleanup.casks_to_uninstall).to eql(%w[456])
     end
 
     it "computes which formulae to uninstall" do
@@ -36,20 +34,16 @@ describe Bundle::Commands::Cleanup do
         { :name => "h", :full_name => "other/tap/h" },
         { :name => "i", :full_name => "homebrew/tap/i", :aliases => ["i2"] },
       ]
-      Bundler.with_clean_env do
-        expect(Bundle::Commands::Cleanup.formulae_to_uninstall).to eql %w[
-          c
-          homebrew/tap/e
-          other/tap/h
-        ]
-      end
+      expect(Bundle::Commands::Cleanup.formulae_to_uninstall).to eql %w[
+        c
+        homebrew/tap/e
+        other/tap/h
+      ]
     end
 
     it "computes which tap to untap" do
       allow(Bundle::TapDumper).to receive(:tap_names).and_return(%w[z])
-      Bundler.with_clean_env do
-        expect(Bundle::Commands::Cleanup.taps_to_untap).to eql(%w[z])
-      end
+      expect(Bundle::Commands::Cleanup.taps_to_untap).to eql(%w[z])
     end
   end
 

--- a/spec/dump_command_spec.rb
+++ b/spec/dump_command_spec.rb
@@ -12,7 +12,7 @@ describe Bundle::Commands::Dump do
 
     it "raises error" do
       expect do
-        Bundler.with_clean_env { Bundle::Commands::Dump.run }
+        Bundle::Commands::Dump.run
       end.to raise_error(RuntimeError)
     end
   end
@@ -30,7 +30,7 @@ describe Bundle::Commands::Dump do
       expect_any_instance_of(Pathname).to receive(:open).with("w") { |&block| block.call io }
       expect(io).to receive(:write)
       expect do
-        Bundler.with_clean_env { Bundle::Commands::Dump.run }
+        Bundle::Commands::Dump.run
       end.to_not raise_error
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,12 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
 ]
 
 require "bundle"
+require 'bundler'
 
-RSpec.configure do |_config|
+RSpec.configure do |config|
+  config.around(:each) do |example|
+    Bundler.with_clean_env { example.run }
+  end
 end
 
 

--- a/spec/tap_installer_spec.rb
+++ b/spec/tap_installer_spec.rb
@@ -7,7 +7,7 @@ describe Bundle::TapInstaller do
 
   context ".installed_taps" do
     it "calls Homebrew" do
-      Bundler.with_clean_env { Bundle::TapInstaller.installed_taps }
+      Bundle::TapInstaller.installed_taps
     end
   end
 


### PR DESCRIPTION
Currently, when we want to run the test suite, we must run `bundle exec rake spec`. When run `rake spec` alone, `without bundler exec`, an exception is thrown `NameError: uninitialized constant Bundler` because we when run with `bundle exec`, `bundler` is automated required for us.

This a confused behaviour because in the code, we don't use bundler. And in fact, if we remove all the bundler stuffs, then just run `rake spec`, the test will pass.

So i make some changes in the `spec_helper`. First, require `bundler` explicitly. Second, run all specs under `Bundler.with_clean_env`, which make the test easy to understand and separate setup test env with the actual test.