### PR TITLE
Unlink and stop service for conflicting formulae.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,18 +30,17 @@ Create a `Brewfile` in the root of your project:
 
 Then list your Homebrew based dependencies in your `Brewfile`:
 
-    cask_args appdir: '/Applications'
-    tap 'caskroom/cask'
-    tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
-    brew 'emacs', args: ['with-cocoa', 'with-gnutls']
-    brew 'redis', restart_service: true
-    brew 'mongodb'
-    brew 'sphinx'
-    brew 'imagemagick'
-    brew 'mysql'
-    cask 'google-chrome'
-    cask 'java' unless system '/usr/libexec/java_home --failfast'
-    cask 'firefox', args: { appdir: '/Applications' }
+```ruby
+cask_args appdir: '/Applications'
+tap 'caskroom/cask'
+tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
+brew 'imagemagick'
+brew 'mysql', restart_service: true, conflicts_with: ['homebrew/versions/mysql56']
+brew 'emacs', args: ['with-cocoa', 'with-gnutls']
+cask 'google-chrome'
+cask 'java' unless system '/usr/libexec/java_home --failfast'
+cask 'firefox', args: { appdir: '~/my-apps/Applications' }
+```
 
 You can then easily install all of the dependencies with one of the following commands:
 
@@ -76,14 +75,15 @@ This provides a successful exit code if everything is up-to-date so is useful fo
 ### Restarting services
 
 You can choose whether `brew bundle` restarts a service every time it's run, or
-only when the formula is installed or upgraded. In you `Brewfile`:
-`Brewfile`:
+only when the formula is installed or upgraded in your `Brewfile`:
 
-    # Always restart myservice
-    brew 'myservice', restart_service: true
+```ruby
+# Always restart myservice
+brew 'myservice', restart_service: true
 
-    # Only restart when installing or upgrading myservice
-    brew 'myservice', restart_service: :changed
+# Only restart when installing or upgrading myservice
+brew 'myservice', restart_service: :changed
+```
 
 ## Note
 

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -52,6 +52,16 @@ module Bundle
       @formula_aliases
     end
 
+    def self.formula_info(name)
+      @formula_info_name ||= {}
+      @formula_info_name[name] ||= begin
+        require "formula"
+        formula = Formula[name]
+        return {} unless formula
+        formula_inspector formula.to_hash
+      end
+    end
+
     private
 
     def self.formulae_info
@@ -86,6 +96,7 @@ module Bundle
         :version => version,
         :dependencies => f["dependencies"],
         :requirements => f["requirements"],
+        :conflicts_with => f["conflicts_with"],
         :pinned? => !!f["pinned"],
         :outdated? => !!f["outdated"],
       }

--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -1,5 +1,11 @@
 module Bundle
   class BrewServices
+    def self.stop(name)
+      started = !`brew services list | grep "#{name}" | grep -q "started"`.chomp.empty?
+      return true unless started
+      Bundle.system "brew", "services", "stop", name
+    end
+
     def self.restart(name)
       Bundle.system "brew", "services", "restart", name
     end

--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -10,12 +10,12 @@ module Bundle
       end
     end
 
-    attr_reader :entries
+    attr_reader :entries, :cask_arguments
 
     def initialize(input)
       @input = input
       @entries = []
-      @cask_args = {}
+      @cask_arguments = {}
 
       begin
         process
@@ -61,7 +61,7 @@ module Bundle
 
     def cask_args(args)
       raise "cask_args(#{args.inspect}) should be a Hash object" unless args.is_a? Hash
-      @cask_args = args
+      @cask_arguments = args
     end
 
     def brew(name, options = {})
@@ -75,7 +75,7 @@ module Bundle
       raise "name(#{name.inspect}) should be a String object" unless name.is_a? String
       raise "options(#{options.inspect}) should be a Hash object" unless options.is_a? Hash
       name = Bundle::Dsl.sanitize_cask_name(name)
-      options[:args] = @cask_args.merge options.fetch(:args, {})
+      options[:args] = @cask_arguments.merge options.fetch(:args, {})
       @entries << Entry.new(:cask, name, options)
     end
 

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -19,6 +19,7 @@ describe Bundle::BrewDumper do
   context "when Homebrew returns JSON with a malformed linked_keg" do
     before do
       Bundle::BrewDumper.reset!
