### PR TITLE
Add check to ensure mas is signed in (#233)

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -25,6 +25,10 @@ module Bundle
     end
   end
 
+  def mas_signedin?
+    Bundle.system "mas", "account"
+  end
+
   def cask_installed?
     @cask ||= begin
       File.directory?("#{HOMEBREW_PREFIX}/Caskroom") ||

--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -11,6 +11,14 @@ module Bundle
         end
       end
 
+      unless Bundle.mas_signedin?
+        puts "Not signed in to Mac App Store." if ARGV.verbose?
+        Bundle.system "mas", "signin", "--dialog", ""
+        unless Bundle.mas_signedin?
+          raise "Unable to install #{name} app. mas not signed in to Mac App Store."
+        end
+      end
+      
       if installed_app_ids.include? id
         puts "Skipping install of #{name} app. It is already installed." if ARGV.verbose?
         return true

--- a/spec/mac_app_store_installer_spec.rb
+++ b/spec/mac_app_store_installer_spec.rb
@@ -31,11 +31,11 @@ describe Bundle::MacAppStoreInstaller do
 
     context "when mas is not signed in" do
       before do
-        allow(Bundle).to receive(:mas_signedin?).and_return(false)
         allow(ARGV).to receive(:verbose?).and_return(false)
       end
 
       it "tries to sign in with mas" do
+        expect(Bundle).to receive(:system).with("mas", "account").and_return(false).twice
         expect(Bundle).to receive(:system).with("mas", "signin", "--dialog", "").and_return(true)
         expect { do_install }.to raise_error(RuntimeError)
       end

--- a/spec/mac_app_store_installer_spec.rb
+++ b/spec/mac_app_store_installer_spec.rb
@@ -29,25 +29,44 @@ describe Bundle::MacAppStoreInstaller do
       allow(ARGV).to receive(:verbose?).and_return(false)
     end
 
-    context "when app is installed" do
+    context "when mas is not signed in" do
       before do
-        allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return([123])
+        allow(Bundle).to receive(:mas_signedin?).and_return(false)
+        allow(ARGV).to receive(:verbose?).and_return(false)
       end
 
-      it "skips" do
-        expect(Bundle).not_to receive(:system)
-        expect(do_install).to eql(true)
+      it "tries to sign in with mas" do
+        expect(Bundle).to receive(:system).with("mas", "signin", "--dialog", "").and_return(true)
+        expect { do_install }.to raise_error(RuntimeError)
       end
     end
 
-    context "when app is not installed" do
+    context "when mas is signed in" do
       before do
-        allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return([])
+        allow(Bundle).to receive(:mas_signedin?).and_return(true)
+        allow(ARGV).to receive(:verbose?).and_return(false)
       end
 
-      it "installs app" do
-        expect(Bundle).to receive(:system).with("mas", "install", "123").and_return(true)
-        expect(do_install).to eql(true)
+      context "when app is installed" do
+        before do
+          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return([123])
+        end
+
+        it "skips" do
+          expect(Bundle).not_to receive(:system)
+          expect(do_install).to eql(true)
+        end
+      end
+
+      context "when app is not installed" do
+        before do
+          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return([])
+        end
+
+        it "installs app" do
+          expect(Bundle).to receive(:system).with("mas", "install", "123").and_return(true)
+          expect(do_install).to eql(true)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR would resolve the issue #233.

When the user is not signed in to the Mac App Store, it will open the `App Store.app` and prompt for logging in instead of failing to install all apps specified for `mas` in the `Brewfile`.

Clarification of the chosen command:
`mas signin` requires to provide an Apple ID, which is not possible to provide at the time of the call. So I opted for `mas signin --dialog ''`. The `--dialog` option opens the login dialog of the `App Store.app` and passes the string after the argument to the email field of the dialog (therefore we pass an empty string)