### PR TITLE
add formulae descriptions (if available) when dumping Brewfile

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -24,12 +24,16 @@ module Bundle
       requested_formula = formulae.select do |f|
         f[:installed_on_request?] || !f[:installed_as_dependency?]
       end
+      longest_brewline = 0
       requested_formula.map do |f|
         brewline = "brew \"#{f[:full_name]}\""
         args = f[:args].map { |arg| "\"#{arg}\"" }.sort.join(", ")
         brewline += ", args: [#{args}]" unless f[:args].empty?
         brewline += ", restart_service: true" if BrewServices.started?(f[:full_name])
-        brewline
+        longest_brewline = [longest_brewline, brewline.length].max
+        [brewline, f[:desc]]
+      end.map do |brewline, desc|
+        desc.to_s.empty? ? brewline : format("%-#{longest_brewline}s # %s", brewline, desc)
       end.join("\n")
     end
 
@@ -117,6 +121,7 @@ module Bundle
         name: f["name"],
         oldname: f["oldname"],
         full_name: f["full_name"],
+        desc: f["desc"],
         aliases: f["aliases"],
         args: args,
         version: version,

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -59,6 +59,7 @@ describe Bundle::BrewDumper do
       expect(subject.formulae).to contain_exactly(
         name: "foo",
         full_name: "homebrew/tap/foo",
+        desc: "",
         oldname: nil,
         aliases: [],
         args: [],
@@ -112,7 +113,7 @@ describe Bundle::BrewDumper do
           {
             "name" => "foo",
             "full_name" => "homebrew/tap/foo",
-            "desc" => "",
+            "desc" => "Foo's description",
             "homepage" => "",
             "oldname" => nil,
             "aliases" => [],
@@ -142,7 +143,7 @@ describe Bundle::BrewDumper do
           {
             "name" => "bar",
             "full_name" => "bar",
-            "desc" => "",
+            "desc" => "Bar's description",
             "homepage" => "",
             "oldname" => nil,
             "aliases" => [],
@@ -151,6 +152,38 @@ describe Bundle::BrewDumper do
             "installed" => [{
               "version" => "2.0",
               "used_options" => ["--with-a", "--with-b"],
+              "built_as_bottle" => nil,
+              "poured_from_bottle" => true,
+              "installed_as_dependency" => true,
+              "installed_on_request" => true,
+              "runtime_dependencies" => [],
+            }],
+            "linked_keg" => nil,
+            "keg_only" => nil,
+            "dependencies" => [],
+            "recommended_dependencies" => [],
+            "optional_dependencies" => [],
+            "build_dependencies" => [],
+            "conflicts_with" => [],
+            "caveats" => nil,
+            "requirements" => [],
+            "options" => [],
+            "bottle" => {},
+            "pinned" => true,
+            "outdated" => true,
+          },
+          {
+            "name" => "nodesc",
+            "full_name" => "nodesc",
+            "desc" => "",
+            "homepage" => "",
+            "oldname" => nil,
+            "aliases" => [],
+            "versions" => { "stable" => "2.1", "bottle" => false },
+            "revision" => 0,
+            "installed" => [{
+              "version" => "2.0",
+              "used_options" => [],
               "built_as_bottle" => nil,
               "poured_from_bottle" => true,
               "installed_as_dependency" => true,
@@ -181,6 +214,7 @@ describe Bundle::BrewDumper do
         {
           name: "foo",
           full_name: "homebrew/tap/foo",
+          desc: "Foo's description",
           oldname: nil,
           aliases: [],
           args: [],
@@ -196,8 +230,10 @@ describe Bundle::BrewDumper do
           pinned?: false,
           outdated?: false,
         },
+      {
         name: "bar",
         full_name: "bar",
+        desc: "Bar's description",
         oldname: nil,
         aliases: [],
         args: ["with-a", "with-b"],
@@ -212,11 +248,31 @@ describe Bundle::BrewDumper do
         conflicts_with: [],
         pinned?: true,
         outdated?: true,
+      },
+      {
+        name: "nodesc",
+        full_name: "nodesc",
+        desc: "",
+        oldname: nil,
+        aliases: [],
+        args: [],
+        version: "2.0",
+        installed_as_dependency?: true,
+        installed_on_request?: true,
+        dependencies: [],
+        recommended_dependencies: [],
+        optional_dependencies: [],
+        build_dependencies: [],
+        requirements: [],
+        conflicts_with: [],
+        pinned?: true,
+        outdated?: true,
+      }
       )
     end
 
     it "dumps as foo and bar with args" do
-      expect(subject.dump).to eql("brew \"bar\", args: [\"with-a\", \"with-b\"]\nbrew \"homebrew/tap/foo\"")
+      expect(subject.dump).to eql("brew \"bar\", args: [\"with-a\", \"with-b\"] # Bar's description\nbrew \"nodesc\"\nbrew \"homebrew/tap/foo\"                # Foo's description")
     end
 
     it "formula_info returns the formula" do


### PR DESCRIPTION
This patch makes it so that when one runs `brew bundle dump` it will
append the formulae's descriptions as comments to the generated
Brewfile.

Comments are padded to align with the longest "brew line."

For example:

    ...
    tap "homebrew/bundle"
    brew "libyaml"                       # YAML Parser
    brew "consul", restart_service: true # Tool for service discovery, monitoring and configuration
    brew "eot-utils"
    brew "pick"                          # Utility to choose one option from a set of choices
    ...