### PR TITLE
 Ensure `MacAppStoreDumper` only dumps valid app details

### DIFF
--- a/lib/bundle/mac_app_store_dumper.rb
+++ b/lib/bundle/mac_app_store_dumper.rb
@@ -13,13 +13,16 @@ module Bundle
     def apps
       @apps ||= if Bundle.mas_installed?
         `mas list 2>/dev/null`.split("\n").map do |app|
-          id, name_with_version = app.split(" ", 2)
-          name = name_with_version.gsub(/ \([\d\.]+\)$/, "")
-          [id, name]
+          app_details = app.match(/\A(?<id>\d+)\s+(?<name>[\w\s]*)\s+\((?<version>[\d\.]*)\)\Z/)
+
+          # Only add the application details should we have a valid match.
+          if app_details
+            [app_details[:id], app_details[:name]]
+          end
         end
       else
         []
-      end
+      end.compact
     end
 
     def app_ids

--- a/spec/mac_app_store_dumper_spec.rb
+++ b/spec/mac_app_store_dumper_spec.rb
@@ -48,4 +48,55 @@ describe Bundle::MacAppStoreDumper do
       expect(subject.apps).to eql([["123", "foo"], ["456", "bar"], ["789", "baz"]])
     end
   end
+
+  context "with invalid app details" do
+    let(:invalid_mas_output) do
+      <<~HEREDOC
+        497799835 Xcode (9.2)
+        425424353 The Unarchiver (4.0.0)
+        08981434 iMovie (10.1.8)
+         Install macOS High Sierra (13105)
+        409201541 Pages (7.1)
+        123456789 123AppNameWithNumbers (1.0)
+        409203825 Numbers (5.1)
+      HEREDOC
+    end
+
+    let(:expected_app_details_array) do
+      [
+        ["497799835", "Xcode"],
+        ["425424353", "The Unarchiver"],
+        ["08981434", "iMovie"],
+        ["409201541", "Pages"],
+        ["123456789", "123AppNameWithNumbers"],
+        ["409203825", "Numbers"],
+      ]
+    end
+
+    let(:expected_mas_dumped_output) do
+      <<~HEREDOC
+        mas "123AppNameWithNumbers", id: 123456789
+        mas "iMovie", id: 08981434
+        mas "Numbers", id: 409203825
+        mas "Pages", id: 409201541
+        mas "The Unarchiver", id: 425424353
+        mas "Xcode", id: 497799835
+      HEREDOC
+    end
+
+    before do
+      Bundle::MacAppStoreDumper.reset!
+      allow(Bundle).to receive(:mas_installed?).and_return(true)
+      allow(Bundle::MacAppStoreDumper).to receive(:`).and_return(invalid_mas_output)
+    end
+    subject { Bundle::MacAppStoreDumper }
+
+    it "returns only valid apps" do
+      expect(subject.apps).to eql(expected_app_details_array)
+    end
+
+    it "dumps excluding invalid apps" do
+      expect(subject.dump).to eq(expected_mas_dumped_output.strip)
+    end
+  end
 end

--- a/spec/mac_app_store_dumper_spec.rb
+++ b/spec/mac_app_store_dumper_spec.rb
@@ -40,7 +40,7 @@ describe Bundle::MacAppStoreDumper do
     before do
       Bundle::MacAppStoreDumper.reset!
       allow(Bundle).to receive(:mas_installed?).and_return(true)
-      allow(Bundle::MacAppStoreDumper).to receive(:`).and_return("123 foo\n456 bar\n789 baz")
+      allow(Bundle::MacAppStoreDumper).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)")
     end
     subject { Bundle::MacAppStoreDumper }
 


### PR DESCRIPTION
During a routine `brew bundle` I came across the following exception
(which manages to halt all commands):

```
Error: Invalid Brewfile: uninitialized constant #<Class:#<Bundle::Dsl:0x00000101a5d898>>::Install
```

Searching around the issue tracker, I noticed a couple of [existing](https://github.com/Homebrew/homebrew-bundle/issues/308)
[issues](https://github.com/Homebrew/homebrew-bundle/issues/321) where this was occurring when the `mas list` output included
an application from the app store that wasn't formatted as `brew bundle`
expected. Sure enough, this was also my issue.

```
497799835 Xcode (9.2)
409183694 Keynote (8.1)
408981434 iMovie (10.1.8)
 Install macOS High Sierra (13105)
409201541 Pages (7.1)
682658836 GarageBand (10.3.1)
409203825 Numbers (5.1)
```

Taking a look at the `MacAppStoreDumper` class, the way this output was
previously generated was by splitting on the first bit of whitespace it
encounters and assigned the two parts to the app ID and app name
respectively. In the case of the High Sierra upgrade app, there wasn't
an ID for it and the first bit of whitespace came after "Install". This
explains why the generated line would be:

```
mas "macOS High Sierra", id: Install
```

It was splitting on the first bit of whitespace it encountered and
didn't restrict what that first value could possibly be for it to be a
valid application.

In order to firm up the app details extraction method a little more,
I've swapped the extraction to use a regular expression with named
captures.  By doing this, it introduces a (very) loose validation of
what the `mas list` output should be providing. If the output format
changes, it won't break `brew bundle` subcommands, it will just fail to
add them to the generated output.

Additionally, there is a new `compact` call added to the `@apps` value
to ensure that the `dump` method doesn't need to concern itself with
iterating on empty values and potentially throwing `nilClass` exceptions
for the `downcase` name calls.

Fixes #308
Fixes #321