### PR TITLE
.travis.yml: use Ruby 2.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 os: osx
-env: OSX=10.12
-osx_image: xcode8.1
-rvm: system
+osx_image: xcode9
+rvm: 2.3.3
 cache: bundler
 
 before_install:

--- a/lib/bundle.rb
+++ b/lib/bundle.rb
@@ -1,3 +1,10 @@
+# check ruby version before requiring any modules.
+RUBY_VERSION_SPLIT = RUBY_VERSION.split "."
+RUBY_X = RUBY_VERSION_SPLIT[0].to_i
+RUBY_Y = RUBY_VERSION_SPLIT[1].to_i
+TOO_OLD_RUBY = RUBY_X < 2 || (RUBY_X == 2 && RUBY_Y < 3)
+raise "Homebrew Bundle must be run under Ruby 2.3!" if TOO_OLD_RUBY
+
 require "bundle/bundle"
 require "bundle/dsl"
 require "bundle/brew_services"


### PR DESCRIPTION
This matches the version Homebrew itself is now using.