### PR TITLE
Add --zap command line switch

### DIFF
--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -29,7 +29,7 @@ require "bundle"
 usage = <<-EOS.undent
   brew bundle [-v|--verbose] [--file=<path>|--global]
   brew bundle dump [--force] [--file=<path>|--global]
-  brew bundle cleanup [--force] [--file=<path>|--global]
+  brew bundle cleanup [--force] [--zap] [--file=<path>|--global]
   brew bundle check [--file=<path>|--global]
   brew bundle [--version]
   brew bundle [-h|--help]
@@ -45,6 +45,7 @@ usage = <<-EOS.undent
   Options:
   -v, --verbose          print verbose output
   --force                uninstall dependencies or overwrite existing Brewfile
+  --zap                  zaps all files associated with Casks to be uninstalled
   --file=<path>          set Brewfile path
   --global               set Brewfile path to $HOME/.Brewfile
   -h, --help             show this help message and exit

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -28,7 +28,13 @@ module Bundle::Commands
         end
       else
         if casks.any?
-          Kernel.system "brew", "cask", "uninstall", "--force", *casks
+          if ARGV.include?("--zap")
+            action = "zap"
+          else
+            action = "uninstall"
+          end
+
+          Kernel.system "brew", "cask", action, "--force", *casks
           puts "Uninstalled #{casks.size} cask#{casks.size == 1 ? "" : "s"}"
         end
 

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -77,6 +77,22 @@ describe Bundle::Commands::Cleanup do
     end
   end
 
+  context "there are casks to zap" do
+    before do
+      Bundle::Commands::Cleanup.reset!
+      allow(Bundle::Commands::Cleanup).to receive(:casks_to_uninstall).and_return(%w[a b])
+      allow(Bundle::Commands::Cleanup).to receive(:formulae_to_uninstall).and_return([])
+      allow(Bundle::Commands::Cleanup).to receive(:taps_to_untap).and_return([])
+      allow(ARGV).to receive(:force?).and_return(true)
+      ARGV << "--zap"
+    end
+
+    it "uninstalls casks" do
+      expect(Kernel).to receive(:system).with(*%w[brew cask zap --force a b])
+      expect { Bundle::Commands::Cleanup.run }.to output(/Uninstalled 2 casks/).to_stdout
+    end
+  end
+
   context "there are formulae to uninstall" do
     before do
       Bundle::Commands::Cleanup.reset!


### PR DESCRIPTION
This allows cleanup to "zap" casks instead of uninstalling them,
performing a more thorough removal.