### PR TITLE
bundle: need Caskroom and tap for cask installed.

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -31,7 +31,7 @@ module Bundle
 
   def cask_installed?
     @cask ||= begin
-      File.directory?("#{HOMEBREW_PREFIX}/Caskroom") ||
+      File.directory?("#{HOMEBREW_PREFIX}/Caskroom") &&
         File.directory?("#{HOMEBREW_REPOSITORY}/Library/Taps/caskroom")
     end
   end


### PR DESCRIPTION
Otherwise `brew bundle dump` (the only place that actually uses this method) may auto-tap caskroom/cask and put the tap output when `brew cask list` is called.

Fixes #265.