### PR TITLE
Check command will check all services that might need starting, instead of just the first

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -74,9 +74,7 @@ module Bundle
       @formula_info_name ||= {}
       @formula_info_name[name] ||= begin
         require "formula"
-        formula = Formula[name]
-        return {} unless formula
-        formula_inspector formula.to_hash
+        formula_inspector Formula[name].to_hash
       end
     end
 

--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -64,12 +64,12 @@ module Bundle
           formula = Bundle::BrewInstaller.new(e.name, e.options)
           needs_to_start = formula.start_service? || formula.restart_service?
           next unless needs_to_start
-          return false if Bundle::BrewServices.started?(e.name)
+          next if Bundle::BrewServices.started?(e.name)
 
           old_names = Bundle::BrewDumper.formula_oldnames
           old_name = old_names[e.name]
           old_name ||= old_names[e.name.split("/").last]
-          return false if old_name && Bundle::BrewServices.started?(old_name)
+          next if old_name && Bundle::BrewServices.started?(old_name)
 
           true
         end

--- a/spec/check_command_spec.rb
+++ b/spec/check_command_spec.rb
@@ -65,10 +65,11 @@ describe Bundle::Commands::Check do
   context "when service is not started" do
     before do
       allow_any_instance_of(Bundle::CaskDumper).to receive(:casks).and_return([])
-      allow(Bundle::BrewInstaller).to receive(:installed_formulae).and_return(["abc"])
+      allow(Bundle::BrewInstaller).to receive(:installed_formulae).and_return(["abc", "def"])
       allow(Bundle::BrewInstaller).to receive(:upgradable_formulae).and_return([])
       allow(ARGV).to receive(:include?).and_return(true)
-      allow(Bundle::BrewServices).to receive(:started?).with("abc").and_return(false)
+      allow(Bundle::BrewServices).to receive(:started?).with("abc").and_return(true)
+      allow(Bundle::BrewServices).to receive(:started?).with("def").and_return(false)
     end
 
     it "should not raises error by default" do
@@ -78,14 +79,14 @@ describe Bundle::Commands::Check do
 
     context "restart_service is true" do
       it "raises an error" do
-        allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc', restart_service: true")
+        allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc', restart_service: true\nbrew 'def', restart_service: true")
         expect { do_check }.to raise_error(SystemExit)
       end
     end
 
     context "start_service is true" do
       it "raises an error" do
-        allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc', start_service: true")
+        allow_any_instance_of(Pathname).to receive(:read).and_return("brew 'abc', start_service: true\nbrew 'def', start_service: true")
         expect { do_check }.to raise_error(SystemExit)
       end
     end


### PR DESCRIPTION
If two formulae have services that need to start and the first is
already started, the previous code would exit early from the method and
not check the second service. By switching to `next`, we properly
compare each service until one is found that needs to be started.

Note: The second commit is mostly for style's sake, and can be removed if requested. `Bundle::BrewInstaller#resolve_conflicts!` also has the potentially-confusing return from a block, but an early-exit is desirable there, so I've left it.