### PR TITLE
lib/bundle/brewfile: fix file parameter handling.

### DIFF
--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -11,7 +11,7 @@ module Bundle
           if ARGV.include?("--global")
             raise "'HOMEBREW_BUNDLE_FILE' can not be specified with '--global'" if env_bundle_file.present?
             "#{ENV["HOME"]}/.Brewfile"
-          elsif ARGV.include?("--file")
+          elsif ARGV.value("file").present?
             handle_file_value(ARGV.value("file"), dash_writes_to_stdout)
           elsif env_bundle_file.present?
             env_bundle_file

--- a/spec/bundle/brewfile_spec.rb
+++ b/spec/bundle/brewfile_spec.rb
@@ -5,13 +5,11 @@ require "spec_helper"
 describe Bundle::Brewfile do
   describe "path" do
     let(:env_bundle_file_value) { nil }
-    let(:has_file) { false }
     let(:file_value) { "" }
     let(:has_global) { false }
 
     before do
-      allow(ARGV).to receive(:include?).with("--file").and_return(has_file)
-      allow(ARGV).to receive(:value).with("file").and_return(file_value)
+      allow(ARGV).to receive(:value).with("file")
       allow(ARGV).to receive(:include?).with("--global").and_return(has_global)
 
       original_method = ENV.method(:[])
@@ -26,7 +24,9 @@ describe Bundle::Brewfile do
     end
 
     context "when `--file` is passed" do
-      let(:has_file) { true }
+      before do
+        allow(ARGV).to receive(:value).with("file").and_return(file_value)
+      end
 
       context "with a relative path" do
         let(:file_value) { "path/to/Brewfile" }


### PR DESCRIPTION
Don't check for `ARGV.include?` as that's not always `true` when `--file` is specified.

Fixes #507
Closes #508