### PR TITLE
Include verbose output for check to list out what needs to be done

### DIFF
--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -9,9 +9,28 @@ module Bundle::Commands
     end
 
     def self.run
-      if any_taps_to_tap? || any_casks_to_install? || any_apps_to_install? || any_formulae_to_install?
+      if unsatisfied?
         puts "brew bundle can't satisfy your Brewfile's dependencies."
         puts "Install missing dependencies with `brew bundle install`."
+        if ARGV.verbose?
+          puts
+          if taps_to_tap.any?
+            puts "Taps to tap:"
+            taps_to_tap.each {|tap| puts "- #{tap}" }
+          end
+          if casks_to_install.any?
+            puts "Casks to install:"
+            casks_to_install.each {|cask| puts "- #{cask.name}" }
+          end
+          if apps_to_install.any?
+            puts "Apps to install:"
+            apps_to_install.each {|app| puts "- #{app}" }
+          end
+          if formula_to_install.any?
+            puts "Formulae to install:"
+            formula_to_install.each {|formula| puts "- #{formula}" }
+          end
+        end
         exit 1
       else
         puts "The Brewfile's dependencies are satisfied."
@@ -20,36 +39,77 @@ module Bundle::Commands
 
     private
 
-    def self.any_casks_to_install?
-      @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
-      requested_casks = @dsl.entries.select { |e| e.type == :cask }.map(&:name)
-      return false if requested_casks.empty?
-      current_casks = Bundle::CaskDumper.casks
-      (requested_casks - current_casks).any?
+    def self.unsatisfied?
+      any_taps_to_tap? || any_casks_to_install? || any_apps_to_install? || any_formulae_to_install?
     end
 
-    def self.any_formulae_to_install?
-      @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
-      requested_formulae = @dsl.entries.select { |e| e.type == :brew }.map(&:name)
-      requested_formulae.any? do |f|
-        !Bundle::BrewInstaller.formula_installed_and_up_to_date?(f)
+    def self.requested_casks
+      @requested_casks ||= dsl.entries.select { |e| e.type == :cask }.map(&:name)
+    end
+
+    def self.current_casks
+      @current_casks ||= Bundle::CaskDumper.casks
+    end
+
+    def self.casks_to_install
+      @casks_to_install ||= requested_casks - current_casks
+    end
+
+    def self.any_casks_to_install?
+      return false if requested_casks.empty?
+      casks_to_install.any?
+    end
+
+    def self.requested_formulae
+      @requested_formulae ||= dsl.entries.select { |e| e.type == :brew }.map(&:name)
+    end
+
+    def self.formula_to_install
+      requested_formulae.reject do |f|
+        Bundle::BrewInstaller.formula_installed_and_up_to_date?(f)
       end
     end
 
+    def self.any_formulae_to_install?
+      formula_to_install.any?
+    end
+
+    def self.requested_taps
+      @requested_taps ||= dsl.entries.select { |e| e.type == :tap }.map(&:name)
+    end
+
+    def self.current_taps
+      @current_taps ||= Bundle::TapDumper.tap_names
+    end
+
+    def self.taps_to_tap
+      @taps_to_tap ||= requested_taps - current_taps
+    end
+
     def self.any_taps_to_tap?
-      @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
-      requested_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
       return false if requested_taps.empty?
-      current_taps = Bundle::TapDumper.tap_names
-      (requested_taps - current_taps).any?
+      taps_to_tap.any?
+    end
+
+    def self.requested_apps
+      @requested_apps ||= dsl.entries.select { |e| e.type == :mac_app_store }.map {|e| e.options[:id] }
+    end
+
+    def self.current_apps
+      @current_apps ||= Bundle::MacAppStoreDumper.app_ids
+    end
+
+    def self.apps_to_install
+      @apps_to_install ||= requested_apps - current_apps
     end
 
     def self.any_apps_to_install?
-      @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
-      requested_apps = @dsl.entries.select { |e| e.type == :mac_app_store }.map {|e| e.options[:id] }
       return false if requested_apps.empty?
-      current_apps = Bundle::MacAppStoreDumper.app_ids
-      (requested_apps - current_apps).any?
+      apps_to_install.any?
+    end
+
+    def self.dsl
+      @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
     end
   end
 end

--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -26,9 +26,9 @@ module Bundle::Commands
             puts "Apps to install:"
             apps_to_install.each {|app| puts "- #{app}" }
           end
-          if formula_to_install.any?
+          if formulae_to_install.any?
             puts "Formulae to install:"
-            formula_to_install.each {|formula| puts "- #{formula}" }
+            formulae_to_install.each {|formula| puts "- #{formula}" }
           end
         end
         exit 1
@@ -64,14 +64,14 @@ module Bundle::Commands
       @requested_formulae ||= dsl.entries.select { |e| e.type == :brew }.map(&:name)
     end
 
-    def self.formula_to_install
+    def self.formulae_to_install
       requested_formulae.reject do |f|
         Bundle::BrewInstaller.formula_installed_and_up_to_date?(f)
       end
     end
 
     def self.any_formulae_to_install?
-      formula_to_install.any?
+      formulae_to_install.any?
     end
 
     def self.requested_taps


### PR DESCRIPTION
I mentioned this in https://github.com/Homebrew/homebrew-bundle/issues/176 . I needed a way to figure out why `brew bundle` wasn't installing all the dependencies to satisfy `brew bundle check`.

This can be tested with `brew bundle check --verbose`.

This diff probably could be smaller, but I factored out most of the variables to their own methods so I knew they could be used in the verbose section.

One last thing is: I assume that there's checks like `return false if requested_taps.empty?` to avoid load time / memory for loading the taps tapped if none were requested.