### PR TITLE
mas: better handle signin failure

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -28,7 +28,7 @@ module Bundle
   end
 
   def mas_signedin?
-    Bundle.system "mas", "account"
+    Kernel.system "mas account &>/dev/null"
   end
 
   def cask_installed?

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "utils/formatter"
+
 module Bundle
   module Commands
     # TODO: refactor into multiple modules
@@ -42,8 +44,6 @@ module Bundle
             puts cleanup
           end
         else
-          require "utils/formatter"
-
           if casks.any?
             puts "Would uninstall casks:"
             puts Formatter.columns casks

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -2,6 +2,7 @@
 
 require "extend/ENV"
 require "formula"
+require "formulary"
 require "utils"
 
 module Bundle

--- a/spec/mac_app_store_installer_spec.rb
+++ b/spec/mac_app_store_installer_spec.rb
@@ -62,7 +62,7 @@ describe Bundle::MacAppStoreInstaller do
       end
 
       it "tries to sign in with mas" do
-        expect(Bundle).to receive(:system).with("mas", "account").and_return(false).twice
+        expect(Kernel).to receive(:system).with("mas account &>/dev/null").and_return(false).twice
         expect(Bundle).to receive(:system).with("mas", "signin", "--dialog", "").and_return(true)
         expect { do_install }.to raise_error(RuntimeError)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ PROJECT_ROOT ||= File.expand_path("..", __dir__)
 STUB_PATH ||= File.expand_path(File.join(__FILE__, "..", "stub"))
 $LOAD_PATH.unshift(STUB_PATH)
 
+require "global"
 require "bundle"
 
 Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").each { |f| require f }
@@ -43,42 +44,3 @@ RSpec.configure do |config|
 end
 
 require "unindent"
-
-# Stub out the inclusion of Homebrew's code.
-LIBS_TO_SKIP = ["formula", "tap", "utils/formatter"].freeze
-
-module Kernel
-  alias old_require require
-  def require(path)
-    old_require(path) unless LIBS_TO_SKIP.include?(path)
-  end
-end
-
-HOMEBREW_PREFIX = Pathname.new("/usr/local")
-HOMEBREW_REPOSITORY = Pathname.new("/usr/local/Homebrew")
-
-module Formatter
-  module_function
-
-  def columns(*); end
-
-  def success(*args)
-    args
-  end
-
-  def error(*args)
-    args
-  end
-end
-
-class Formula
-  def self.installed
-    []
-  end
-end
-
-class Tap
-  def self.map
-    []
-  end
-end

--- a/spec/stub/formula.rb
+++ b/spec/stub/formula.rb
@@ -27,10 +27,8 @@ class Formula
   def installed?
     true
   end
-end
 
-class Formulary
-  def self.factory(name)
-    Formula.new(name)
+  def self.installed
+    []
   end
 end

--- a/spec/stub/formulary.rb
+++ b/spec/stub/formulary.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Formulary
+  def self.factory(name)
+    Formula.new(name)
+  end
+end

--- a/spec/stub/global.rb
+++ b/spec/stub/global.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+HOMEBREW_PREFIX = Pathname.new("/usr/local")
+HOMEBREW_REPOSITORY = Pathname.new("/usr/local/Homebrew")

--- a/spec/stub/os.rb
+++ b/spec/stub/os.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module MacOS
+  module_function
+
+  def version
+    :high_sierra
+  end
+end

--- a/spec/stub/tap.rb
+++ b/spec/stub/tap.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Tap
+  def self.map
+    []
+  end
+end

--- a/spec/stub/utils/formatter.rb
+++ b/spec/stub/utils/formatter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Formatter
+  module_function
+
+  def columns(*); end
+
+  def success(*args)
+    args
+  end
+
+  def error(*args)
+    args
+  end
+end


### PR DESCRIPTION
- see if app can be skipped because it doesn’t need upgrade
- don’t try to sign in on Mojave (it doesn’t work)
- only fail if app actually needs installed/upgraded
- don’t print `mas account` output; just use exit code
- add `MacOS` stub and cleanup existing stub code

Fixes #370