### PR TITLE
Allow `Brewfile` location to be specified in ENV

### DIFF
--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -5,15 +5,15 @@ module Bundle
     module_function
 
     def path(dash_writes_to_stdout: false)
-      env_bundle_file = ENV.fetch("HOMEBREW_BUNDLE_FILE", "")
+      env_bundle_file = ENV["HOMEBREW_BUNDLE_FILE"]
 
       filename =
           if ARGV.include?("--global")
-            raise "'HOMEBREW_BUNDLE_FILE' can not be specified with '--global'" unless env_bundle_file.empty?
+            raise "'HOMEBREW_BUNDLE_FILE' can not be specified with '--global'" if env_bundle_file.present?
             "#{ENV["HOME"]}/.Brewfile"
           elsif ARGV.include?("--file")
             handle_file_value(ARGV.value("file"), dash_writes_to_stdout)
-          elsif !env_bundle_file.empty?
+          elsif env_bundle_file.present?
             env_bundle_file
           else
             "Brewfile"

--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -5,26 +5,37 @@ module Bundle
     module_function
 
     def path(dash_writes_to_stdout: false)
-      if ARGV.include?("--global")
-        Pathname.new("#{ENV["HOME"]}/.Brewfile")
-      else
-        filename = ARGV.value("file")
-        if filename == "-"
-          filename = if dash_writes_to_stdout
-            "/dev/stdout"
+      env_bundle_file = ENV.fetch("HOMEBREW_BUNDLE_FILE", "")
+
+      filename =
+          if ARGV.include?("--global")
+            raise "'HOMEBREW_BUNDLE_FILE' can not be specified with '--global'" unless env_bundle_file.empty?
+            "#{ENV["HOME"]}/.Brewfile"
+          elsif ARGV.include?("--file")
+            handle_file_value(ARGV.value("file"), dash_writes_to_stdout)
+          elsif !env_bundle_file.empty?
+            env_bundle_file
           else
-            "/dev/stdin"
+            "Brewfile"
           end
-        end
-        filename ||= "Brewfile"
-        Pathname.new(filename).expand_path(Dir.pwd)
-      end
+
+      Pathname.new(filename).expand_path(Dir.pwd)
     end
 
     def read
       Brewfile.path.read
     rescue Errno::ENOENT
       raise "No Brewfile found"
+    end
+
+    def handle_file_value(filename, dash_writes_to_stdout)
+      if filename != "-"
+        filename
+      elsif dash_writes_to_stdout
+        "/dev/stdout"
+      else
+        "/dev/stdin"
+      end
     end
   end
 end

--- a/spec/bundle/brewfile_spec.rb
+++ b/spec/bundle/brewfile_spec.rb
@@ -4,49 +4,113 @@ require "spec_helper"
 
 describe Bundle::Brewfile do
   describe "path" do
+    let(:env_bundle_file_value) { "" }
+    let(:has_file) { false }
+    let(:file_value) { "" }
+    let(:has_global) { false }
+
+    before do
+      allow(ARGV).to receive(:include?).with("--file").and_return(has_file)
+      allow(ARGV).to receive(:value).with("file").and_return(file_value)
+      allow(ARGV).to receive(:include?).with("--global").and_return(has_global)
+
+      allow(ENV).to receive(:fetch).with("HOMEBREW_BUNDLE_FILE", "").and_return(env_bundle_file_value)
+    end
+
     context "when `--file` is passed" do
-      before do
-        allow(ARGV).to receive(:include?).with("--global").and_return(false)
-        allow(ARGV).to receive(:value).with("file").and_return(file_value)
-      end
+      let(:has_file) { true }
 
       context "with a relative path" do
         let(:file_value) { "path/to/Brewfile" }
+        let(:expected_pathname) { Pathname.new(file_value).expand_path(Dir.pwd) }
 
         it "returns the expected path" do
-          expect(described_class.path).to eq(Pathname.new("path/to/Brewfile").expand_path(Dir.pwd))
+          expect(described_class.path).to eq(expected_pathname)
+        end
+
+        context "and HOMEBREW_BUNDLE_FILE is set" do
+          let(:env_bundle_file_value) { "/path/to/Brewfile" }
+
+          it "returns the value specified by `--file` path" do
+            expect(described_class.path).to eq(expected_pathname)
+          end
         end
       end
 
       context "with an absolute path" do
         let(:file_value) { "/tmp/random_file" }
