### PR TITLE
brew-bundle: require newer Homebrew version.

### DIFF
--- a/cmd/brew-bundle.rb
+++ b/cmd/brew-bundle.rb
@@ -51,7 +51,7 @@
 #:       --mas                          output Mac App Store dependencies.
 
 if !defined?(HOMEBREW_VERSION) || !HOMEBREW_VERSION ||
-   Version.new(HOMEBREW_VERSION) < Version.new("1.3.0")
+   Version.new(HOMEBREW_VERSION) < Version.new("2.1.0")
   odie "Your Homebrew is outdated. Please run `brew update`."
 end
 


### PR DESCRIPTION
We use ActiveSupport internally now so need at least ~2.0.0 (but let's go for a newer 2.1.0 to be safer).

Fixes #509.