### PR TITLE
Check for Brewfile existence before doing any work

### DIFF
--- a/lib/bundle/dumper.rb
+++ b/lib/bundle/dumper.rb
@@ -12,6 +12,7 @@ module Bundle
         filename ||= "Brewfile"
         file = Pathname.new(filename).expand_path(Dir.pwd)
       end
+      raise "#{file} already exists" if should_not_write_file?(file, ARGV.force?)
       content = []
       content << TapDumper.dump
       casks_required_by_formulae = BrewDumper.cask_requirements
@@ -20,16 +21,16 @@ module Bundle
       content << BrewDumper.dump
       content << cask_after_formula
       content = content.reject(&:empty?).join("\n") + "\n"
-      write_file file, content, ARGV.force?
+      write_file file, content
     end
 
     private
 
-    def self.write_file(file, content, overwrite = false)
-      if file.exist? && !overwrite && file.to_s != "/dev/stdout"
-        raise "#{file} already exists."
-      end
+    def self.should_not_write_file?(file, overwrite = false)
+      file.exist? && !overwrite && file.to_s != "/dev/stdout"
+    end
 
+    def self.write_file(file, content)
       file.open("w") { |io| io.write content }
     end
   end

--- a/spec/dump_command_spec.rb
+++ b/spec/dump_command_spec.rb
@@ -15,6 +15,15 @@ describe Bundle::Commands::Dump do
         Bundle::Commands::Dump.run
       end.to raise_error(RuntimeError)
     end
+
+    it "should exit before doing any work" do
+      expect(Bundle::TapDumper).not_to receive(:dump)
+      expect(Bundle::BrewDumper).not_to receive(:dump)
+      expect(Bundle::CaskDumper).not_to receive(:dump)
+      expect do
+        Bundle::Commands::Dump.run
+      end.to raise_error(RuntimeError)
+    end
   end
 
   context "when files existed and `--force` is passed" do


### PR DESCRIPTION
This makes failure faster.

```
$ time brew bundle dump

real  0m2.451s
user  0m2.060s
sys 0m0.314s

$ time brew bundle dump
Error: /Users/colin/Source/homebrew/homebrew-bundle/Brewfile already exists

real  0m0.260s
user  0m0.193s
sys 0m0.055s
```