### PR TITLE
dsl: rescue all exceptions.

### DIFF
--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -19,7 +19,7 @@ module Bundle
 
       begin
         process
-      rescue => e
+      rescue Exception => e
         error_msg = "Invalid Brewfile: #{e.message}"
         raise RuntimeError, error_msg, e.backtrace
       end


### PR DESCRIPTION
Make this `rescue` broader to avoid having confusing error messages like in #203 (and to not tell people to report it).