### PR TITLE
brew_dumper: better handle unreadable formulae.

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -84,6 +84,9 @@ module Bundle
         require "formula"
         formula_inspector formula_hash(Formula[name])
       end
+    rescue NameError, ArgumentError, ScriptError,
+           FormulaUnavailableError => e
+      opoo "'#{name}' formula is unreadable: #{e}"
     end
 
     def formulae_info
@@ -91,6 +94,9 @@ module Bundle
       Formula.installed.map do |f|
         formula_inspector formula_hash(f)
       end.compact
+    rescue NameError, ArgumentError, ScriptError,
+           FormulaUnavailableError => e
+      opoo "Unreadable formula: #{e}"
     end
 
     def formula_hash(formula)

--- a/spec/bundle/brew_dumper_spec.rb
+++ b/spec/bundle/brew_dumper_spec.rb
@@ -657,6 +657,27 @@ describe Bundle::BrewDumper do
     end
   end
 
+  context "#formula_info" do
+    let(:f) { OpenStruct.new }
+
+    it "handles formula syntax errors" do
+      allow(Formula).to receive(:[]).and_raise(NoMethodError)
+      expect(described_class).to receive(:opoo).once
+      described_class.instance_variable_set("@formula_info_name", nil)
+      described_class.formula_info("foo")
+    end
+  end
+
+  context "#formulae_info" do
+    let(:f) { OpenStruct.new }
+
+    it "handles formula syntax errors" do
+      allow(Formula).to receive(:installed).and_raise(NoMethodError)
+      expect(described_class).to receive(:opoo).once
+      described_class.formulae_info
+    end
+  end
+
   context "#formula_hash" do
     let(:f) { OpenStruct.new }
 


### PR DESCRIPTION
Improve the error messages so it's more obvious what's happening.

Fixes https://github.com/Homebrew/brew/issues/5315