### PR TITLE
Add upgrade/outdated support to mas and cask.

### DIFF
--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -31,9 +31,9 @@ module Bundle
       def any_casks_to_install?
         @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
         requested_casks = @dsl.entries.select { |e| e.type == :cask }.map(&:name)
-        return false if requested_casks.empty?
-        current_casks = Bundle::CaskDumper.casks
-        (requested_casks - current_casks).any?
+        requested_casks.any? do |c|
+          !Bundle::CaskInstaller.cask_installed_and_up_to_date?(c)
+        end
       end
 
       def any_formulae_to_install?
@@ -54,10 +54,10 @@ module Bundle
 
       def any_apps_to_install?
         @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
-        requested_apps = @dsl.entries.select { |e| e.type == :mac_app_store }.map { |e| e.options[:id] }
-        return false if requested_apps.empty?
-        current_apps = Bundle::MacAppStoreDumper.app_ids
-        (requested_apps - current_apps).any?
+        requested_app_ids = @dsl.entries.select { |e| e.type == :mac_app_store }.map { |e| e.options[:id] }
+        requested_app_ids.any? do |id|
+          !Bundle::MacAppStoreInstaller.app_id_installed_and_up_to_date?(id)
+        end
       end
 
       def any_formulae_to_start?

--- a/spec/mac_app_store_dumper_spec.rb
+++ b/spec/mac_app_store_dumper_spec.rb
@@ -40,12 +40,12 @@ describe Bundle::MacAppStoreDumper do
     before do
       Bundle::MacAppStoreDumper.reset!
       allow(Bundle).to receive(:mas_installed?).and_return(true)
-      allow(Bundle::MacAppStoreDumper).to receive(:`).and_return("foo 123\nbar 456\nbaz 789")
+      allow(Bundle::MacAppStoreDumper).to receive(:`).and_return("123 foo\n456 bar\n789 baz")
     end
     subject { Bundle::MacAppStoreDumper }
 
     it "returns list %w[foo bar baz]" do
-      expect(subject.apps).to eql([["foo", "123"], ["bar", "456"], ["baz", "789"]])
+      expect(subject.apps).to eql([["123", "foo"], ["456", "bar"], ["789", "baz"]])
     end
   end
 end

--- a/spec/mac_app_store_installer_spec.rb
+++ b/spec/mac_app_store_installer_spec.rb
@@ -13,6 +13,15 @@ describe Bundle::MacAppStoreInstaller do
     end
   end
 
+  context ".app_id_installed_and_up_to_date?" do
+    it "returns result" do
+      allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return(["123", "456"])
+      allow(Bundle::MacAppStoreInstaller).to receive(:outdated_app_ids).and_return(["456"])
+      expect(Bundle::MacAppStoreInstaller.app_id_installed_and_up_to_date?(123)).to eql(true)
+      expect(Bundle::MacAppStoreInstaller.app_id_installed_and_up_to_date?(456)).to eql(false)
+    end
+  end
+
   context "when mas is not installed" do
     before do
       allow(Bundle).to receive(:mas_installed?).and_return(false)
@@ -23,12 +32,28 @@ describe Bundle::MacAppStoreInstaller do
       expect(Bundle).to receive(:system).with("brew", "install", "mas").and_return(true)
       expect { do_install }.to raise_error(RuntimeError)
     end
+
+    context ".outdated_app_ids" do
+      it "does not shell out" do
+        expect(Bundle::MacAppStoreInstaller).not_to receive(:`)
+        Bundle::MacAppStoreInstaller.reset!
+        Bundle::MacAppStoreInstaller.outdated_app_ids
+      end
+    end
   end
 
   context "when mas is installed" do
     before do
       allow(Bundle).to receive(:mas_installed?).and_return(true)
       allow(ARGV).to receive(:verbose?).and_return(false)
+    end
+
+    context ".outdated_app_ids" do
+      it "returns app ids" do
+        expect(Bundle::MacAppStoreInstaller).to receive(:`).and_return("foo 123")
+        Bundle::MacAppStoreInstaller.reset!
+        Bundle::MacAppStoreInstaller.outdated_app_ids
+      end
     end
 
     context "when mas is not signed in" do
@@ -47,16 +72,29 @@ describe Bundle::MacAppStoreInstaller do
       before do
         allow(Bundle).to receive(:mas_signedin?).and_return(true)
         allow(ARGV).to receive(:verbose?).and_return(false)
+        allow(Bundle::MacAppStoreInstaller).to receive(:outdated_app_ids).and_return([])
       end
 
       context "when app is installed" do
         before do
-          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return([123])
+          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return(["123"])
         end
 
         it "skips" do
           expect(Bundle).not_to receive(:system)
           expect(do_install).to eql(:skipped)
+        end
+      end
+
+      context "when app is outdated" do
+        before do
+          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return(["123"])
+          allow(Bundle::MacAppStoreInstaller).to receive(:outdated_app_ids).and_return(["123"])
+        end
+
+        it "upgrades" do
+          expect(Bundle).to receive(:system).with("mas", "upgrade", "123").and_return(true)
+          expect(do_install).to eql(:success)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ require "bundle"
 require "bundler"
 
 RSpec.configure do |config|
+  config.filter_run_when_matching :focus
   config.around(:each) do |example|
     Bundler.with_clean_env { example.run }
   end


### PR DESCRIPTION
These tools now both have `upgrade` and `outdated` commands so let's use
them everywhere that makes sense.

Additionally, because it helped by debug, automatically filter out
`rspec` tests with `:focus`.

Fixes #309.