+      allow(Formula).to receive(:[]).and_return(nil)
       allow(Formula).to receive(:installed).and_return(
         [{
           "name" => "foo",
@@ -58,6 +59,7 @@ describe Bundle::BrewDumper do
           :version => nil,
           :dependencies => [],
           :requirements => [],
+          :conflicts_with => [],
           :pinned? => false,
           :outdated? => false,
         },
@@ -68,6 +70,31 @@ describe Bundle::BrewDumper do
   context "formulae `foo` and `bar` are installed" do
     before do
       Bundle::BrewDumper.reset!
+      allow(Formula).to receive(:[]).and_return(
+        {
+          "name" => "foo",
+          "full_name" => "homebrew/tap/foo",
+          "desc" => "",
+          "homepage" => "",
+          "oldname" => nil,
+          "aliases" => [],
+          "versions" => { "stable" => "1.0", "bottle" => false },
+          "revision" => 0,
+          "installed" => [{
+            "version" => "1.0",
+            "used_options" => [],
+            "built_as_bottle" => nil,
+            "poured_from_bottle" => true,
+          }],
+          "linked_keg" => "1.0",
+          "keg_only" => nil,
+          "dependencies" => [],
+          "conflicts_with" => [],
+          "caveats" => nil,
+          "requirements" => [],
+          "options" => [],
+          "bottle" => {},
+        })
       allow(Formula).to receive(:installed).and_return([
         {
           "name" => "foo",
@@ -132,6 +159,7 @@ describe Bundle::BrewDumper do
           :version => "1.0",
           :dependencies => [],
           :requirements => [],
+          :conflicts_with => [],
           :pinned? => false,
           :outdated? => false,
         },
@@ -143,6 +171,7 @@ describe Bundle::BrewDumper do
           :version => "2.0",
           :dependencies => [],
           :requirements => [],
+          :conflicts_with => [],
           :pinned? => true,
           :outdated? => true,
         },
@@ -151,6 +180,10 @@ describe Bundle::BrewDumper do
 
     it "dumps as foo and bar with args" do
       expect(subject.dump).to eql("brew 'bar', args: ['with-a', 'with-b']\nbrew 'homebrew/tap/foo'")
+    end
+
+    it "formula_info returns the formula" do
+      expect(subject.formula_info('foo')[:name]).to eql("foo")
     end
   end
 
@@ -166,6 +199,9 @@ describe Bundle::BrewDumper do
           :version => "1.1beta",
           :dependencies => [],
           :requirements => [],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
         },
         {
           :name => "bar",
@@ -175,6 +211,9 @@ describe Bundle::BrewDumper do
           :version => "HEAD",
           :dependencies => [],
           :requirements => [],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
         },
       ]
     end
@@ -198,6 +237,9 @@ describe Bundle::BrewDumper do
           :version => "1.0",
           :dependencies => [],
           :requirements => [],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
         },
       ]
     end
@@ -220,6 +262,9 @@ describe Bundle::BrewDumper do
           :version => "2.0",
           :dependencies => [],
           :requirements => [],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
         },
       ]
     end
@@ -242,6 +287,9 @@ describe Bundle::BrewDumper do
           :version => "1.0",
           :dependencies => ["b"],
           :requirements => [],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
         },
         {
           :name => "b",
@@ -251,6 +299,9 @@ describe Bundle::BrewDumper do
           :version => "1.0",
           :dependencies => [],
           :requirements => [{ "name" => "foo", "default_formula" => "c", "cask" => "bar" }],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
         },
         {
           :name => "c",
@@ -260,6 +311,9 @@ describe Bundle::BrewDumper do
           :version => "1.0",
           :dependencies => [],
           :requirements => [],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
         },
       ]
     end

--- a/spec/brew_services_spec.rb
+++ b/spec/brew_services_spec.rb
@@ -1,18 +1,28 @@
 require "spec_helper"
 
 describe Bundle::BrewServices do
-  def restart_service
-    Bundle::BrewServices.restart("nginx")
-  end
-
   context "when brew-services is installed" do
     before do
       allow(ARGV).to receive(:verbose?).and_return(false)
     end
 
-    it "restart the formula" do
+    context "stops the service" do
+      it "when the service is started" do
+        allow(Bundle::BrewServices).to receive(:`).and_return("nginx  started  homebrew.mxcl.nginx.plist")
+        expect(Bundle).to receive(:system).with("brew", "services", "stop", "nginx").and_return(true)
+        expect(Bundle::BrewServices.stop("nginx")).to eql(true)
+      end
+
+      it "when the service is already stopped" do
+        allow(Bundle::BrewServices).to receive(:`).and_return("")
+        expect(Bundle).to_not receive(:system).with("brew", "services", "stop", "nginx")
+        expect(Bundle::BrewServices.stop("nginx")).to eql(true)
+      end
+    end
+
+    it "restarts the service" do
       expect(Bundle).to receive(:system).with("brew", "services", "restart", "nginx").and_return(true)
