### PR TITLE
Add docs for zap flag

### DIFF
--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -27,6 +27,8 @@
 #:
 #:    If `--force` is passed, uninstall dependencies or overwrite an existing Brewfile.
 #:
+#:    If `--zap` is passed, casks will be removed using the `zap` command instead of `uninstall`.
+#:
 #:    If `--file=<path>` is passed, the Brewfile path is set accordingly
 #:    Use `--file=-` to output to console.
 #:


### PR DESCRIPTION
I was uncertain what difference the `--zap` flag would have when running `brew bundle cleanup` and had to take a look at the source to find out. Adding a brief explanation helps clarify the difference.