### PR TITLE
Adds --describe option to brew bundle dump

### DIFF
--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -4,7 +4,7 @@
 #:    `brew bundle` [-v|--verbose] [--no-upgrade] [--file=<path>|--global]:
 #:    Install or upgrade all dependencies in a Brewfile.
 #:
-#:    `brew bundle dump` [--force] [--file=<path>|--global]
+#:    `brew bundle dump` [--force] [--file=<path>|--global] [--describe]
 #:    Write all installed casks/formulae/taps into a Brewfile.
 #:
 #:    `brew bundle cleanup` [--force] [--file=<path>|--global]
@@ -28,6 +28,10 @@
 #:    `--file=-` to output to console).
 #:
 #:    If `--global` is passed, set Brewfile path to `$HOME/.Brewfile`.
+#:
+#:    If `--describe` is passed, output a comment above each line containing the
+#:    description of the dependency at the time of the dump for dependencies
+#:    that have a description.
 #:
 #:    If `-h` or `--help` are passed, print this help message and exit.
 if !defined?(HOMEBREW_VERSION) || !HOMEBREW_VERSION ||

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -25,7 +25,9 @@ module Bundle
         f[:installed_on_request?] || !f[:installed_as_dependency?]
       end
       requested_formula.map do |f|
-        brewline = "brew \"#{f[:full_name]}\""
+        brewline = ""
+        brewline += "# #{f[:desc]}\n" if ARGV.include?("--describe")
+        brewline += "brew \"#{f[:full_name]}\""
         args = f[:args].map { |arg| "\"#{arg}\"" }.sort.join(", ")
         brewline += ", args: [#{args}]" unless f[:args].empty?
         brewline += ", restart_service: true" if BrewServices.started?(f[:full_name])
@@ -121,6 +123,7 @@ module Bundle
 
       {
         name: f["name"],
+        desc: f["desc"],
         oldname: f["oldname"],
         full_name: f["full_name"],
         aliases: f["aliases"],

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -26,7 +26,7 @@ module Bundle
       end
       requested_formula.map do |f|
         brewline = ""
-        brewline += "# #{f[:desc]}\n" if ARGV.include?("--describe")
+        brewline += "# #{f[:desc]}\n" if ARGV.include?("--describe") && f[:desc]
         brewline += "brew \"#{f[:full_name]}\""
         args = f[:args].map { |arg| "\"#{arg}\"" }.sort.join(", ")
         brewline += ", args: [#{args}]" unless f[:args].empty?

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -59,6 +59,7 @@ describe Bundle::BrewDumper do
       expect(subject.formulae).to contain_exactly(
         name: "foo",
         full_name: "homebrew/tap/foo",
+        desc: "",
         oldname: nil,
         aliases: [],
         args: [],
@@ -183,6 +184,7 @@ describe Bundle::BrewDumper do
         {
           name: "foo",
           full_name: "homebrew/tap/foo",
+          desc: "",
           oldname: nil,
           aliases: [],
           args: [],
@@ -202,6 +204,7 @@ describe Bundle::BrewDumper do
         },
         name: "bar",
         full_name: "bar",
+        desc: "",
         oldname: nil,
         aliases: [],
         args: ["with-a", "with-b"],

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -482,7 +482,7 @@ describe Bundle::BrewDumper do
 
   context "when --describe is not set" do
     before do
-      ARGV.delete("--describe") if ARGV.include?("--describe")
+      stub_const("ARGV", [])
       Bundle::BrewDumper.reset!
       allow(Bundle::BrewDumper).to receive(:formulae_info).and_return [
         {
@@ -518,6 +518,7 @@ describe Bundle::BrewDumper do
         },
       ]
     end
+
     it "does not output a comment with dependency description" do
       expect(Bundle::BrewDumper.dump).not_to include("#")
     end
@@ -525,7 +526,7 @@ describe Bundle::BrewDumper do
 
   context "when --describe is set" do
     before do
-      ARGV << "--describe" unless ARGV.include?("--describe")
+      stub_const("ARGV", ["--describe"])
       Bundle::BrewDumper.reset!
       allow(Bundle::BrewDumper).to receive(:formulae_info).and_return [
         {
@@ -561,9 +562,7 @@ describe Bundle::BrewDumper do
         },
       ]
     end
-    after do
-      ARGV.delete("--describe") if ARGV.include?("--describe")
-    end
+
     it "outputs a comment on the line before a dependency with a description" do
       expect(Bundle::BrewDumper.dump).to include("# z")
     end

--- a/spec/brew_dumper_spec.rb
+++ b/spec/brew_dumper_spec.rb
@@ -477,6 +477,99 @@ describe Bundle::BrewDumper do
     end
   end
 
+  context "when --describe is not set" do
+    before do
+      ARGV.delete("--describe") if ARGV.include?("--describe")
+      Bundle::BrewDumper.reset!
+      allow(Bundle::BrewDumper).to receive(:formulae_info).and_return [
+        {
+          name: "a",
+          full_name: "a",
+          desc: "z",
+          aliases: [],
+          args: [],
+          version: "1.0",
+          dependencies: ["b", "d", "c"],
+          recommended_dependencies: [],
+          optional_dependencies: [],
+          build_dependencies: [],
+          requirements: [],
+          conflicts_with: [],
+          pinned?: false,
+          outdated?: false,
+        },
+        {
+          name: "b",
+          full_name: "b",
+          aliases: [],
+          args: [],
+          version: "1.0",
+          dependencies: [],
+          recommended_dependencies: [],
+          optional_dependencies: [],
+          build_dependencies: [],
+          requirements: [],
+          conflicts_with: [],
+          pinned?: false,
+          outdated?: false,
+        },
+      ]
+    end
+    it "does not output a comment with dependency description" do
+      expect(Bundle::BrewDumper.dump).not_to include("#")
+    end
+  end
+
+  context "when --describe is set" do
+    before do
+      ARGV << "--describe" unless ARGV.include?("--describe")
+      Bundle::BrewDumper.reset!
+      allow(Bundle::BrewDumper).to receive(:formulae_info).and_return [
+        {
+          name: "a",
+          full_name: "a",
+          desc: "z",
+          aliases: [],
+          args: [],
+          version: "1.0",
+          dependencies: ["b", "d", "c"],
+          recommended_dependencies: [],
+          optional_dependencies: [],
+          build_dependencies: [],
+          requirements: [],
+          conflicts_with: [],
+          pinned?: false,
+          outdated?: false,
+        },
+        {
+          name: "b",
+          full_name: "b",
+          aliases: [],
+          args: [],
+          version: "1.0",
+          dependencies: [],
+          recommended_dependencies: [],
+          optional_dependencies: [],
+          build_dependencies: [],
+          requirements: [],
+          conflicts_with: [],
+          pinned?: false,
+          outdated?: false,
+        },
+      ]
+    end
+    after do
+      ARGV.delete("--describe") if ARGV.include?("--describe")
+    end
+    it "outputs a comment on the line before a dependency with a description" do
+      expect(Bundle::BrewDumper.dump).to include("# z")
+    end
+    it "does not output a comment if a formula lacks a description" do
+      lines_with_comments = Bundle::BrewDumper.dump.split.select { |line| line.include?("#") }
+      expect(lines_with_comments.size).to eq(1)
+    end
+  end
+
   context "when order of args for a formula is different in different environment" do
     it "dumps args in same order" do
       formula_info = [


### PR DESCRIPTION
This option outputs above each dependency a comment containing a description when the dependency has a description associated with it.

Right now, only Homebrew formulae have descriptions. Casks, taps, and mas dependencies do not have descriptions available.

Fixes #322