### PR TITLE
mac_app_store_installer: fix outdated handling.

### DIFF
--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -50,11 +50,11 @@ module Bundle
     end
 
     def app_id_installed?(id)
-      installed_app_ids.include? id.to_s
+      installed_app_ids.include? id
     end
 
     def app_id_upgradable?(id)
-      outdated_app_ids.include? id.to_s
+      outdated_app_ids.include? id
     end
 
     def installed_app_ids
@@ -64,7 +64,7 @@ module Bundle
     def outdated_app_ids
       @outdated_app_ids ||= if Bundle.mas_installed?
         `mas outdated 2>/dev/null`.split("\n").map do |app|
-          app.split(" ", 2).first
+          app.split(" ", 2).first.to_i
         end
       else
         []

--- a/spec/mac_app_store_installer_spec.rb
+++ b/spec/mac_app_store_installer_spec.rb
@@ -15,8 +15,8 @@ describe Bundle::MacAppStoreInstaller do
 
   context ".app_id_installed_and_up_to_date?" do
     it "returns result" do
-      allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return(["123", "456"])
-      allow(Bundle::MacAppStoreInstaller).to receive(:outdated_app_ids).and_return(["456"])
+      allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return([123, 456])
+      allow(Bundle::MacAppStoreInstaller).to receive(:outdated_app_ids).and_return([456])
       expect(Bundle::MacAppStoreInstaller.app_id_installed_and_up_to_date?(123)).to eql(true)
       expect(Bundle::MacAppStoreInstaller.app_id_installed_and_up_to_date?(456)).to eql(false)
     end
@@ -77,7 +77,7 @@ describe Bundle::MacAppStoreInstaller do
 
       context "when app is installed" do
         before do
-          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return(["123"])
+          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return([123])
         end
 
         it "skips" do
@@ -88,8 +88,8 @@ describe Bundle::MacAppStoreInstaller do
 
       context "when app is outdated" do
         before do
-          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return(["123"])
-          allow(Bundle::MacAppStoreInstaller).to receive(:outdated_app_ids).and_return(["123"])
+          allow(Bundle::MacAppStoreInstaller).to receive(:installed_app_ids).and_return([123])
+          allow(Bundle::MacAppStoreInstaller).to receive(:outdated_app_ids).and_return([123])
         end
 
         it "upgrades" do


### PR DESCRIPTION
This was previously always showing `mas` apps as outdated incorrectly.