### PR TITLE
Implement dependency checking during cleanup

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -59,6 +59,11 @@ module Bundle::Commands
       kept_formulae.map! { |f| Bundle::BrewDumper.formula_aliases[f] || f }
       current_formulae = Bundle::BrewDumper.formulae
       all_deps = Hash[current_formulae.map { |f| [f[:name], f[:dependencies]] }]
+      all_reqs = Hash[current_formulae.map { |f|
+        [f[:name], f[:requirements].map { |r| r["default_formula"] }.select {
+          |r| ! r.nil? } ]
+      }]
+      all_deps.merge!(all_reqs) { |k, deps, reqs| deps + reqs }
       dependencies = {}
       kept_formulae.each { |f| dependencies[f] = all_deps[f] }
       # Work out nested dependencies

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -64,6 +64,13 @@ module Bundle::Commands
           |r| ! r.nil? } ]
       }]
       all_deps.merge!(all_reqs) { |k, deps, reqs| deps + reqs }
+      current_formulae.each do |f|
+        # Deal with the full name (homebrew/x11/foo) being specified in the
+        # brewfile
+        if f[:name] != f[:full_name]
+          all_deps[f[:full_name]] = f[:name]
+        end
+      end
       dependencies = {}
       kept_formulae.each { |f| dependencies[f] = all_deps[f] }
       # Work out nested dependencies

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -26,13 +26,20 @@ describe Bundle::Commands::Cleanup do
 
     it "computes which formulae to uninstall" do
       allow(Bundle::BrewDumper).to receive(:formulae).and_return [
-        { :name => "a2", :full_name => "a2", :aliases => ["a"] },
-        { :name => "c", :full_name => "c" },
-        { :name => "d", :full_name => "homebrew/tap/d", :aliases => ["d2"] },
-        { :name => "e", :full_name => "homebrew/tap/e" },
-        { :name => "f", :full_name => "homebrew/tap/f" },
-        { :name => "h", :full_name => "other/tap/h" },
-        { :name => "i", :full_name => "homebrew/tap/i", :aliases => ["i2"] },
+        { :name => "a2", :full_name => "a2", :aliases => ["a"],
+          :dependencies => [], :requirements => []},
+        { :name => "c", :full_name => "c",
+          :dependencies => [], :requirements => []},
+        { :name => "d", :full_name => "homebrew/tap/d", :aliases => ["d2"],
+          :dependencies => [], :requirements => []},
+        { :name => "e", :full_name => "homebrew/tap/e",
+          :dependencies => [], :requirements => []},
+        { :name => "f", :full_name => "homebrew/tap/f",
+          :dependencies => [], :requirements => []},
+        { :name => "h", :full_name => "other/tap/h",
+          :dependencies => [], :requirements => []},
+        { :name => "i", :full_name => "homebrew/tap/i", :aliases => ["i2"],
+          :dependencies => [], :requirements => []},
       ]
       expect(Bundle::Commands::Cleanup.formulae_to_uninstall).to eql %w[
         c
@@ -43,11 +50,21 @@ describe Bundle::Commands::Cleanup do
 
     it "computes which formulae to uninstall with dependencies" do
       allow(Bundle::BrewDumper).to receive(:formulae).and_return [
-        { :name => "a", :full_name => "a", :dependencies => ["q"] },
-        { :name => "p", :full_name => "p", :dependencies => [] },
-        { :name => "q", :full_name => "q", :dependencies => ["r"] },
-        { :name => "r", :full_name => "r", :dependencies => [] },
-        { :name => "s", :full_name => "s", :dependencies => [] }
+        { :name => "a", :full_name => "a",
+          :dependencies => ["q"], :requirements => [
+            {"name" => "t", "default_formula" => "t"},
+            {"name" => "u", "default_formula" => nil}
+        ] },
+        { :name => "p", :full_name => "p",
+          :dependencies => [], :requirements => [] },
+        { :name => "q", :full_name => "q",
+          :dependencies => ["r"], :requirements => [] },
+        { :name => "r", :full_name => "r",
+          :dependencies => [], :requirements => [] },
+        { :name => "s", :full_name => "s",
+          :dependencies => [], :requirements => [] },
+        { :name => "t", :full_name => "t",
+          :dependencies => [], :requirements => [] },
       ]
       expect(Bundle::Commands::Cleanup.formulae_to_uninstall).to eql %w[
         p

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -55,6 +55,8 @@ describe Bundle::Commands::Cleanup do
             {"name" => "t", "default_formula" => "t"},
             {"name" => "u", "default_formula" => nil}
         ] },
+        { :name => "f", :full_name => "homebrew/tap/f",
+          :dependencies => ["v"], :requirements => [] },
         { :name => "p", :full_name => "p",
           :dependencies => [], :requirements => [] },
         { :name => "q", :full_name => "q",
@@ -64,6 +66,8 @@ describe Bundle::Commands::Cleanup do
         { :name => "s", :full_name => "s",
           :dependencies => [], :requirements => [] },
         { :name => "t", :full_name => "t",
+          :dependencies => [], :requirements => [] },
+        { :name => "v", :full_name => "v",
           :dependencies => [], :requirements => [] },
       ]
       expect(Bundle::Commands::Cleanup.formulae_to_uninstall).to eql %w[

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -41,6 +41,20 @@ describe Bundle::Commands::Cleanup do
       ]
     end
 
+    it "computes which formulae to uninstall with dependencies" do
+      allow(Bundle::BrewDumper).to receive(:formulae).and_return [
+        { :name => "a", :full_name => "a", :dependencies => ["q"] },
+        { :name => "p", :full_name => "p", :dependencies => [] },
+        { :name => "q", :full_name => "q", :dependencies => ["r"] },
+        { :name => "r", :full_name => "r", :dependencies => [] },
+        { :name => "s", :full_name => "s", :dependencies => [] }
+      ]
+      expect(Bundle::Commands::Cleanup.formulae_to_uninstall).to eql %w[
+        p
+        s
+      ]
+    end
+
     it "computes which tap to untap" do
       allow(Bundle::TapDumper).to receive(:tap_names).and_return(%w[z homebrew/bundle homebrew/core])
       expect(Bundle::Commands::Cleanup.taps_to_untap).to eql(%w[z])


### PR DESCRIPTION
This change grabs the dependencies of all formulae mentioned in the
Brewfile, and adds them to the list of formulae to keep during cleanup.

When looking at the formula list, I saw dependencies listed for the formulae I have installed, so it looks like dependencies are now being tracked as suggested in #143. Let me know if this is the wrong approach.

Fixes #143 
