### PR TITLE
cleanup: run brew cleanup.

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -35,6 +35,11 @@ module Bundle
           end
 
           Kernel.system "brew", "untap", *taps if taps.any?
+
+          cleanup = system_output_no_stderr("brew", "cleanup")
+          unless cleanup.empty?
+            puts cleanup
+          end
         else
           require "utils/formatter"
 
@@ -51,6 +56,12 @@ module Bundle
           if taps.any?
             puts "Would untap:"
             puts Formatter.columns taps
+          end
+
+          cleanup = system_output_no_stderr("brew", "cleanup", "--dry-run")
+          unless cleanup.empty?
+            puts "Would 'brew cleanup':"
+            puts cleanup
           end
         end
       end
@@ -109,6 +120,10 @@ module Bundle
         kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
         current_taps = Bundle::TapDumper.tap_names
         current_taps - kept_taps - IGNORED_TAPS
+      end
+
+      def system_output_no_stderr(cmd, *args)
+        IO.popen([cmd, *args], err: :close).read
       end
     end
   end

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -150,4 +150,34 @@ describe Bundle::Commands::Cleanup do
       expect { Bundle::Commands::Cleanup.run }.to output(/Would uninstall formulae:.*Would untap:/m).to_stdout
     end
   end
+
+  context "there is brew cleanup output" do
+    before do
+      Bundle::Commands::Cleanup.reset!
+      allow(Bundle::Commands::Cleanup).to receive(:casks_to_uninstall).and_return([])
+      allow(Bundle::Commands::Cleanup).to receive(:formulae_to_uninstall).and_return([])
+      allow(Bundle::Commands::Cleanup).to receive(:taps_to_untap).and_return([])
+      expect(Bundle::Commands::Cleanup).to receive(:system_output_no_stderr).and_return(["cleaned"])
+    end
+
+    context "with --force" do
+      before do
+        allow(ARGV).to receive(:force?).and_return(true)
+      end
+
+      it "prints output" do
+        expect { Bundle::Commands::Cleanup.run }.to output(/cleaned/).to_stdout
+      end
+    end
+
+    context "without --force" do
+      before do
+        allow(ARGV).to receive(:force?).and_return(false)
+      end
+
+      it "prints output" do
+        expect { Bundle::Commands::Cleanup.run }.to output(/cleaned/).to_stdout
+      end
+    end
+  end
 end


### PR DESCRIPTION
It makes sense to also run `brew cleanup` on `brew bundle cleanup` so it can be a one stop shop for cleaning up your Homebrew.