### PR TITLE
Cleanup: don't untap homebrew/core

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -66,7 +66,7 @@ module Bundle::Commands
       @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
       kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
       current_taps = Bundle::TapDumper.tap_names
-      current_taps - kept_taps
+      current_taps - kept_taps - %w[homebrew/core]
     end
   end
 end

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -45,6 +45,11 @@ describe Bundle::Commands::Cleanup do
       allow(Bundle::TapDumper).to receive(:tap_names).and_return(%w[z])
       expect(Bundle::Commands::Cleanup.taps_to_untap).to eql(%w[z])
     end
+
+    it "excludes homebrew/core from the taps to untap" do
+      allow(Bundle::TapDumper).to receive(:tap_names).and_return(%w[a homebrew/core w])
+      expect(Bundle::Commands::Cleanup.taps_to_untap).to eql(%w[a w])
+    end
   end
 
   context "no formulae to uninstall and no taps to untap" do


### PR DESCRIPTION
We currently get an error when running `brew bundle cleanup -f` if the bundle was dumped before tapping `homebrew/core` because `brew-bundle` tries to untap it while [Homebrew forbids it](https://github.com/Homebrew/homebrew/blob/e13ff6294a0bbc28fc98d6f797b1b56ce93ecd67/Library/Homebrew/cmd/untap.rb#L9).