### PR TITLE
Bundle.system: better way to handle verbose

### DIFF
--- a/lib/bundle/utils.rb
+++ b/lib/bundle/utils.rb
@@ -1,18 +1,19 @@
 module Bundle
   def self.system(cmd, *args)
-    verbose = ARGV.verbose?
+    if ARGV.verbose?
+      return super cmd, *args
+    end
     logs = []
     success = nil
     IO.popen([cmd, *args], :err => [:child, :out]) do |pipe|
       while buf = pipe.gets
-        puts buf if verbose
         logs << buf
       end
       Process.wait(pipe.pid)
       success = $?.success?
       pipe.close
     end
-    puts logs.join unless success || verbose
+    puts logs.join unless success
     success
   end
 

--- a/spec/mac_app_store_installer_spec.rb
+++ b/spec/mac_app_store_installer_spec.rb
@@ -19,7 +19,7 @@ describe Bundle::MacAppStoreInstaller do
 
     it "tries to install mas" do
       expect(Bundle).to receive(:system).with("brew", "install", "mas").and_return(true)
-      expect { do_install }.to raise_error
+      expect { do_install }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -4,12 +4,12 @@ describe Bundle do
   context "system call succeed" do
     it "omits all stdout output if ARGV.verbose? is false" do
       allow(ARGV).to receive(:verbose?).and_return(false)
-      expect { Bundle.system "echo", "foo" }.to_not output.to_stdout
+      expect { Bundle.system "echo", "foo" }.to_not output.to_stdout_from_any_process
     end
 
     it "emits all stdout output if ARGV.verbose? is true" do
       allow(ARGV).to receive(:verbose?).and_return(true)
-      expect { Bundle.system "echo", "foo" }.to output("foo\n").to_stdout
+      expect { Bundle.system "echo", "foo" }.to output("foo\n").to_stdout_from_any_process
     end
   end
 
@@ -20,12 +20,12 @@ describe Bundle do
 
     it "emits all stdout output even if ARGV.verbose? is false" do
       allow(ARGV).to receive(:verbose?).and_return(false)
-      expect { Bundle.system "echo", "foo" }.to output("foo\n").to_stdout
+      expect { Bundle.system "echo", "foo" }.to output("foo\n").to_stdout_from_any_process
     end
 
     it "emits all stdout output only once if ARGV.verbose? is true" do
       allow(ARGV).to receive(:verbose?).and_return(true)
-      expect { Bundle.system "echo", "foo" }.to output("foo\n").to_stdout
+      expect { Bundle.system "echo", "foo" }.to output("foo\n").to_stdout_from_any_process
     end
   end
 


### PR DESCRIPTION
Use Kernel.system instead of our own logic to handle verbose output. This
allows us to show progress bar for downloading.