### PR TITLE
Add `frozen_string_literal: true` to the top of all files & fix issues with frozen strings

### DIFF
--- a/lib/bundle.rb
+++ b/lib/bundle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # check ruby version before requiring any modules.
 RUBY_VERSION_SPLIT = RUBY_VERSION.split "."
 RUBY_X = RUBY_VERSION_SPLIT[0].to_i

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -165,7 +165,8 @@ module Bundle
         ).uniq
         topo[f[:full_name]] = deps.map do |dep|
           ff = @formulae.detect { |formula| formula[:name] == dep || formula[:full_name] == dep }
-          ff[:full_name] if ff
+          next unless ff
+          ff[:full_name]
         end.compact
       end
       @formulae = topo.tsort.map { |name| @formulae.detect { |formula| formula[:full_name] == name } }

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require "json"
 require "tsort"
+
 module Bundle
   module BrewDumper
     module_function

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -170,7 +170,7 @@ module Bundle
       end
       @formulae = topo.tsort.map { |name| @formulae.detect { |formula| formula[:full_name] == name } }
     rescue TSort::Cyclic => e
-      odie <<~EOS
+      odie <<-EOS.undent
         #{e.message}
         Formulae dependency graph sorting failed (likely due to a circular dependency)!
       EOS

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -170,7 +170,7 @@ module Bundle
       end
       @formulae = topo.tsort.map { |name| @formulae.detect { |formula| formula[:full_name] == name } }
     rescue TSort::Cyclic => e
-      odie <<-EOS.undent
+      odie <<~EOS
         #{e.message}
         Formulae dependency graph sorting failed (likely due to a circular dependency)!
       EOS

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -154,7 +154,7 @@ module Bundle
       conflicts_with.each do |conflict|
         next unless BrewInstaller.formula_installed?(conflict)
         if ARGV.verbose?
-          puts <<~EOS
+          puts <<-EOS.undent
               Unlinking #{conflict} formula.
               It is currently installed and conflicts with #{@name}.
           EOS

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -154,7 +154,7 @@ module Bundle
       conflicts_with.each do |conflict|
         next unless BrewInstaller.formula_installed?(conflict)
         if ARGV.verbose?
-          puts <<-EOS.undent
+          puts <<~EOS
               Unlinking #{conflict} formula.
               It is currently installed and conflicts with #{@name}.
           EOS

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -154,9 +154,9 @@ module Bundle
       conflicts_with.each do |conflict|
         next unless BrewInstaller.formula_installed?(conflict)
         if ARGV.verbose?
-          puts <<~EOS
-              Unlinking #{conflict} formula.
-              It is currently installed and conflicts with #{@name}.
+          puts <<~EOS.unindent
+            Unlinking #{conflict} formula.
+            It is currently installed and conflicts with #{@name}.
           EOS
         end
         return false unless Bundle.system("brew", "unlink", conflict)

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   class BrewInstaller
     def self.reset!

--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module BrewServices
     module_function

--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "English"
 
 module Bundle

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module CaskDumper
     module_function

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module CaskInstaller
     module_function

--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module Commands
     module Check

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module Commands
     module Cleanup

--- a/lib/bundle/commands/dump.rb
+++ b/lib/bundle/commands/dump.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module Commands
     module Dump

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "extend/ENV"
 require "formula"
 require "utils"

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module Commands
     module Install

--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   class Dsl
     class Entry

--- a/lib/bundle/dumper.rb
+++ b/lib/bundle/dumper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "pathname"
 

--- a/lib/bundle/mac_app_store_dumper.rb
+++ b/lib/bundle/mac_app_store_dumper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "json"
 
 module Bundle

--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module MacAppStoreInstaller
     module_function

--- a/lib/bundle/tap_dumper.rb
+++ b/lib/bundle/tap_dumper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "json"
 
 module Bundle

--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bundle
   module TapInstaller
     module_function

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -462,7 +462,6 @@ describe Bundle::BrewDumper do
       before do
         allow(Bundle::BrewDumper::Topo).to \
           receive(:new).and_raise(TSort::Cyclic)
-        allow_any_instance_of(String).to receive(:undent)
         allow_any_instance_of(Object).to receive(:odie) { raise }
       end
 

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "tsort"
 

