### PR TITLE
brew_dumper: fix HEAD installation

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -79,7 +79,7 @@ module Bundle
 
       if keg
         args = keg["used_options"].to_a.map { |option| option.gsub(/^--/, "") }
-        args << "HEAD" if keg["version"] == "HEAD"
+        args << "HEAD" if keg["version"].to_s.start_with?("HEAD")
         args << "devel" if keg["version"].to_s.gsub(/_\d+$/, "") == f["versions"]["devel"]
         args.uniq!
         version = keg["version"]


### PR DESCRIPTION
We have started to record commit information in the HEAD prefix.