### PR TITLE
brew_services: escape formula name in regex.

### DIFF
--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -1,7 +1,7 @@
 module Bundle
   class BrewServices
     def self.stop(name)
-      started = `brew services list`.lines.grep(/^#{name} +started/).any?
+      started = `brew services list`.lines.grep(/^#{Regexp.escape(name)} +started/).any?
       return true unless started
       Bundle.system "brew", "services", "stop", name
     end


### PR DESCRIPTION
CC @xu-cheng #159 