+        let(:expected_pathname) { Pathname.new(file_value) }
 
         it "returns the expected path" do
-          expect(described_class.path).to eq(Pathname.new("/tmp/random_file"))
+          expect(described_class.path).to eq(expected_pathname)
+        end
+
+        context "and HOMEBREW_BUNDLE_FILE is set" do
+          let(:env_bundle_file_value) { "/path/to/Brewfile" }
+
+          it "returns the value specified by `--file` path" do
+            expect(described_class.path).to eq(expected_pathname)
+          end
         end
       end
 
       context "with `-`" do
         let(:file_value) { "-" }
+        let(:expected_pathname) { Pathname.new("/dev/stdin") }
 
         it "returns stdin by default" do
           allow(ARGV).to receive(:include?).with("dump").and_return(false)
-          expect(described_class.path).to eq(Pathname.new("/dev/stdin"))
+          expect(described_class.path).to eq(expected_pathname)
         end
 
-        it "returns stdout for dash_writes_to_stdout" do
-          expect(described_class.path(dash_writes_to_stdout: true)).to eq(Pathname.new("/dev/stdout"))
+        context "and HOMEBREW_BUNDLE_FILE is set" do
+          let(:env_bundle_file_value) { "/path/to/Brewfile" }
+
+          it "returns the value specified by `--file` path" do
+            expect(described_class.path).to eq(expected_pathname)
+          end
+        end
+
+        context "when `dash_writes_to_stdout` is true" do
+          let(:expected_pathname) { Pathname.new("/dev/stdout") }
+
+          it "returns stdout" do
+            expect(described_class.path(dash_writes_to_stdout: true)).to eq(expected_pathname)
+          end
+        end
+
+        context "when `dash_writes_to_stdout` is true and HOMEBREW_BUNDLE_FILE is set" do
+          let(:expected_pathname) { Pathname.new("/dev/stdout") }
+          let(:env_bundle_file_value) { "/path/to/Brewfile" }
+
+          it "returns the value specified by `--file` path" do
+            expect(described_class.path(dash_writes_to_stdout: true)).to eq(expected_pathname)
+          end
         end
       end
     end
 
     context "when `--global` is passed" do
-      before do
-        allow(ARGV).to receive(:include?).with("--global").and_return(true)
-      end
+      let(:has_global) { true }
 
       it "returns the expected path" do
         expect(described_class.path).to eq(Pathname.new("#{ENV["HOME"]}/.Brewfile"))
+      end
+    end
+
+    context "and HOMEBREW_BUNDLE_FILE has a value" do
+      let(:env_bundle_file_value) { "/path/to/Brewfile" }
+
+      it "returns the expected path" do
+        expect(described_class.path).to eq(Pathname.new(env_bundle_file_value))
+      end
+
+      context "that is `` (empty)" do
+        let(:env_bundle_file_value) { "" }
+
+        it "defaults to `${PWD}/Brewfile`" do
+          expect(described_class.path).to eq(Pathname.new("Brewfile").expand_path(Dir.pwd))
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ PROJECT_ROOT ||= File.expand_path("..", __dir__)
 STUB_PATH ||= File.expand_path(File.join(__FILE__, "..", "stub"))
 $LOAD_PATH.unshift(STUB_PATH)
 
+require "object"
 require "global"
 require "bundle"
 

--- a/spec/stub/object.rb
+++ b/spec/stub/object.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# monkeypatch Object so it behaves as if ActiveSupport were present
+class Object
+  def blank?
+    respond_to?(:empty?) ? empty? : !self
+  end
+
+  def present?
+    !blank?
+  end
+end
+


### PR DESCRIPTION
Adds support for `HOMEBREW_BUNDLE_FILE` as a way to specify the location
of the `Brewfile` to be used by `brew bundle` commands.

Specifying `HOMEBREW_BUNDLE_FILE` when `--global` or `--file` are also
specified results in an error.

Existing behavior wherein `--global` overrides `--file` with no error is
preserved. This could be revisited in the future, the code in
`brewfile.rb` would likely need further refactoring.

* This addresses an issue initially raised in https://github.com/Homebrew/homebrew-bundle/issues/368.