### PR TITLE
Update deprecated EOS usage

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -154,7 +154,7 @@ module Bundle
       conflicts_with.each do |conflict|
         next unless BrewInstaller.formula_installed?(conflict)
         if ARGV.verbose?
-          puts <<~EOS.unindent
+          puts <<~EOS
             Unlinking #{conflict} formula.
             It is currently installed and conflicts with #{@name}.
           EOS

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -7,7 +7,7 @@ describe Bundle::Commands::Cleanup do
     before do
       Bundle::Commands::Cleanup.reset!
       allow(ARGV).to receive(:value).and_return(nil)
-      allow_any_instance_of(Pathname).to receive(:read).and_return <<-EOS
+      allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
         tap 'x'
         tap 'y'
         cask '123'

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -7,7 +7,7 @@ describe Bundle::Dsl do
     allow_any_instance_of(Bundle::Dsl).to receive(:system).with("/usr/libexec/java_home --failfast").and_return(false)
     allow(ARGV).to receive(:verbose?).and_return(true)
     # Keep in sync with the README
-    dsl = Bundle::Dsl.new <<-EOS
+    dsl = Bundle::Dsl.new <<~EOS
       # frozen_string_literal: true
       cask_args appdir: '/Applications'
       tap 'caskroom/cask'


### PR DESCRIPTION
Use `<<~EOS` everywhere instead. Fixes #316.