### PR TITLE
brew & tap dumper: pass explicit sort to handle APFS

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -30,7 +30,7 @@ module Bundle
         brewline += ", args: [#{args}]" unless f[:args].empty?
         brewline += ", restart_service: true" if BrewServices.started?(f[:full_name])
         brewline
-      end.join("\n")
+      end.sort.join("\n")
     end
 
     def cask_requirements

--- a/lib/bundle/tap_dumper.rb
+++ b/lib/bundle/tap_dumper.rb
@@ -21,7 +21,7 @@ module Bundle
       taps.map do |tap|
         remote = ", \"#{tap["remote"]}\"" if tap["custom_remote"] && tap["remote"]
         "tap \"#{tap["name"]}\"#{remote}"
-      end.join("\n")
+      end.sort.join("\n")
     end
 
     def tap_names

--- a/spec/tap_dumper_spec.rb
+++ b/spec/tap_dumper_spec.rb
@@ -18,19 +18,19 @@ describe Bundle::TapDumper do
     end
   end
 
-  context "there are tap `homebrew/foo` and `bitbucket/bar`" do
+  context "there are tap `bitbucket/bar` and `homebrew/foo`" do
     before do
       Bundle::TapDumper.reset!
       allow(Tap).to receive(:map).and_return [
         {
-          "name" => "homebrew/foo",
-          "remote" => "https://github.com/Homebrew/homebrew-foo",
-          "custom_remote" => false,
-        },
-        {
           "name" => "bitbucket/bar",
           "remote" => "https://bitbucket.org/bitbucket/bar.git",
           "custom_remote" => true,
+        },
+        {
+          "name" => "homebrew/foo",
+          "remote" => "https://github.com/Homebrew/homebrew-foo",
+          "custom_remote" => false,
         },
       ]
     end
@@ -41,7 +41,7 @@ describe Bundle::TapDumper do
     end
 
     it "dumps output" do
-      expect(subject.dump).to eql("tap \"homebrew/foo\"\ntap \"bitbucket/bar\", \"https://bitbucket.org/bitbucket/bar.git\"")
+      expect(subject.dump).to eql("tap \"bitbucket/bar\", \"https://bitbucket.org/bitbucket/bar.git\"\ntap \"homebrew/foo\"")
     end
   end
 end


### PR DESCRIPTION
https://github.com/Homebrew/brew/issues/3311  

`mas` and Cask dumpers seem to sort correctly.

Edit: Apologies, mistaken PR.