### PR TITLE
brew_services: consider "not stopped" as started.

### DIFF
--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -29,7 +29,7 @@ module Bundle
       @started_services ||= if Bundle.services_installed?
         `brew services list`.lines.map do |line|
           name, state, _plist = line.split(/\s+/)
-          next unless state == "started"
+          next if state == "stopped"
           name
         end.compact
       else


### PR DESCRIPTION
States such as `error` or `unknown` both indicate an intention from the user that this service be started.