### PR TITLE
Fix ruby issues

### DIFF
--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -35,19 +35,16 @@ module Bundle
 
       @entries.each do |entry|
         arg = [entry.name]
-        cls = case entry.type
+        verb, cls = case entry.type
               when :brew
                 arg << entry.options
-                verb = "installing"
-                Bundle::BrewInstaller
+                ["installing", Bundle::BrewInstaller]
               when :cask
                 arg << entry.options
-                verb = "installing"
-                Bundle::CaskInstaller
+                ["installing", Bundle::CaskInstaller]
               when :tap
                 arg << entry.options[:clone_target]
-                verb = "tapping"
-                Bundle::TapInstaller
+                ["tapping", Bundle::TapInstaller]
               end
         if cls.install(*arg)
           puts "Succeeded in #{verb} #{entry.name}"

--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -100,7 +100,7 @@ module Bundle
         user = $1
         repo = $2
         name = $3
-        "#{user}/#{repo.sub /homebrew-/, ""}/#{name}"
+        "#{user}/#{repo.sub(/homebrew-/, "")}/#{name}"
       else
         name
       end

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -49,7 +49,7 @@ describe Bundle::BrewDumper do
     subject { Bundle::BrewDumper }
 
     it "returns no version" do
-      expect(subject.formulae).to contain_exactly *[
+      expect(subject.formulae).to contain_exactly(*[
         {
           :name => "foo",
           :full_name => "homebrew/tap/foo",
@@ -61,7 +61,7 @@ describe Bundle::BrewDumper do
           :pinned? => false,
           :outdated? => false,
         },
-      ]
+      ])
     end
   end
 
@@ -123,7 +123,7 @@ describe Bundle::BrewDumper do
     subject { Bundle::BrewDumper }
 
     it "returns foo and bar with their information" do
-      expect(subject.formulae).to contain_exactly *[
+      expect(subject.formulae).to contain_exactly(*[
         {
           :name => "foo",
           :full_name => "homebrew/tap/foo",
@@ -146,7 +146,7 @@ describe Bundle::BrewDumper do
           :pinned? => true,
           :outdated? => true,
         },
-      ]
+      ])
     end
 
     it "dumps as foo and bar with args" do


### PR DESCRIPTION
@xu-cheng / @andrew / @mikemcquaid: just a bit of minor refactoring to the codebase, mainly to get rid of some annoying Ruby warnings in the `lib` and `spec` files, and a minor change to make a `case` statement a tad more idiomatic... hope you approve!  I've kept the individual commits very atomic, to make reviewing them as easy as possible.Thanks, @pvdb