### PR TITLE
brew services related fix

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -4,6 +4,7 @@ require "tsort"
 module Bundle
   class BrewDumper
     def self.reset!
+      Bundle::BrewServices.reset!
       @formulae = nil
       @formula_aliases = nil
     end

--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -1,19 +1,38 @@
 module Bundle
   class BrewServices
+    def self.reset!
+      @started_services = nil
+    end
+
     def self.stop(name)
-      started = `brew services list`.lines.grep(/^#{Regexp.escape(name)} +started/).any?
-      return true unless started
-      Bundle.system "brew", "services", "stop", name
+      return true unless started?(name)
+      if Bundle.system "brew", "services", "stop", name
+        started_services.delete(name)
+        true
+      end
     end
 
     def self.restart(name)
-      Bundle.system "brew", "services", "restart", name
+      if Bundle.system "brew", "services", "restart", name
+        started_services << name
+        true
+      end
     end
 
     def self.started?(name)
-      @started_services ||= `brew services list`.lines.grep(/started/)
-      started_service_names = @started_services.map {|s| s.split(/\s+/).first}
-      started_service_names.include? name
+      started_services.include? name
+    end
+
+    def self.started_services
+      @started_services ||= if Bundle.services_installed?
+        `brew services list`.lines.map do |line|
+          name, state, _plist = line.split(/\s+/)
+          next unless state == "started"
+          name
+        end.compact
+      else
+        []
+      end
     end
   end
 end

--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -6,6 +6,7 @@ module Bundle::Commands
       Bundle::BrewDumper.reset!
       Bundle::MacAppStoreDumper.reset!
       Bundle::TapDumper.reset!
+      Bundle::BrewServices.reset!
     end
 
     def self.run

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -5,6 +5,7 @@ module Bundle::Commands
       Bundle::CaskDumper.reset!
       Bundle::BrewDumper.reset!
       Bundle::TapDumper.reset!
+      Bundle::BrewServices.reset!
     end
 
     def self.run

--- a/lib/bundle/utils.rb
+++ b/lib/bundle/utils.rb
@@ -29,6 +29,12 @@ module Bundle
     end
   end
 
+  def self.services_installed?
+    @services ||= begin
+      !!which("brew-services.rb")
+    end
+  end
+
   def self.brewfile
     if ARGV.include?("--global")
       file = Pathname.new("#{ENV["HOME"]}/.Brewfile")

--- a/spec/brew_services_spec.rb
+++ b/spec/brew_services_spec.rb
@@ -1,6 +1,27 @@
 require "spec_helper"
 
 describe Bundle::BrewServices do
+  context ".started_services" do
+    before do
+      Bundle::BrewServices.reset!
+    end
+
+    it "is empty when brew servies not installed" do
+      allow(Bundle).to receive(:services_installed?).and_return(false)
+      expect(Bundle::BrewServices.started_services).to be_empty
+    end
+
+    it "returns started services" do
+      allow(Bundle).to receive(:services_installed?).and_return(true)
+      allow(Bundle::BrewServices).to receive(:`).and_return <<-EOS
+nginx  started  homebrew.mxcl.nginx.plist
+apache stopped  homebrew.mxcl.apache.plist
+mysql  started  homebrew.mxcl.mysql.plist
+EOS
+      expect(Bundle::BrewServices.started_services).to contain_exactly("nginx", "mysql")
+    end
+  end
+
   context "when brew-services is installed" do
     before do
       allow(ARGV).to receive(:verbose?).and_return(false)
@@ -8,25 +29,25 @@ describe Bundle::BrewServices do
 
     context "stops the service" do
       it "when the service is started" do
-        allow(Bundle::BrewServices).to receive(:`).and_return <<-EOS
-nginx  started  homebrew.mxcl.nginx.plist
-apache stopped  homebrew.mxcl.apache.plist
-mysql  started  homebrew.mxcl.mysql.plist
-EOS
+        allow(Bundle::BrewServices).to receive(:started_services).and_return(%w[nginx])
         expect(Bundle).to receive(:system).with("brew", "services", "stop", "nginx").and_return(true)
         expect(Bundle::BrewServices.stop("nginx")).to eql(true)
+        expect(Bundle::BrewServices.started_services).not_to include("nginx")
       end
 
       it "when the service is already stopped" do
-        allow(Bundle::BrewServices).to receive(:`).and_return("")
+        allow(Bundle::BrewServices).to receive(:started_services).and_return(%w[])
         expect(Bundle).to_not receive(:system).with("brew", "services", "stop", "nginx")
         expect(Bundle::BrewServices.stop("nginx")).to eql(true)
+        expect(Bundle::BrewServices.started_services).not_to include("nginx")
       end
     end
 
     it "restarts the service" do
+      allow(Bundle::BrewServices).to receive(:started_services).and_return([])
       expect(Bundle).to receive(:system).with("brew", "services", "restart", "nginx").and_return(true)
       expect(Bundle::BrewServices.restart("nginx")).to eql(true)
+      expect(Bundle::BrewServices.started_services).to include("nginx")
     end
   end
 end

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -10,6 +10,7 @@ describe Bundle::Dumper do
     Bundle::TapDumper.reset!
     Bundle::CaskDumper.reset!
     Bundle::MacAppStoreDumper.reset!
+    Bundle::BrewServices.reset!
     allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava")
   end
   subject { Bundle::Dumper }

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -36,6 +36,13 @@ describe Bundle do
     end
   end
 
+  context "check for brew services" do
+    it "finds it when present" do
+      allow(Bundle).to receive(:which).and_return(true)
+      expect(Bundle.services_installed?).to eql(true)
+    end
+  end
+
   context "check for mas" do
     it "finds it when present" do
       allow(Bundle).to receive(:which).and_return(true)


### PR DESCRIPTION
* check whether brew services is installed. Otherwise, `brew bundle dump`
  will install brew services.
* remove duplicate codes on checking services started.
* avoid opportunistic regex, e.g. we should not match `started` in formula or
  plist file name.