### PR TITLE
Allow automatically linking formulae.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ cask_args appdir: "/Applications"
 tap "caskroom/cask"
 tap "telemachus/brew", "https://telemachus@bitbucket.org/telemachus/brew.git"
 brew "imagemagick"
-brew "mysql", restart_service: true, conflicts_with: ["homebrew/versions/mysql56"]
+brew "mysql@5.6", restart_service: true, link: true, conflicts_with: ["mysql"]
 brew "emacs", args: ["with-cocoa", "with-gnutls"]
 cask "google-chrome"
 cask "java" unless system "/usr/libexec/java_home --failfast"

--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -78,7 +78,7 @@ rescue RuntimeError, SystemCallError => e
   exit 1
 rescue StandardError => e
   onoe e
-  puts "#{Tty.white}Please report this bug:#{Tty.reset}"
+  puts "#{Tty.bold}Please report this bug:#{Tty.reset}"
   puts "    #{Formatter.url("https://github.com/Homebrew/homebrew-bundle/issues/")}"
   puts e.backtrace
   exit 1

--- a/spec/brew_installer_spec.rb
+++ b/spec/brew_installer_spec.rb
@@ -34,6 +34,30 @@ describe Bundle::BrewInstaller do
     end
   end
 
+  context "link option is true" do
+    before do
+      allow(ARGV).to receive(:verbose?).and_return(false)
+      allow_any_instance_of(Bundle::BrewInstaller).to receive(:install_change_state!).and_return(:success)
+    end
+
+    it "links formula" do
+      expect(Bundle).to receive(:system).with("brew", "link", "--force", "mysql").and_return(true)
+      Bundle::BrewInstaller.install(formula, link: true)
+    end
+  end
+
+  context "link option is false" do
+    before do
+      allow(ARGV).to receive(:verbose?).and_return(false)
+      allow_any_instance_of(Bundle::BrewInstaller).to receive(:install_change_state!).and_return(:success)
+    end
+
+    it "unlinks formula" do
+      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql").and_return(true)
+      Bundle::BrewInstaller.install(formula, link: false)
+    end
+  end
+
   context "conflicts_with option is provided" do
     before do
       expect(Bundle::BrewDumper).to receive(:formula_info).and_return(

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -11,7 +11,7 @@ describe Bundle::Dsl do
       tap 'caskroom/cask'
       tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
       brew 'imagemagick'
-      brew 'mysql', restart_service: true, conflicts_with: ['homebrew/versions/mysql56']
+      brew 'mysql@5.6', restart_service: true, link: true, conflicts_with: ['mysql']
       brew 'emacs', args: ['with-cocoa', 'with-gnutls']
       cask 'google-chrome'
       cask 'java' unless system '/usr/libexec/java_home --failfast'
@@ -23,8 +23,8 @@ describe Bundle::Dsl do
     expect(dsl.entries[1].name).to eql("telemachus/brew")
     expect(dsl.entries[1].options).to eql(clone_target: "https://telemachus@bitbucket.org/telemachus/brew.git")
     expect(dsl.entries[2].name).to eql("imagemagick")
-    expect(dsl.entries[3].name).to eql("mysql")
-    expect(dsl.entries[3].options).to eql(restart_service: true, conflicts_with: ["homebrew/versions/mysql56"])
+    expect(dsl.entries[3].name).to eql("mysql@5.6")
+    expect(dsl.entries[3].options).to eql(restart_service: true, link: true, conflicts_with: ["mysql"])
     expect(dsl.entries[4].name).to eql("emacs")
     expect(dsl.entries[4].options).to eql(args: ["with-cocoa", "with-gnutls"])
     expect(dsl.entries[5].name).to eql("google-chrome")


### PR DESCRIPTION
For versioned formulae e.g. `mysql@5.6` it may be desirable to automatically link formulae after that are installed by Homebrew/bundle if you are only going to have one version of MySQL on a system and you wish it to be in your `PATH` by default.