### PR TITLE
Remove old link.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,7 +74,7 @@ This provides a successful exit code if everything is up-to-date so is useful fo
 
 ### Exec
 
-Runs an external command within Homebrew's [superenv](https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md#superenv-notes) build environment:
+Runs an external command within Homebrew's superenv build environment:
 
     $ brew bundle exec -- bundle install
 


### PR DESCRIPTION
The new docs site doesn't allow deep linking so just remove this link.