### PR TITLE
Fix to dumps fomula args in same order

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -20,7 +20,7 @@ module Bundle
         if f[:args].empty?
           "brew '#{f[:full_name]}'"
         else
-          args = f[:args].map { |arg| "'#{arg}'" }.join(", ")
+          args = f[:args].map { |arg| "'#{arg}'" }.sort.join(", ")
           "brew '#{f[:full_name]}', args: [#{args}]"
         end
       end.join("\n")

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -327,4 +327,41 @@ describe Bundle::BrewDumper do
       expect(subject.cask_requirements).to eq %w[bar]
     end
   end
+
+  context "when order of args for a formula is different in different environment" do
+    it "dumps args in same order" do
+      formula_info = [
+        [{
+          :name => "a",
+          :full_name => "a",
+          :aliases => [],
+          :args => ['with-1', 'with-2'],
+          :version => "1.0",
+          :dependencies => ["b"],
+          :requirements => [],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
+        }],
+        [{
+          :name => "a",
+          :full_name => "a",
+          :aliases => [],
+          :args => ['with-2', 'with-1'],
+          :version => "1.0",
+          :dependencies => ["b"],
+          :requirements => [],
+          :conflicts_with => [],
+          :pinned? => false,
+          :outdated? => false,
+        }]
+      ]
+      dump_lines = formula_info.map do |info|
+        Bundle::BrewDumper.reset!
+        allow(Bundle::BrewDumper).to receive(:formulae_info).and_return(info)
+        Bundle::BrewDumper.dump
+      end
+      expect(dump_lines[0]).to eql(dump_lines[1])
+    end
+  end
 end


### PR DESCRIPTION
Fix to dumps args in same order when a formula installed with args specified in different order on different machines.

In current implementation, as I present below, there is the case that has difference about its order.

```diff
-brew 'gcc', args: ['with-jit', 'with-nls', 'with-all-languages']
+brew 'gcc', args: ['with-all-languages', 'with-jit', 'with-nls']
```