### PR TITLE
Add support for bundle install --without=<groups>

### DIFF
--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -1,7 +1,7 @@
 #:  * `bundle` <command>:
 #:    Bundler for non-Ruby dependencies from Homebrew.
 #:
-#:    `brew bundle` [-v|--verbose] [--no-upgrade] [--file=<path>|--global]:
+#:    `brew bundle` [-v|--verbose] [--no-upgrade] [--file=<path>|--global] [--without=<groups>]:
 #:    Install or upgrade all dependencies in a Brewfile.
 #:
 #:    `brew bundle dump` [--force] [--file=<path>|--global]
@@ -28,6 +28,8 @@
 #:    `--file=-` to output to console).
 #:
 #:    If `--global` is passed, set Brewfile path to `$HOME/.Brewfile`.
+#:
+#:    If `--without=<groups>` is passed, skip installation in specified groups.
 #:
 #:    If `-h` or `--help` are passed, print this help message and exit.
 

--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -17,6 +17,8 @@ module Bundle
       @entries = []
       @cask_arguments = {}
 
+      @groups = %w[default]
+
       begin
         process
       # Want to catch all exceptions for e.g. syntax errors.
@@ -34,7 +36,12 @@ module Bundle
       success = 0
       failure = 0
 
-      @entries.each do |entry|
+      without_groups = ARGV.values(:without).to_a
+      selected_entries = @entries.select do |entry|
+        (without_groups & entry.options[:groups]).empty?
+      end
+
+      selected_entries.each do |entry|
         arg = [entry.name]
         verb = "installing"
         cls = case entry.type
@@ -74,6 +81,7 @@ module Bundle
       raise "name(#{name.inspect}) should be a String object" unless name.is_a? String
       raise "options(#{options.inspect}) should be a Hash object" unless options.is_a? Hash
       name = Bundle::Dsl.sanitize_brew_name(name)
+      options[:groups] = @groups.dup
       @entries << Entry.new(:brew, name, options)
     end
 
@@ -82,6 +90,7 @@ module Bundle
       raise "options(#{options.inspect}) should be a Hash object" unless options.is_a? Hash
       name = Bundle::Dsl.sanitize_cask_name(name)
       options[:args] = @cask_arguments.merge options.fetch(:args, {})
+      options[:groups] = @groups.dup
       @entries << Entry.new(:cask, name, options)
     end
 
@@ -89,14 +98,24 @@ module Bundle
       id = options[:id]
       raise "name(#{name.inspect}) should be a String object" unless name.is_a? String
       raise "options[:id](#{id}) should be an Integer object" unless id.is_a? Integer
-      @entries << Entry.new(:mac_app_store, name, id: id)
+      options[:groups] = @groups.dup
+      @entries << Entry.new(:mac_app_store, name, options)
     end
 
     def tap(name, clone_target = nil)
       raise "name(#{name.inspect}) should be a String object" unless name.is_a? String
       raise "clone_target(#{clone_target.inspect}) should be nil or a String object" if clone_target && !clone_target.is_a?(String)
       name = Bundle::Dsl.sanitize_tap_name(name)
-      @entries << Entry.new(:tap, name, clone_target: clone_target)
+      options = { clone_target: clone_target, groups: @groups.dup }
+      @entries << Entry.new(:tap, name, options)
+    end
+
+    def group(name)
+      raise "name(#{name.inspect}) should be a String object" unless name.is_a? String
+      @groups.push name
+      yield
+    ensure
+      @groups.pop
     end
 
     HOMEBREW_TAP_ARGS_REGEX = %r{^([\w-]+)/(homebrew-)?([\w-]+)$}

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -16,22 +16,31 @@ describe Bundle::Dsl do
       cask 'java' unless system '/usr/libexec/java_home --failfast'
       cask 'firefox', args: { appdir: '~/my-apps/Applications' }
       mas '1Password', id: 443987910
+      group 'myfancygroup' do
+        brew 'vim'
+      end
     EOS
     expect(dsl.cask_arguments).to eql(appdir: "/Applications")
     expect(dsl.entries[0].name).to eql("caskroom/cask")
+    expect(dsl.entries[0].options).to eql(clone_target: nil, groups: ["default"])
     expect(dsl.entries[1].name).to eql("telemachus/brew")
-    expect(dsl.entries[1].options).to eql(clone_target: "https://telemachus@bitbucket.org/telemachus/brew.git")
+    expect(dsl.entries[1].options).to eql(clone_target: "https://telemachus@bitbucket.org/telemachus/brew.git", groups: ["default"])
     expect(dsl.entries[2].name).to eql("imagemagick")
+    expect(dsl.entries[2].options).to eql(groups: ["default"])
     expect(dsl.entries[3].name).to eql("mysql")
-    expect(dsl.entries[3].options).to eql(restart_service: true, conflicts_with: ["homebrew/versions/mysql56"])
+    expect(dsl.entries[3].options).to eql(restart_service: true, conflicts_with: ["homebrew/versions/mysql56"], groups: ["default"])
     expect(dsl.entries[4].name).to eql("emacs")
-    expect(dsl.entries[4].options).to eql(args: ["with-cocoa", "with-gnutls"])
+    expect(dsl.entries[4].options).to eql(args: ["with-cocoa", "with-gnutls"], groups: ["default"])
     expect(dsl.entries[5].name).to eql("google-chrome")
