### PR TITLE
brewfile: use /dev/stdout for dump command.

### DIFF
--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -9,7 +9,13 @@ module Bundle
         Pathname.new("#{ENV["HOME"]}/.Brewfile")
       else
         filename = ARGV.value("file")
-        filename = "/dev/stdin" if filename == "-"
+        if filename == "-"
+          filename = if ARGV.include?("dump")
+            "/dev/stdout"
+          else
+            "/dev/stdin"
+          end
+        end
         filename ||= "Brewfile"
         Pathname.new(filename).expand_path(Dir.pwd)
       end

--- a/spec/bundle/brewfile_spec.rb
+++ b/spec/bundle/brewfile_spec.rb
@@ -29,7 +29,13 @@ describe Bundle::Brewfile do
       context "with `-`" do
         let(:file_value) { "-" }
 
-        it "returns the expected path" do
+        it "returns stdout for dump command" do
+          allow(ARGV).to receive(:include?).with("dump").and_return(true)
+          expect(described_class.path).to eq(Pathname.new("/dev/stdout"))
+        end
+
+        it "returns stdin for non-dump commands" do
+          allow(ARGV).to receive(:include?).with("dump").and_return(false)
           expect(described_class.path).to eq(Pathname.new("/dev/stdin"))
         end
       end


### PR DESCRIPTION
Doesn't make sense to attempt to dump to stdin.

Fixes #405.