### PR TITLE
brew_dumper: provide circular dependency resolution help.

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -215,6 +215,7 @@ module Bundle
         Formulae dependency graph sorting failed (likely due to a circular dependency):
         #{cycle_first}: #{topo[cycle_first]}
         #{cycle_last}: #{topo[cycle_last]}
+        Please run `brew reinstall #{cycle_first} #{cycle_last}` and try again.
       EOS
     end
   end


### PR DESCRIPTION
This should resolve any issues where there the circular dependency has been already fixed.

References https://github.com/Homebrew/brew/issues/5520