### PR TITLE
brew_dumper: fix handling of pinned/outdated.

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -116,8 +116,8 @@ module Bundle
         build_dependencies: f["build_dependencies"],
         requirements: f["requirements"],
         conflicts_with: f["conflicts_with"],
-        pinned?: !f["pinned"].nil?,
-        outdated?: !f["outdated"].nil?,
+        pinned?: (f["pinned"] || false),
+        outdated?: (f["outdated"] || false),
       }
     end
 


### PR DESCRIPTION
Previously it was doing e.g. `!f["pinned"].nil?` which would actually end up being `true` if `f["pinned"]` was `false`. As a result of both `pinned?` and `outdated?` having this behaviour it broke `brew bundle check` checking if formulae were outdated and `brew bundle`
from upgrading them.