### PR TITLE
upgrade the json gem from 1.8.3 to 1.8.6 to get ruby >=2.4 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
+  gem "json", "~> 1.8.6"
   gem "codecov"
   gem "rake"
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       url
     diff-lcs (1.3)
     docile (1.1.5)
-    json (1.8.3)
+    json (1.8.6)
     rake (10.4.2)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -35,10 +35,11 @@ PLATFORMS
 
 DEPENDENCIES
   codecov
+  json (~> 1.8.6)
   rake
   rspec
   simplecov
   unindent
 
 BUNDLED WITH
-   1.16.1
+   1.16.5


### PR DESCRIPTION
Version 1.8.3 of the json gem isn't compatable with ruby 2.4 and later.
see: https://github.com/flori/json/issues/303

Specifically require the json gem to ensure we fetch a compatible
version.