### PR TITLE
restart_service only if formula installed or upgraded

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,18 @@ You can check there's anything to install/upgrade in the `Brewfile` by running:
 
 This provides a successful exit code if everything is up-to-date so is useful for scripting.
 
+### Restarting services
+
+You can choose whether `brew bundle` restarts a service every time it's run, or
+only when the formula is installed or upgraded. In you `Brewfile`:
+`Brewfile`:
+
+    # Always restart myservice
+    brew 'myservice', restart_service: true
+
+    # Only restart when installing or upgrading myservice
+    brew 'myservice', restart_service: :changed
+
 ## Note
 
 Homebrew does not support installing specific versions of a library, only the most recent one so there is no good mechanism for storing installed versions in a .lock file.

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -39,7 +39,7 @@ module Bundle
     end
 
     def restart_service!
-      BrewServices.restart(@full_name) if restart_service?
+      restart_service? ? BrewServices.restart(@full_name) : true
     end
 
     def self.formula_installed_and_up_to_date?(formula)

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -7,15 +7,18 @@ module Bundle
     end
 
     def self.install(name, options = {})
-      result = new(name, options).install_or_upgrade
-      result = BrewServices.restart(name) if result && options[:restart_service]
-      result
+      new(name, options).run
     end
 
     def initialize(name, options = {})
       @full_name = name
       @name = name.split("/").last
       @args = options.fetch(:args, []).map { |arg| "--#{arg}" }
+      @restart_service = options.fetch(:restart_service, false)
+    end
+
+    def run
+      install_or_upgrade and restart_service!
     end
 
     def install_or_upgrade
@@ -24,6 +27,19 @@ module Bundle
       else
         install!
       end
+    end
+
+    def restart_service?
+      # Restart if `restart_service: :always`, or if the formula was installed or upgraded
+      @restart_service && (@restart_service.to_s != 'changed' || changed?)
+    end
+
+    def changed?
+      @changed
+    end
+
+    def restart_service!
+      BrewServices.restart(@full_name) if restart_service?
     end
 
     def self.formula_installed_and_up_to_date?(formula)
@@ -79,6 +95,7 @@ module Bundle
       if (success = Bundle.system("brew", "install", @full_name, *@args))
         BrewInstaller.installed_formulae << @name
       end
+      @changed = true
 
       success
     end
@@ -87,8 +104,10 @@ module Bundle
       if upgradable?
         puts "Upgrading #{@name} formula. It is installed but not up-to-date." if ARGV.verbose?
         Bundle.system("brew", "upgrade", @name)
+        @changed = true
       else
         puts "Skipping install of #{@name} formula. It is already up-to-date." if ARGV.verbose?
+        @changed = false
         true
       end
     end

--- a/spec/brew_installer_spec.rb
+++ b/spec/brew_installer_spec.rb
@@ -6,14 +6,13 @@ describe Bundle::BrewInstaller do
   let(:installer) { Bundle::BrewInstaller.new(formula, options) }
 
   def do_install
-    installer.install_or_upgrade
+    installer.run
   end
 
   context "restart_service option is true" do
     context "formula is installed successfully" do
       before do
         allow_any_instance_of(Bundle::BrewInstaller).to receive(:install_or_upgrade).and_return(true)
-        allow_any_instance_of(Bundle::BrewInstaller).to receive(:restart_service?).and_return(true)
       end
 
       it "restart service" do
@@ -145,6 +144,12 @@ describe Bundle::BrewInstaller do
           end
         end
       end
+    end
+  end
+
+  context '#changed?' do
+    it 'should be falsy by default' do
+      expect(Bundle::BrewInstaller.new(formula).changed?).to eql(nil)
     end
   end
 

--- a/spec/brew_installer_spec.rb
+++ b/spec/brew_installer_spec.rb
@@ -13,6 +13,7 @@ describe Bundle::BrewInstaller do
     context "formula is installed successfully" do
       before do
         allow_any_instance_of(Bundle::BrewInstaller).to receive(:install_or_upgrade).and_return(true)
+        allow_any_instance_of(Bundle::BrewInstaller).to receive(:restart_service?).and_return(true)
       end
 
       it "restart service" do
@@ -143,6 +144,40 @@ describe Bundle::BrewInstaller do
             expect(do_install).to eql(true)
           end
         end
+      end
+    end
+  end
+
+  context '#restart_service?' do
+    it 'should be false by default' do
+      expect(Bundle::BrewInstaller.new(formula).restart_service?).to eql(false)
+    end
+
+    context 'if a service is unchanged' do
+      before do
+        allow_any_instance_of(Bundle::BrewInstaller).to receive(:changed?).and_return(false)
+      end
+
+      it 'should be true with {restart_service: true}' do
+        expect(Bundle::BrewInstaller.new(formula, restart_service: true).restart_service?).to eql(true)
+      end
+
+      it 'should be false if {restart_service: :changed}' do
+        expect(Bundle::BrewInstaller.new(formula, restart_service: :changed).restart_service?).to eql(false)
+      end
+    end
+
+    context 'if a service is changed' do
+      before do
+        allow_any_instance_of(Bundle::BrewInstaller).to receive(:changed?).and_return(true)
+      end
+
+      it 'should be true with {restart_service: true}' do
+        expect(Bundle::BrewInstaller.new(formula, restart_service: true).restart_service?).to eql(true)
+      end
+
+      it 'should be true if {restart_service: :changed}' do
+        expect(Bundle::BrewInstaller.new(formula, restart_service: :changed).restart_service?).to eql(true)
       end
     end
   end


### PR DESCRIPTION
First off, thanks for making homebrew and Brewfiles. It's a boon for Mac development. :cake: 

This changes `restart_service: true` to only restart services if they’re installed or upgraded. Avoiding unnecessary restarts is faster, and less disruptive for developers who may be using those services while `brew bundle`'ing.

This changes the current default of restarting services on each `brew
bundle run`. If a user would like to keep the current behavior, they can specify `restart_service: :always` in their Brewfile.