### PR TITLE
Alphabetize `mas list` when dumped to Brewfile

### DIFF
--- a/lib/bundle/mac_app_store_dumper.rb
+++ b/lib/bundle/mac_app_store_dumper.rb
@@ -25,7 +25,7 @@ module Bundle
     end
 
     def dump
-      apps.sort_by { |id, name| name.downcase }.map { |id, name| "mas '#{name}', id: #{id}" }.join("\n")
+      apps.sort_by { |_, name| name.downcase }.map { |id, name| "mas '#{name}', id: #{id}" }.join("\n")
     end
   end
 end

--- a/lib/bundle/mac_app_store_dumper.rb
+++ b/lib/bundle/mac_app_store_dumper.rb
@@ -25,7 +25,7 @@ module Bundle
     end
 
     def dump
-      apps.map { |id, name| "mas '#{name}', id: #{id}" }.join("\n")
+      apps.sort_by { |id, name| name.downcase }.map { |id, name| "mas '#{name}', id: #{id}" }.join("\n")
     end
   end
 end


### PR DESCRIPTION
To my knowledge, the App Store doesn't have a concept of dependencies, so the objection to alphabetizing mentioned in #242 doesn't apply.

Fixes #256.

(This is literally the first time I've looked at, much less written, any Ruby. Apologies for code quality or whatever else I may have messed up. 😄 )