### PR TITLE
Extract `Brewfile` locator logic to its own module

### DIFF
--- a/lib/bundle.rb
+++ b/lib/bundle.rb
@@ -7,6 +7,7 @@ RUBY_Y = RUBY_VERSION_SPLIT[1].to_i
 TOO_OLD_RUBY = RUBY_X < 2 || (RUBY_X == 2 && RUBY_Y < 3)
 raise "Homebrew Bundle must be run under Ruby 2.3!" if TOO_OLD_RUBY
 
+require "bundle/brewfile"
 require "bundle/bundle"
 require "bundle/dsl"
 require "bundle/checker"

--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Bundle
+  module Brewfile
+    module_function
+
+    def path
+      if ARGV.include?("--global")
+        Pathname.new("#{ENV["HOME"]}/.Brewfile")
+      else
+        filename = ARGV.value("file")
+        filename = "/dev/stdin" if filename == "-"
+        filename ||= "Brewfile"
+        Pathname.new(filename).expand_path(Dir.pwd)
+      end
+    end
+
+    def read
+      Brewfile.path.read
+    rescue Errno::ENOENT
+      raise "No Brewfile found"
+    end
+  end
+end

--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -43,18 +43,4 @@ module Bundle
       !which("brew-services.rb").nil?
     end
   end
-
-  def brewfile
-    if ARGV.include?("--global")
-      file = Pathname.new("#{ENV["HOME"]}/.Brewfile")
-    else
-      filename = ARGV.value("file")
-      filename = "/dev/stdin" if filename == "-"
-      filename ||= "Brewfile"
-      file = Pathname.new(filename).expand_path(Dir.pwd)
-    end
-    file.read
-  rescue Errno::ENOENT
-    raise "No Brewfile found"
-  end
 end

--- a/lib/bundle/checker.rb
+++ b/lib/bundle/checker.rb
@@ -57,7 +57,7 @@ module Bundle
     }.freeze
 
     def check(exit_on_first_error)
-      @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
+      @dsl ||= Bundle::Dsl.new(Brewfile.read)
 
       check_method_names = CHECKS.keys
 

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -68,14 +68,14 @@ module Bundle
       end
 
       def casks_to_uninstall
-        @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
+        @dsl ||= Bundle::Dsl.new(Brewfile.read)
         kept_casks = @dsl.entries.select { |e| e.type == :cask }.map(&:name)
         current_casks = Bundle::CaskDumper.casks
         current_casks - kept_casks
       end
 
       def formulae_to_uninstall
-        @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
+        @dsl ||= Bundle::Dsl.new(Brewfile.read)
         kept_formulae = @dsl.entries.select { |e| e.type == :brew }.map(&:name)
         kept_formulae.map! do |f|
           Bundle::BrewDumper.formula_aliases[f] ||
@@ -117,7 +117,7 @@ module Bundle
       IGNORED_TAPS = %w[homebrew/core homebrew/bundle].freeze
 
       def taps_to_untap
-        @dsl ||= Bundle::Dsl.new(Bundle.brewfile)
+        @dsl ||= Bundle::Dsl.new(Brewfile.read)
         kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
         current_taps = Bundle::TapDumper.tap_names
         current_taps - kept_taps - IGNORED_TAPS

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -33,7 +33,7 @@ module Bundle
         raise "Error: #{command} was not found on your PATH!" if command_path.nil?
         command_path = command_path.dirname.to_s
 
-        brewfile = Bundle::Dsl.new(Bundle.brewfile)
+        brewfile = Bundle::Dsl.new(Brewfile.read)
         ENV.deps = brewfile.entries.map do |entry|
           next unless entry.type == :brew
           f = Formulary.factory(entry.name)

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -6,7 +6,7 @@ module Bundle
       module_function
 
       def run
-        parsed_entries = Bundle::Dsl.new(Bundle.brewfile).entries
+        parsed_entries = Bundle::Dsl.new(Brewfile.read).entries
         Bundle::Installer.install(parsed_entries) || exit(1)
       end
     end

--- a/lib/bundle/commands/list.rb
+++ b/lib/bundle/commands/list.rb
@@ -6,7 +6,7 @@ module Bundle
       module_function
 
       def run
-        parsed_entries = Bundle::Dsl.new(Bundle.brewfile).entries
+        parsed_entries = Bundle::Dsl.new(Brewfile.read).entries
         Bundle::Lister.list(parsed_entries) || exit(1)
       end
     end

--- a/lib/bundle/dumper.rb
+++ b/lib/bundle/dumper.rb
@@ -8,15 +8,8 @@ module Bundle
     module_function
 
     def dump_brewfile
-      if ARGV.include?("--global")
-        file = Pathname.new("#{ENV["HOME"]}/.Brewfile")
-      else
-        filename = ARGV.value("file")
-        filename = "/dev/stdout" if filename == "-"
-        filename ||= "Brewfile"
-        file = Pathname.new(filename).expand_path(Dir.pwd)
-      end
-      raise "#{file} already exists" if should_not_write_file?(file, ARGV.force?)
+      brewfile_path = Brewfile.path
+      raise "#{brewfile_path} already exists" if should_not_write_file?(brewfile_path, ARGV.force?)
       content = []
       content << TapDumper.dump
       casks_required_by_formulae = BrewDumper.cask_requirements
@@ -26,7 +19,7 @@ module Bundle
       content << cask_after_formula
       content << MacAppStoreDumper.dump
       content = content.reject(&:empty?).join("\n") + "\n"
-      write_file file, content
+      write_file brewfile_path, content
     end
 
     def should_not_write_file?(file, overwrite = false)

--- a/spec/brewfile_spec.rb
+++ b/spec/brewfile_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Bundle::Brewfile do
+  describe "path" do
+    context "when `--file` is passed" do
+      before do
+        allow(ARGV).to receive(:include?).with("--global").and_return(false)
+        allow(ARGV).to receive(:value).with("file").and_return(file_value)
+      end
+
+      context "with a relative path" do
+        let(:file_value) { "path/to/Brewfile" }
+
+        it "returns the expected path" do
+          expect(Bundle::Brewfile.path).to eq(Pathname.new("path/to/Brewfile").expand_path(Dir.pwd))
+        end
+      end
+
+      context "with an absolute path" do
+        let(:file_value) { "/tmp/random_file" }
+
+        it "returns the expected path" do
+          expect(Bundle::Brewfile.path).to eq(Pathname.new("/tmp/random_file"))
+        end
+      end
+
+      context "with `-`" do
+        let(:file_value) { "-" }
+
+        it "returns the expected path" do
+          expect(Bundle::Brewfile.path).to eq(Pathname.new("/dev/stdin"))
+        end
+      end
+    end
+
+    context "when `--global` is passed" do
+      before do
+        allow(ARGV).to receive(:include?).with("--global").and_return(true)
+      end
+
+      it "returns the expected path" do
+        expect(Bundle::Brewfile.path).to eq(Pathname.new("#{ENV["HOME"]}/.Brewfile"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Bundle.brewfile` and `Dumper.dump_brewfile` contained duplicate logic
for locating the `Brewfile`. This logic now resides in the `Brewfile`
module.

This is the first step in addressing https://github.com/Homebrew/homebrew-bundle/issues/368