### PR TITLE
spec_helper: only submit coverage for CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 before_install:
   - sudo gem install bundler
   - HOMEBREW_DEVELOPER=1 brew update
+  - rm -rf $(brew --repo)/Library/Taps/homebrew/*
   - ln -s . $(brew --repo)/Library/Taps/homebrew/homebrew-bundle
 script:
   - brew style homebrew/bundle

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,9 +14,9 @@ $:.unshift(STUB_PATH)
 Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").each { |f| require f }
 
 SimpleCov.formatters = [
-  SimpleCov::Formatter::Codecov,
   SimpleCov::Formatter::HTMLFormatter,
 ]
+SimpleCov.formatters << SimpleCov::Formatter::Codecov if ENV["CI"]
 
 require "bundle"
 require "bundler"


### PR DESCRIPTION
Otherwise there’s annoying warnings when doing a local test run.