### PR TITLE
Adding `--no-restart` flag to `dump` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ brew bundle dump
 
 The `--force` option will allow an existing `Brewfile` to be overwritten as well.
 The `--describe` option will output a description comment above each line.
+The `--no-restart` option will prevent `restart_service` from being added to ``brew`` lines with running services.
 
 ### Cleanup
 

--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -12,12 +12,13 @@
 #:       -v, --verbose                  print the output from commands as they are run.
 #:       --no-upgrade                   don't run `brew upgrade` on outdated dependencies. Note they may still be upgraded by `brew install` if needed.
 #:
-#:  `brew bundle dump` [`--force`] [`--describe`] [`--file=`<path>|`--global`]
+#:  `brew bundle dump` [`--force`] [`--describe`] [`--no-restart`] [`--file=`<path>|`--global`]
 #:
 #:  Write all installed casks/formulae/taps into a Brewfile.
 #:
 #:       --force                        overwrite an existing `Brewfile`.
 #:       --describe                     output a description comment above each line. This comment will not be output if the dependency does not have a description.
+#:       --no-restart                   do not add `restart_service` to formula lines.
 #:
 #:  `brew bundle cleanup` [`--force`] [`--zap`] [`--file=`<path>|`--global`]
 #:

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -32,7 +32,9 @@ module Bundle
         brewline += "brew \"#{f[:full_name]}\""
         args = f[:args].map { |arg| "\"#{arg}\"" }.sort.join(", ")
         brewline += ", args: [#{args}]" unless f[:args].empty?
-        brewline += ", restart_service: true" if BrewServices.started?(f[:full_name])
+        if !ARGV.include?("--no-restart") && BrewServices.started?(f[:full_name])
+          brewline += ", restart_service: true"
+        end
         brewline += ", link: #{f[:link?]}" unless f[:link?].nil?
         brewline
       end.join("\n")


### PR DESCRIPTION
I like to use `brew bundle` to record what home-brew packages I have installed on a cron job, just for workstation automation purposes. Whenever I have a service started (`postgresql` comes up a lot), the output of my cron job that dumps my brewfile alternates between containing `restart_service: true` for those formulae and not containing it, which results in a lot of noisy changes to my brewfile.

I thought it might be nice to have a `--no-restart` flag for the dump command to never include the `restart_service` part of the dump.

I'm not sure if my use case is very common, but this feature would be very helpful for me. Thanks!