--- a/spec/brew_installer_spec.rb
+++ b/spec/brew_installer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::BrewInstaller do

--- a/spec/brew_installer_spec.rb
+++ b/spec/brew_installer_spec.rb
@@ -82,7 +82,6 @@ describe Bundle::BrewInstaller do
 
     it "prints a message" do
       allow(ARGV).to receive(:verbose?).and_return(true)
-      allow_any_instance_of(String).to receive(:undent).and_return("")
       allow_any_instance_of(Bundle::BrewInstaller).to receive(:puts)
       Bundle::BrewInstaller.install(formula, restart_service: true, conflicts_with: ["mysql56"])
     end

--- a/spec/brew_services_spec.rb
+++ b/spec/brew_services_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::BrewServices do

--- a/spec/brew_services_spec.rb
+++ b/spec/brew_services_spec.rb
@@ -15,7 +15,7 @@ describe Bundle::BrewServices do
 
     it "returns started services" do
       allow(Bundle).to receive(:services_installed?).and_return(true)
-      allow(Bundle::BrewServices).to receive(:`).and_return <<-EOS.unindent
+      allow(Bundle::BrewServices).to receive(:`).and_return <<~EOS
         nginx  started  homebrew.mxcl.nginx.plist
         apache stopped  homebrew.mxcl.apache.plist
         mysql  started  homebrew.mxcl.mysql.plist

--- a/spec/cask_dumper_spec.rb
+++ b/spec/cask_dumper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::CaskDumper do

--- a/spec/cask_installer_spec.rb
+++ b/spec/cask_installer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::CaskInstaller do

--- a/spec/check_command_spec.rb
+++ b/spec/check_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::Commands::Check do

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::Commands::Cleanup do

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::Dsl do

--- a/spec/dump_command_spec.rb
+++ b/spec/dump_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::Commands::Dump do

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::Dumper do

--- a/spec/exec_command_spec.rb
+++ b/spec/exec_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::Commands::Exec do

--- a/spec/install_command_spec.rb
+++ b/spec/install_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::Commands::Install do

--- a/spec/mac_app_store_dumper_spec.rb
+++ b/spec/mac_app_store_dumper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::MacAppStoreDumper do

--- a/spec/mac_app_store_installer_spec.rb
+++ b/spec/mac_app_store_installer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::MacAppStoreInstaller do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "simplecov"
 SimpleCov.start do
   add_filter "/test/"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,11 +31,6 @@ end
 
 require "unindent"
 
-class String
-  # Compatibility with Homebrew's String extensions.
-  alias_method :undent, :unindent
-end
-
 # Stub out the inclusion of Homebrew's code.
 LIBS_TO_SKIP = ["formula", "tap", "utils/formatter"].freeze
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,11 @@ end
 
 require "unindent"
 
+class String
+  # Compatibility with Homebrew's String extensions.
+  alias_method :undent, :unindent
+end
+
 # Stub out the inclusion of Homebrew's code.
 LIBS_TO_SKIP = ["formula", "tap", "utils/formatter"].freeze
 

--- a/spec/stub/extend/ENV.rb
+++ b/spec/stub/extend/ENV.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV.instance_eval do
   def deps
     @deps || []

--- a/spec/stub/formula.rb
+++ b/spec/stub/formula.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pathname"
 
 class Formula

--- a/spec/stub/utils.rb
+++ b/spec/stub/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pathname"
 
 def which(command)

--- a/spec/tap_dumper_spec.rb
+++ b/spec/tap_dumper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::TapDumper do

--- a/spec/tap_installer_spec.rb
+++ b/spec/tap_installer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle::TapInstaller do

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Bundle do


### PR DESCRIPTION
In #289, @MikeMcQuaid suggested that we test the entire project with `--enable-frozen-string-literal`. I gave that a shot and unfortunately couldn't make it work (RSpec has several string-modifying method calls which rely on string mutability in that library).

In Jekyll, we found that freezing strings greatly sped up the execution of the program since the Ruby VM didn't have to continue allocating new strings every time it saw a literal.

In an effort to bring this project into full compliance with frozen string literals, I submit to you the following. It does not include the fixes in #289, but they could be wrapped into 1 PR if that's what you'd prefer.

/cc @MikeMcQuaid 