### PR TITLE
Move requirement of English stdlib to library

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -1,3 +1,5 @@
+require "English"
+
 module Bundle
   module_function
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,6 @@ RSpec.configure do |config|
 end
 
 require "unindent"
-require "English"
 
 # Stub out the inclusion of Homebrew's code.
 LIBS_TO_SKIP = ["formula", "tap", "utils/formatter"].freeze


### PR DESCRIPTION
After #275, we ran into CI error:

```
brew bundle
==> Tapping homebrew/bundle
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle'...
remote: Counting objects: 57, done.
remote: Compressing objects: 100% (55/55), done.
remote: Total 57 (delta 5), reused 12 (delta 0), pack-reused 0
Receiving objects: 100% (57/57), 29.32 KiB | 0 bytes/s, done.
Resolving deltas: 100% (5/5), done.
Tapped 0 formulae (72 files, 157.6KB)
Error: undefined method `success?' for nil:NilClass
Please report this bug:
    https://github.com/Homebrew/homebrew-bundle/issues/
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/bundle.rb:13:in `block in system'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/bundle.rb:8:in `popen'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/bundle.rb:8:in `system'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:159:in `install!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:35:in `install_change_state!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:24:in `run'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:10:in `install'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:55:in `block in install'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:37:in `each'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:37:in `install'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/commands/install.rb:7:in `run'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/cmd/brew-bundle.rb:60:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/brew.rb:24:in `require?'
/usr/local/Homebrew/Library/Homebrew/brew.rb:97:in `<main>'
```