### PR TITLE
CaskDumper uses cask full-name

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -8,7 +8,7 @@ module Bundle
 
     def casks
       @casks ||= if Bundle.cask_installed?
-        `brew cask list -1 2>/dev/null`.split("\n").map { |cask| cask.chomp " (!)" }
+        `brew cask list --full-name 2>/dev/null`.split("\n").map { |cask| cask.chomp " (!)" }
       else
         []
       end


### PR DESCRIPTION
Commands like `cleanup` and `check` would provide incorrect information
if a cask from a tap other than caskroom/cask was installed. While the
Brewfile might include the tap name (e.g. "caskroom/version/foo"),
CaskDumper would report the installed cask as "foo". Now that CaskDumper
provides the full name of the cask, comparisons between a Brewfile and
the installed state correctly consider the tap the cask is from.

This requires homebrew/brew#2878, which adds the flag, to be merged first.