### PR TITLE
README: point Coverage Status link to CodeCov page

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 Bundler for non-Ruby dependencies from Homebrew
 
-[![Coverage Status](https://codecov.io/github/Homebrew/homebrew-bundle/coverage.svg)](https://coveralls.io/r/Homebrew/homebrew-bundle)
+[![Coverage Status](https://codecov.io/github/Homebrew/homebrew-bundle/coverage.svg)](https://codecov.io/github/Homebrew/homebrew-bundle)
 [![Build Status](https://travis-ci.org/Homebrew/homebrew-bundle.svg)](https://travis-ci.org/Homebrew/homebrew-bundle)
 
 ## Requirements


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-bundle/pull/212 changed the **Coverage Status** badge to **CodeCov** but the actual link was left pointing to **Coveralls**. I believe that this was simply an accidental oversight, hence this PR, but if it was intentional feel free to summarily close this PR.

@MikeMcQuaid You are probably the best one to look at this since the change was your PR to begin with.