### PR TITLE
Corrects two Rubocop warnings new since project-wide config changed

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -191,7 +191,7 @@ module Bundle
           - f[:build_dependencies] \
         ).uniq
         topo[f[:full_name]] = deps.map do |dep|
-          ff = @formulae.find { |formula| formula[:name] == dep || formula[:full_name] == dep }
+          ff = @formulae.find { |formula| [formula[:name], formula[:full_name]].include?(dep) }
           next unless ff
           ff[:full_name]
         end.compact

--- a/lib/bundle/lister.rb
+++ b/lib/bundle/lister.rb
@@ -10,7 +10,6 @@ module Bundle
       end
     end
 
-    private_class_method
     def self.show?(type)
       return true if ARGV.include?("--all")
       return true if ARGV.include?("--casks") && type == :cask


### PR DESCRIPTION
Fixes warnings emitted in tests for #372 

1. https://travis-ci.org/Homebrew/homebrew-bundle/builds/435899798#L1708
2. https://travis-ci.org/Homebrew/homebrew-bundle/builds/435899798#L1711