### PR TITLE
cleanup: fix handling of tapped casks.

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -70,7 +70,7 @@ module Bundle
       def casks_to_uninstall
         @dsl ||= Bundle::Dsl.new(Brewfile.read)
         kept_casks = @dsl.entries.select { |e| e.type == :cask }.map(&:name)
-        current_casks = Bundle::CaskDumper.casks
+        current_casks = Bundle::CaskDumper.casks(full_names_only: true)
         current_casks - kept_casks
       end
 


### PR DESCRIPTION
Fixes regression introduced in #514 where these would be marked for removal by `brew cleanup`.

Fixes #519.