### PR TITLE
cask_dumper: use full and short names.

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -5,21 +5,28 @@ module Bundle
     module_function
 
     def reset!
-      @casks = nil
+      @full_name_casks = nil
+      @short_name_casks = nil
     end
 
-    def casks
-      @casks ||= if Bundle.cask_installed?
-        `brew cask list --full-name 2>/dev/null`.split("\n").map { |cask| cask.chomp " (!)" }
-      else
-        []
-      end
+    def casks(full_names_only: false)
+      return [] unless Bundle.cask_installed?
+
+      @full_name_casks ||= `brew cask list --full-name 2>/dev/null`.split("\n")
+      @short_name_casks ||= `brew cask list 2>/dev/null`.split("\n")
+
+      casks = @full_name_casks
+      casks += @short_name_casks unless full_names_only
+
+      casks.map { |cask| cask.chomp " (!)" }
+            .uniq
     end
 
     def dump(casks_required_by_formulae)
+      full_name_casks = casks(full_names_only: true)
       [
-        (casks & casks_required_by_formulae).map { |cask| "cask \"#{cask}\"" }.join("\n"),
-        (casks - casks_required_by_formulae).map { |cask| "cask \"#{cask}\"" }.join("\n"),
+        (full_name_casks & casks_required_by_formulae).map { |cask| "cask \"#{cask}\"" }.join("\n"),
+        (full_name_casks - casks_required_by_formulae).map { |cask| "cask \"#{cask}\"" }.join("\n"),
       ]
     end
   end


### PR DESCRIPTION
Allow either in a `Brewfile` to avoid confusion such as in #506.