### PR TITLE
Do not uninstall dependencies for custom formulae

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -79,7 +79,7 @@ module Bundle
 
         formulae_names.each do |name|
           next if @checked_formulae_names.include?(name)
-          formula = current_formulae.find { |f| f[:name] == name }
+          formula = current_formulae.find { |f| f[:full_name] == name }
           next unless formula
           f_deps = formula[:dependencies]
           next unless f_deps

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -18,6 +18,7 @@ describe Bundle::Commands::Cleanup do
         brew 'homebrew/tap/g'
         brew 'homebrew/tap/h'
         brew 'homebrew/tap/i2'
+        brew 'homebrew/tap/hasdependency'
       EOS
     end
 
@@ -35,6 +36,8 @@ describe Bundle::Commands::Cleanup do
         { name: "f", full_name: "homebrew/tap/f" },
         { name: "h", full_name: "other/tap/h" },
         { name: "i", full_name: "homebrew/tap/i", aliases: ["i2"] },
+        { name: "hasdependency", full_name: "homebrew/tap/hasdependency", dependencies: ["isdependency"] },
+        { name: "isdependency", full_name: "homebrew/tap/isdependency" },
       ]
       expect(Bundle::Commands::Cleanup.formulae_to_uninstall).to eql %w[
         c


### PR DESCRIPTION
When searching `current_formulae` for a formula, it was not found if the
formula was from a custom tap and had a `full_name` different from its
`name`. This caused all of its dependencies to be missed.

Fixes #301