### PR TITLE
Fix SimpleCov MultiFormatter deprecation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ $:.unshift(STUB_PATH)
 
 Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").each { |f| require f }
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   Coveralls::SimpleCov::Formatter,
   SimpleCov::Formatter::HTMLFormatter
 ]


### PR DESCRIPTION
Here's an example of the error message:
https://travis-ci.org/Homebrew/homebrew-bundle/builds/163380130#L278

Here's where an alternative new syntax is documented:
https://github.com/colszowka/simplecov/tree/e0accd692594645c836f2a771692b19c21397e41#using-multiple-formatters

Here's an example of the new syntax being used in SimpleCov itself:
https://github.com/colszowka/simplecov/commit/ddde04d4c9e2359ae7dcfdf27a247c61b238cb07#diff-6fc312203870a48a45997f6c5602040eL131