### PR TITLE
Do not auto install cask tap for `brew bundle dump`

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -27,7 +27,7 @@ module Bundle
 
   def cask_installed?
     @cask ||= begin
-      which("brew-cask") || which("brew-cask.rb")
+      Tap.fetch("caskroom", "homebrew-cask").installed?
     end
   end
 

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -68,6 +68,7 @@ describe Bundle::BrewDumper do
   context "formulae `foo` and `bar` are installed" do
     before do
       Bundle::BrewDumper.reset!
+      allow(Bundle).to receive(:services_installed?).and_return(false)
       allow(Formula).to receive(:[]).and_return(
         "name" => "foo",
         "full_name" => "homebrew/tap/foo",
@@ -417,6 +418,7 @@ describe Bundle::BrewDumper do
       ]
       dump_lines = formula_info.map do |info|
         Bundle::BrewDumper.reset!
+        allow(Bundle).to receive(:services_installed?).and_return(false)
         allow(Bundle::BrewDumper).to receive(:formulae_info).and_return(info)
         Bundle::BrewDumper.dump
       end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -31,7 +31,7 @@ describe Bundle do
 
   context "check for brew cask" do
     it "finds it when present" do
-      allow(Bundle).to receive(:which).and_return(true)
+      allow(Tap).to receive_message_chain("fetch.installed?").and_return(true)
       expect(Bundle.cask_installed?).to eql(true)
     end
   end


### PR DESCRIPTION
Since Homebrew began to bundle Homebrew Cask lib directly,
`which("brew-cask.rb")` will always return true. This makes
`brew bundle dump` to think Homebrew Cask is always installed, and
generates the incorrect Brewfile as result.

----

I am still quiet busy recently. Here is a quick bug fix I just found out. ;)