### PR TITLE
Bundle DSL: handle names as frozen string literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 script:
   - brew style "$TRAVIS_REPO_SLUG"
-  - RUBYOPT="--enable-frozen-string-literal" bundle exec rake
+  - bundle exec rake
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 script:
   - brew style "$TRAVIS_REPO_SLUG"
-  - bundle exec rake
+  - RUBYOPT="--enable-frozen-string-literal" bundle exec rake
 
 notifications:
   email:

--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -136,7 +136,7 @@ module Bundle
     end
 
     def self.sanitize_cask_name(name)
-      name = name.downcase
+      name.downcase
     end
   end
 end

--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -113,7 +113,7 @@ module Bundle
     HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.@]+)$}
 
     def self.sanitize_brew_name(name)
-      name.downcase!
+      name = name.downcase
       if name =~ HOMEBREW_CORE_FORMULA_REGEX
         Regexp.last_match(1)
       elsif name =~ HOMEBREW_TAP_FORMULA_REGEX
@@ -127,7 +127,7 @@ module Bundle
     end
 
     def self.sanitize_tap_name(name)
-      name.downcase!
+      name = name.downcase
       if name =~ HOMEBREW_TAP_ARGS_REGEX
         "#{Regexp.last_match(1)}/#{Regexp.last_match(3)}"
       else
@@ -136,7 +136,7 @@ module Bundle
     end
 
     def self.sanitize_cask_name(name)
-      name.downcase
+      name = name.downcase
     end
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -6,6 +6,7 @@ describe Bundle::Dsl do
     allow(ARGV).to receive(:verbose?).and_return(true)
     # Keep in sync with the README
     dsl = Bundle::Dsl.new <<-EOS
+      # frozen_string_literal: true
       cask_args appdir: '/Applications'
       tap 'caskroom/cask'
       tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'


### PR DESCRIPTION
I have a `Brewfile` like this:

```ruby
# frozen_string_literal: true

brew "rbenv"
brew "ruby-build"
```

When I run `brew bundle` or `brew bundle check`, I get:

```text
~/project#master$ brew bundle check
Error: Invalid Brewfile: can't modify frozen String
```

With `HOMEBREW_DEBUG=true`:

```text
~/project#master$ HOMEBREW_DEBUG=true brew bundle check
Error: Invalid Brewfile: can't modify frozen String
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:30:in `instance_eval'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:130:in `sanitize_tap_name'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:107:in `tap'
(eval):3:in `process'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:30:in `instance_eval'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:30:in `process'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/dsl.rb:21:in `initialize'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/commands/check.rb:46:in `new'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/commands/check.rb:46:in `any_taps_to_tap?'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/commands/check.rb:16:in `run'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/cmd/brew-bundle.rb:61:in `<top (required)>'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/utils.rb:20:in `require?'
/usr/local/Homebrew/Library/Homebrew/brew.rb:105:in `<main>'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/cmd/brew-bundle.rb:78:in `exit'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/cmd/brew-bundle.rb:78:in `rescue in <top (required)>'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/cmd/brew-bundle.rb:52:in `<top (required)>'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/utils.rb:20:in `require?'
/usr/local/Homebrew/Library/Homebrew/brew.rb:105:in `<main>'
```

It's caused by calls to `downcase!` By applying this patch, I get:

```text
~/project#master$ brew bundle check
The Brewfile's dependencies are satisfied.
```

I'm not sure how to add a spec for this yet.

/cc @MikeMcQuaid 