+    expect(dsl.entries[5].options).to eql(args: { appdir: "/Applications" }, groups: ["default"])
     expect(dsl.entries[6].name).to eql("java")
+    expect(dsl.entries[6].options).to eql(args: { appdir: "/Applications" }, groups: ["default"])
     expect(dsl.entries[7].name).to eql("firefox")
-    expect(dsl.entries[7].options).to eql(args: { appdir: "~/my-apps/Applications" })
+    expect(dsl.entries[7].options).to eql(args: { appdir: "~/my-apps/Applications" }, groups: ["default"])
     expect(dsl.entries[8].name).to eql("1Password")
-    expect(dsl.entries[8].options).to eql(id: 443_987_910)
+    expect(dsl.entries[8].options).to eql(id: 443_987_910, groups: ["default"])
+    expect(dsl.entries[9].name).to eql("vim")
+    expect(dsl.entries[9].options).to eql(groups: ["default", "myfancygroup"])
   end
 
   it "handles invalid input" do

--- a/spec/install_command_spec.rb
+++ b/spec/install_command_spec.rb
@@ -7,7 +7,7 @@ describe Bundle::Commands::Install do
 
   context "when a Brewfile is not found" do
     it "raises an error" do
-      allow(ARGV).to receive(:value).and_return(nil)
+      allow(ARGV).to receive_messages(:value => nil, :values => nil)
       expect { Bundle::Commands::Install.run }.to raise_error(RuntimeError)
     end
   end
@@ -19,7 +19,7 @@ describe Bundle::Commands::Install do
       allow(Bundle::MacAppStoreInstaller).to receive(:install).and_return(true)
       allow(Bundle::TapInstaller).to receive(:install).and_return(true)
 
-      allow(ARGV).to receive(:value).and_return(nil)
+      allow(ARGV).to receive_messages(:value => nil, :values => nil)
       allow_any_instance_of(Pathname).to receive(:read)
         .and_return("tap 'phinze/cask'\nbrew 'mysql', conflicts_with: ['mysql56']\ncask 'google-chrome'\nmas '1Password', id: 443987910")
       expect { Bundle::Commands::Install.run }.to_not raise_error
@@ -31,10 +31,40 @@ describe Bundle::Commands::Install do
       allow(Bundle::MacAppStoreInstaller).to receive(:install).and_return(false)
       allow(Bundle::TapInstaller).to receive(:install).and_return(false)
 
-      allow(ARGV).to receive(:value).and_return(nil)
+      allow(ARGV).to receive_messages(:value => nil, :values => nil)
       allow_any_instance_of(Pathname).to receive(:read)
         .and_return("tap 'phinze/cask'\nbrew 'mysql', conflicts_with: ['mysql56']\ncask 'google-chrome'\n\nmas '1Password', id: 443987910")
       expect { Bundle::Commands::Install.run }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when --without=default is given" do
+    it "installs nothing" do
+      expect(Bundle::BrewInstaller).not_to receive(:install)
+      expect(Bundle::CaskInstaller).not_to receive(:install)
+      expect(Bundle::MacAppStoreInstaller).not_to receive(:install)
+      expect(Bundle::TapInstaller).not_to receive(:install)
+
+      allow(ARGV).to receive_messages(:value => nil, :values => nil)
+      allow(ARGV).to receive(:values).with(:without).and_return(["default"])
+      allow_any_instance_of(Pathname).to receive(:read)
+        .and_return("tap 'phinze/cask'\nbrew 'mysql', conflicts_with: ['mysql56']\ncask 'google-chrome'\nmas '1Password', id: 443987910")
+      expect { Bundle::Commands::Install.run }.to_not raise_error
+    end
+  end
+
+  context "when --without=my,fancy,group is given" do
+    it "installs entries only outside of myfancygroup" do
+      expect(Bundle::BrewInstaller).not_to receive(:install)
+      expect(Bundle::CaskInstaller).not_to receive(:install)
+      expect(Bundle::MacAppStoreInstaller).not_to receive(:install)
+      expect(Bundle::TapInstaller).to receive(:install).and_return(true)
+
+      allow(ARGV).to receive_messages(:value => nil, :values => nil)
+      allow(ARGV).to receive(:values).with(:without).and_return(%w[my fancy group])
+      allow_any_instance_of(Pathname).to receive(:read)
+        .and_return("tap 'phinze/cask'\ngroup 'my' do\nbrew 'mysql', conflicts_with: ['mysql56']\nend\ngroup 'fancy' do\ncask 'google-chrome'\nend\ngroup 'group' do\nmas '1Password', id: 443987910\nend")
+      expect { Bundle::Commands::Install.run }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Modeled after Ruby bundler and implements #175 partially.
Having `--with` is also possible, but I believe that is too complex for Homebrew.

## Synopsis
In Brewfile:

```ruby
cask_args appdir: "/Applications"

tap "caskroom/cask"
brew "ruby187"
cask "vagrant"
mas 'CotEditor', id: 1024640650

group "development" do
  tap "brew/versions"
  cask "google-chrome"
  brew "vim"
end

group "xcode" do
  mas 'Xcode', id: 497799835
end
```

Everything but not in `development` and `xcode` group can be installed:

```
brew install --without=development,xcode
```