### PR TITLE
cmd/brew-bundle: tweak check help output.

### DIFF
--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -11,9 +11,7 @@
 #:    Uninstall all dependencies not listed in a Brewfile.
 #:
 #:    `brew bundle check` [`--no-upgrade`] [`--file`=<path>|`--global`] [`--verbose`]
-#:    Check if all dependencies are installed in a Brewfile. Missing dependencies
-#:    are listed in verbose mode. `check` will exit on the first category
-#:    missing a dependency unless in verbose mode.
+#:    Check if all dependencies are installed in a Brewfile. Missing dependencies are listed in verbose mode. `check` will exit on the first category missing a dependency unless in verbose mode.
 #:
 #:    `brew bundle exec` <command>
 #:    Run an external command in an isolated build environment.


### PR DESCRIPTION
Display all on one line and allow terminals to do the wrapping. This is consistent with other lines (and commands).