### PR TITLE
Use double-quotes in Brewfiles.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,16 +30,16 @@ Create a `Brewfile` in the root of your project:
 Then list your Homebrew based dependencies in your `Brewfile`:
 
 ```ruby
-cask_args appdir: '/Applications'
-tap 'caskroom/cask'
-tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
-brew 'imagemagick'
-brew 'mysql', restart_service: true, conflicts_with: ['homebrew/versions/mysql56']
-brew 'emacs', args: ['with-cocoa', 'with-gnutls']
-cask 'google-chrome'
-cask 'java' unless system '/usr/libexec/java_home --failfast'
-cask 'firefox', args: { appdir: '~/my-apps/Applications' }
-mas '1Password', id: 443987910
+cask_args appdir: "/Applications"
+tap "caskroom/cask"
+tap "telemachus/brew", "https://telemachus@bitbucket.org/telemachus/brew.git"
+brew "imagemagick"
+brew "mysql", restart_service: true, conflicts_with: ["homebrew/versions/mysql56"]
+brew "emacs", args: ["with-cocoa", "with-gnutls"]
+cask "google-chrome"
+cask "java" unless system "/usr/libexec/java_home --failfast"
+cask "firefox", args: { appdir: "~/my-apps/Applications" }
+mas "1Password", id: 443987910
 ```
 
 You can then easily install all of the dependencies with the following command:

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -24,8 +24,8 @@ module Bundle
         f[:installed_on_request?] || !f[:installed_as_dependency?]
       end
       requested_formula.map do |f|
-        brewline = "brew '#{f[:full_name]}'"
-        args = f[:args].map { |arg| "'#{arg}'" }.sort.join(", ")
+        brewline = "brew \"#{f[:full_name]}\""
+        args = f[:args].map { |arg| "\"#{arg}\"" }.sort.join(", ")
         brewline += ", args: [#{args}]" unless f[:args].empty?
         brewline += ", restart_service: true" if BrewServices.started?(f[:full_name])
         brewline

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -16,8 +16,8 @@ module Bundle
 
     def dump(casks_required_by_formulae)
       [
-        (casks & casks_required_by_formulae).map { |cask| "cask '#{cask}'" }.join("\n"),
-        (casks - casks_required_by_formulae).map { |cask| "cask '#{cask}'" }.join("\n"),
+        (casks & casks_required_by_formulae).map { |cask| "cask \"#{cask}\"" }.join("\n"),
+        (casks - casks_required_by_formulae).map { |cask| "cask \"#{cask}\"" }.join("\n"),
       ]
     end
   end

--- a/lib/bundle/mac_app_store_dumper.rb
+++ b/lib/bundle/mac_app_store_dumper.rb
@@ -25,7 +25,7 @@ module Bundle
     end
 
     def dump
-      apps.sort_by { |_, name| name.downcase }.map { |id, name| "mas '#{name}', id: #{id}" }.join("\n")
+      apps.sort_by { |_, name| name.downcase }.map { |id, name| "mas \"#{name}\", id: #{id}" }.join("\n")
     end
   end
 end

--- a/lib/bundle/tap_dumper.rb
+++ b/lib/bundle/tap_dumper.rb
@@ -17,8 +17,8 @@ module Bundle
 
     def dump
       taps.map do |tap|
-        remote = ", '#{tap["remote"]}'" if tap["custom_remote"] && tap["remote"]
-        "tap '#{tap["name"]}'#{remote}"
+        remote = ", \"#{tap["remote"]}\"" if tap["custom_remote"] && tap["remote"]
+        "tap \"#{tap["name"]}\"#{remote}"
       end.join("\n")
     end
 

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -214,7 +214,7 @@ describe Bundle::BrewDumper do
     end
 
     it "dumps as foo and bar with args" do
-      expect(subject.dump).to eql("brew 'bar', args: ['with-a', 'with-b']\nbrew 'homebrew/tap/foo'")
+      expect(subject.dump).to eql("brew \"bar\", args: [\"with-a\", \"with-b\"]\nbrew \"homebrew/tap/foo\"")
     end
 
     it "formula_info returns the formula" do

--- a/spec/cask_dumper_spec.rb
+++ b/spec/cask_dumper_spec.rb
@@ -47,7 +47,7 @@ describe Bundle::CaskDumper do
     end
 
     it "dumps as `cask 'baz'` and `cask 'foo' cask 'bar'`" do
-      expect(subject.dump(%w[baz])).to eql ["cask 'baz'", "cask 'foo'\ncask 'bar'"]
+      expect(subject.dump(%w[baz])).to eql ["cask \"baz\"", "cask \"foo\"\ncask \"bar\""]
     end
   end
 end

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -18,7 +18,7 @@ describe Bundle::Dumper do
   it "generates output" do
     expect(subject).to receive(:write_file) do |file, content, _overwrite|
       expect(file).to eql(Pathname.new(Dir.pwd).join("Brewfile"))
-      expect(content).to eql("cask 'google-chrome'\ncask 'java'\n")
+      expect(content).to eql("cask \"google-chrome\"\ncask \"java\"\n")
     end
     subject.dump_brewfile
   end

--- a/spec/tap_dumper_spec.rb
+++ b/spec/tap_dumper_spec.rb
@@ -39,7 +39,7 @@ describe Bundle::TapDumper do
     end
 
     it "dumps output" do
-      expect(subject.dump).to eql("tap 'homebrew/foo'\ntap 'bitbucket/bar', 'https://bitbucket.org/bitbucket/bar.git'")
+      expect(subject.dump).to eql("tap \"homebrew/foo\"\ntap \"bitbucket/bar\", \"https://bitbucket.org/bitbucket/bar.git\"")
     end
   end
 end


### PR DESCRIPTION
This better matches Homebrew's (and Rubocop's) general style guidelines and also better handles textual content such
as the `mas` lines' `name`.

This will cause an annoying diff when running `brew bundle dump` but this was a change that feels worth that minor,
one-time annoyance.

Fixes #271.