### PR TITLE
Only clean up build dependencies for bottles

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -106,6 +106,7 @@ module Bundle
         version = keg["version"]
         installed_as_dependency = keg["installed_as_dependency"] || false
         installed_on_request = keg["installed_on_request"] || false
+        poured_from_bottle = keg["poured_from_bottle"] || false
         runtime_dependencies = if deps = keg["runtime_dependencies"]
           deps.map { |dep| dep["full_name"].split("/").last }.compact
         end
@@ -115,6 +116,7 @@ module Bundle
         installed_as_dependency = false
         installed_on_request = false
         runtime_dependencies = nil
+        poured_from_bottle = false
       end
 
       {
@@ -135,6 +137,7 @@ module Bundle
         pinned?: (f["pinned"] || false),
         outdated?: (f["outdated"] || false),
         link?: link,
+        poured_from_bottle?: poured_from_bottle,
       }
     end
 

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -82,6 +82,10 @@ module Bundle
           formula = current_formulae.find { |f| f[:full_name] == name }
           next unless formula
           f_deps = formula[:dependencies]
+          unless formula[:poured_from_bottle?]
+            f_deps += formula[:build_dependencies]
+            f_deps.uniq!
+          end
           next unless f_deps
           next if f_deps.empty?
           @checked_formulae_names << name

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -74,6 +74,7 @@ describe Bundle::BrewDumper do
         pinned?: false,
         outdated?: false,
         link?: nil,
+        poured_from_bottle?: false,
       )
     end
   end
@@ -153,7 +154,7 @@ describe Bundle::BrewDumper do
               "version" => "2.0",
               "used_options" => ["--with-a", "--with-b"],
               "built_as_bottle" => nil,
-              "poured_from_bottle" => true,
+              "poured_from_bottle" => false,
               "installed_as_dependency" => true,
               "installed_on_request" => true,
               "runtime_dependencies" => [],
@@ -197,6 +198,7 @@ describe Bundle::BrewDumper do
           pinned?: false,
           outdated?: false,
           link?: nil,
+          poured_from_bottle?: true,
         },
         name: "bar",
         full_name: "bar",
@@ -215,6 +217,7 @@ describe Bundle::BrewDumper do
         pinned?: true,
         outdated?: true,
         link?: false,
+        poured_from_bottle?: false,
       )
     end
 

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -19,6 +19,8 @@ describe Bundle::Commands::Cleanup do
         brew 'homebrew/tap/h'
         brew 'homebrew/tap/i2'
         brew 'homebrew/tap/hasdependency'
+        brew 'hasbuilddependency1'
+        brew 'hasbuilddependency2'
       EOS
     end
 
@@ -38,11 +40,16 @@ describe Bundle::Commands::Cleanup do
         { name: "i", full_name: "homebrew/tap/i", aliases: ["i2"] },
         { name: "hasdependency", full_name: "homebrew/tap/hasdependency", dependencies: ["isdependency"] },
         { name: "isdependency", full_name: "homebrew/tap/isdependency" },
-      ]
+        { name: "hasbuilddependency1", full_name: "hasbuilddependency1", poured_from_bottle?: true, build_dependencies: ["builddependency1"] },
+        { name: "hasbuilddependency2", full_name: "hasbuilddependency2", poured_from_bottle?: false, build_dependencies: ["builddependency2"] },
+        { name: "builddependency1", full_name: "builddependency1" },
+        { name: "builddependency2", full_name: "builddependency2" },
+      ].map { |f| { dependencies: [], build_dependencies: [] }.merge(f) }
       expect(Bundle::Commands::Cleanup.formulae_to_uninstall).to eql %w[
         c
         homebrew/tap/e
         other/tap/h
+        builddependency1
       ]
     end
 


### PR DESCRIPTION
If a formula has not been poured from a bottle, its build dependency will be used for upgrades and should be kept around.

There's an argument for getting rid of build dependencies during a cleanup (they're not needed for runtime), but it was unexpected for me. Upgrading a formula built from source is very likely, so it seems like a good idea to keep build dependencies around.