### PR TITLE
travis: don't build against Ruby 2.2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: objective-c # Force OS X
-rvm:
-  - 2.0.0
-  - 2.2.0
+rvm: 2.0.0
 cache: bundler
 before_install:
   - brew update


### PR DESCRIPTION
We don't need to test against this version.