### PR TITLE
bundle: fix brew cask installation detection.

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -27,7 +27,8 @@ module Bundle
 
   def cask_installed?
     @cask ||= begin
-      which("brew-cask") || which("brew-cask.rb")
+      File.directory?("#{HOMEBREW_PREFIX}/Caskroom") ||
+        File.directory?("#{HOMEBREW_REPOSITORY}/Library/Taps/caskroom")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,9 @@ module Kernel
   end
 end
 
+HOMEBREW_PREFIX = Pathname.new("/usr/local")
+HOMEBREW_REPOSITORY = Pathname.new("/usr/local/Homebrew")
+
 module Formatter
   module_function
 


### PR DESCRIPTION
Fix the check now that `brew-cask` has moved into Homebrew/brew.

CC @DomT4 to check this fixes your issue.

Fixes #226.