### PR TITLE
Add code coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
 source "https://rubygems.org"
 
 group :test do
+  gem "coveralls"
   gem "guard-rspec"
   gem "guard-rubocop"
   gem "rake"
   gem "rspec"
   gem "simplecov"
+  gem "simplecov-cobertura"
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,3 +15,13 @@ jobs:
         bundle install
         bundle exec rake
       displayName: Tests
+      env:
+        COVERALLS_REPO_TOKEN: $(coveralls.homebrewBundleApiToken)
+
+    - task: PublishCodeCoverageResults@1
+      displayName: Publish code coverage
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: $(Build.SourcesDirectory)/coverage/coverage.xml
+        reportDirectory: $(Build.SourcesDirectory)/coverage
+        failIfCoverageEmpty: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,9 +16,27 @@ require "bundle"
 
 Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").each { |f| require f }
 
-SimpleCov.formatters = [
-  SimpleCov::Formatter::HTMLFormatter,
-]
+formatters = [SimpleCov::Formatter::HTMLFormatter]
+
+# Coveralls in Azure Pipelines
+if ENV["COVERALLS_REPO_TOKEN"] && ENV["TF_BUILD"]
+  require "coveralls"
+
+  formatters << Coveralls::SimpleCov::Formatter
+
+  ENV["CI"] = "1"
+  ENV["CI_NAME"] = "azure-pipelines"
+  ENV["CI_BUILD_NUMBER"] = ENV["BUILD_BUILDID"]
+  ENV["CI_BUILD_URL"] = "#{ENV["SYSTEM_TEAMFOUNDATIONSERVERURI"]}#{ENV["SYSTEM_TEAMPROJECT"]}/_build/results?buildId=#{ENV["BUILD_BUILDID"]}"
+  ENV["CI_BRANCH"] = ENV["BUILD_SOURCEBRANCH"]
+  ENV["CI_PULL_REQUEST"] = ENV["SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"]
+
+  require "simplecov-cobertura"
+  formatters << SimpleCov::Formatter::CoberturaFormatter
+end
+
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
+
 require "bundler"
 require "rspec/support/object_formatter"
 


### PR DESCRIPTION
This will upload code coverage to both Coveralls and Azure Pipelines.

I know we require 100% coverage but this is a bit easier than rerunning tests locally to figure out what you've missed when it drops.