### PR TITLE
Improve renamed formula behaviour

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -37,19 +37,33 @@ module Bundle
       formulae.map { |f| f[:name] }
     end
 
+    def formula_oldnames
+      return @formula_oldnames if @formula_oldnames
+      @formula_oldnames = {}
+      formulae.each do |f|
+        oldname = f[:oldname]
+        next unless oldname
+        @formula_oldnames[oldname] = f[:full_name]
+        if f[:full_name].include? "/" # tap formula
+          tap_name = f[:full_name].rpartition("/").first
+          @formula_oldnames["#{tap_name}/#{oldname}"] = f[:full_name]
+        end
+      end
+      @formula_oldnames
+    end
+
     def formula_aliases
       return @formula_aliases if @formula_aliases
       @formula_aliases = {}
       formulae.each do |f|
         aliases = f[:aliases]
         next if !aliases || aliases.empty?
-        if f[:full_name].include? "/" # tap formula
-          aliases.each do |a|
-            @formula_aliases[a] = f[:full_name]
-            @formula_aliases["#{f[:full_name].rpartition("/").first}/#{a}"] = f[:full_name]
+        aliases.each do |a|
+          @formula_aliases[a] = f[:full_name]
+          if f[:full_name].include? "/" # tap formula
+            tap_name = f[:full_name].rpartition("/").first
+            @formula_aliases["#{tap_name}/#{a}"] = f[:full_name]
           end
-        else
-          aliases.each { |a| @formula_aliases[a] = f[:full_name] }
         end
       end
       @formula_aliases
@@ -91,6 +105,7 @@ module Bundle
 
       {
         name: f["name"],
+        oldname: f["oldname"],
         full_name: f["full_name"],
         aliases: f["aliases"],
         args: args,

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -67,10 +67,17 @@ module Bundle
     def self.formula_in_array?(formula, array)
       return true if array.include?(formula)
       return true if array.include?(formula.split("/").last)
+
+      old_names = Bundle::BrewDumper.formula_oldnames
+      old_name = old_names[formula]
+      old_name ||= old_names[formula.split("/").last]
+      return true if old_name && array.include?(old_name)
+
       resolved_full_name = Bundle::BrewDumper.formula_aliases[formula]
       return false unless resolved_full_name
       return true if array.include?(resolved_full_name)
       return true if array.include?(resolved_full_name.split("/").last)
+
       false
     end
 

--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -64,7 +64,14 @@ module Bundle
           formula = Bundle::BrewInstaller.new(e.name, e.options)
           needs_to_start = formula.start_service? || formula.restart_service?
           next unless needs_to_start
-          !Bundle::BrewServices.started?(e.name)
+          return false if Bundle::BrewServices.started?(e.name)
+
+          old_names = Bundle::BrewDumper.formula_oldnames
+          old_name = old_names[e.name]
+          old_name ||= old_names[e.name.split("/").last]
+          return false if old_name && Bundle::BrewServices.started?(old_name)
+
+          true
         end
       end
     end

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -59,7 +59,11 @@ module Bundle
       def formulae_to_uninstall
         @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
         kept_formulae = @dsl.entries.select { |e| e.type == :brew }.map(&:name)
-        kept_formulae.map! { |f| Bundle::BrewDumper.formula_aliases[f] || f }
+        kept_formulae.map! do |f|
+          Bundle::BrewDumper.formula_aliases[f] ||
+            Bundle::BrewDumper.formula_oldnames[f] ||
+            f
+        end
         current_formulae = Bundle::BrewDumper.formulae
         current_formulae.reject! do |f|
           Bundle::BrewInstaller.formula_in_array?(f[:full_name], kept_formulae)

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -53,6 +53,7 @@ describe Bundle::BrewDumper do
       expect(subject.formulae).to contain_exactly(
         name: "foo",
         full_name: "homebrew/tap/foo",
+        oldname: nil,
         aliases: [],
         args: [],
         version: nil,
@@ -153,18 +154,20 @@ describe Bundle::BrewDumper do
       expect(subject.formulae).to contain_exactly(
         {
           name: "foo",
-            full_name: "homebrew/tap/foo",
-            aliases: [],
-            args: [],
-            version: "1.0",
-            dependencies: [],
-            requirements: [],
-            conflicts_with: [],
-            pinned?: false,
-            outdated?: false,
+          full_name: "homebrew/tap/foo",
+          oldname: nil,
+          aliases: [],
+          args: [],
+          version: "1.0",
+          dependencies: [],
+          requirements: [],
+          conflicts_with: [],
+          pinned?: false,
+          outdated?: false,
         },
         name: "bar",
         full_name: "bar",
+        oldname: nil,
         aliases: [],
         args: ["with-a", "with-b"],
         version: "2.0",
@@ -421,6 +424,27 @@ describe Bundle::BrewDumper do
         Bundle::BrewDumper.dump
       end
       expect(dump_lines[0]).to eql(dump_lines[1])
+    end
+  end
+
+  context "#formula_oldnames" do
+    it "works" do
+      formula_info = [{
+          name: "a",
+          full_name: "homebrew/versions/a",
+          oldname: "aold",
+          aliases: [],
+          args: ["with-1", "with-2"],
+          version: "1.0",
+          dependencies: ["b"],
+          requirements: [],
+          conflicts_with: [],
+          pinned?: false,
+          outdated?: false,
+      }]
+      Bundle::BrewDumper.reset!
+      allow(Bundle::BrewDumper).to receive(:formulae_info).and_return(formula_info)
+      expect(Bundle::BrewDumper.formula_oldnames["aold"]).to eql "homebrew/versions/a"
     end
   end
 end


### PR DESCRIPTION
Use the formula’s `oldname` to handle `Brewfile`s that are still using the old names from before a formula rename. In these cases `brew bundle` will still install things fine but `brew bundle check` would always fail.

CC @technicalpickles who has seen this before.