-      expect(restart_service).to eql(true)
+      expect(Bundle::BrewServices.restart("nginx")).to eql(true)
     end
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -2,26 +2,34 @@ require "spec_helper"
 
 describe Bundle::Dsl do
   it "processes input" do
+    allow_any_instance_of(Bundle::Dsl).to receive(:system).with("/usr/libexec/java_home --failfast").and_return(false)
     allow(ARGV).to receive(:verbose?).and_return(true)
+    # Keep in sync with the README
     dsl = Bundle::Dsl.new <<-EOS
-      cask_args :appdir => "/Applications"
+      p method(:system)
+      cask_args appdir: '/Applications'
       tap 'caskroom/cask'
       tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
-      brew 'git'
+      brew 'imagemagick'
+      brew 'mysql', restart_service: true, conflicts_with: ['homebrew/versions/mysql56']
       brew 'emacs', args: ['with-cocoa', 'with-gnutls']
       cask 'google-chrome'
+      cask 'java' unless system '/usr/libexec/java_home --failfast'
       cask 'firefox', args: { appdir: '~/my-apps/Applications' }
     EOS
+    expect(dsl.cask_arguments).to eql(:appdir => "/Applications")
     expect(dsl.entries[0].name).to eql("caskroom/cask")
     expect(dsl.entries[1].name).to eql("telemachus/brew")
     expect(dsl.entries[1].options).to eql(:clone_target => "https://telemachus@bitbucket.org/telemachus/brew.git")
-    expect(dsl.entries[2].name).to eql("git")
-    expect(dsl.entries[3].name).to eql("emacs")
-    expect(dsl.entries[3].options).to eql(:args => ["with-cocoa", "with-gnutls"])
-    expect(dsl.entries[4].name).to eql("google-chrome")
-    expect(dsl.entries[4].options).to eql(:args => { :appdir=>"/Applications" })
-    expect(dsl.entries[5].name).to eql("firefox")
-    expect(dsl.entries[5].options).to eql(:args => { :appdir=>"~/my-apps/Applications" })
+    expect(dsl.entries[2].name).to eql("imagemagick")
+    expect(dsl.entries[3].name).to eql("mysql")
+    expect(dsl.entries[3].options).to eql(:restart_service => true, :conflicts_with => ["homebrew/versions/mysql56"])
+    expect(dsl.entries[4].name).to eql("emacs")
+    expect(dsl.entries[4].options).to eql(:args => ["with-cocoa", "with-gnutls"])
+    expect(dsl.entries[5].name).to eql("google-chrome")
+    expect(dsl.entries[6].name).to eql("java")
+    expect(dsl.entries[7].name).to eql("firefox")
+    expect(dsl.entries[7].options).to eql(:args => { :appdir=>"~/my-apps/Applications" })
   end
 
   it "handles invalid input" do

--- a/spec/install_command_spec.rb
+++ b/spec/install_command_spec.rb
@@ -16,7 +16,7 @@ describe Bundle::Commands::Install do
 
       allow(ARGV).to receive(:value).and_return(nil)
       allow_any_instance_of(Pathname).to receive(:read).
-        and_return("tap 'phinze/cask'\nbrew 'git'\ncask 'google-chrome'")
+        and_return("tap 'phinze/cask'\nbrew 'mysql', conflicts_with: ['mysql56']\ncask 'google-chrome'")
       expect { Bundle::Commands::Install.run }.to_not raise_error
     end
 
@@ -27,7 +27,7 @@ describe Bundle::Commands::Install do
 
       allow(ARGV).to receive(:value).and_return(nil)
       allow_any_instance_of(Pathname).to receive(:read).
-        and_return("tap 'phinze/cask'\nbrew 'git'\ncask 'google-chrome'")
+        and_return("tap 'phinze/cask'\nbrew 'mysql', conflicts_with: ['mysql56']\ncask 'google-chrome'")
       expect { Bundle::Commands::Install.run }.to raise_error(SystemExit)
     end
   end


### PR DESCRIPTION
Unlink and stop the service for conflicting formulae or those specified
by a `conflicts_with` argument. This is useful when using `brew bundle`
to manage the transition between e.g. `homebrew/versions` versions.

Similar to https://github.com/Homebrew/homebrew-bundle/pull/124

CC @josh @xu-cheng for thoughts.