### PR TITLE
Sets minimum rspec version to 3.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,44 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    codecov (0.1.10)
+      json
+      simplecov
+      url
+    diff-lcs (1.3)
+    docile (1.1.5)
+    json (1.8.3)
+    rake (10.4.2)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    simplecov (0.11.1)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    unindent (1.0)
+    url (0.3.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  codecov
+  rake
+  rspec
+  simplecov
+  unindent
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
I encountered an error saying that `filter_run_when_matching` was missing on the RSpec config object when running specs for #324. It turns out that this method was added in rspec 3.5.0 and I had an older version of RSpec installed and that older version met the requirement in the Gemfile of "any version!"