### PR TITLE
Fix brew bundle check output for services

### DIFF
--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -10,6 +10,10 @@ module Bundle
         @name = name
         @options = options
       end
+
+      def to_s
+        name
+      end
     end
 
     attr_reader :entries, :cask_arguments

--- a/spec/bundle/commands/check_command_spec.rb
+++ b/spec/bundle/commands/check_command_spec.rb
@@ -6,10 +6,10 @@ describe Bundle::Commands::Check do
   RSpec::Matchers.define_negated_matcher :not_raise_error, :raise_error
 
   def do_check(expected_error = nil, expected_output = //)
-    args = expected_error ? [:raise_error, expected_error] : %i[not_raise_error]
-    expect {
+    args = expected_error ? [:raise_error, expected_error] : [:not_raise_error]
+    expect do
       Bundle::Commands::Check.run
-    }.to output(expected_output).to_stdout.and send(*args)
+    end.to output(expected_output).to_stdout.and send(*args)
   end
 
   before do

--- a/spec/bundle/commands/check_command_spec.rb
+++ b/spec/bundle/commands/check_command_spec.rb
@@ -85,13 +85,13 @@ describe Bundle::Commands::Check do
   end
 
   context "when service is not started" do
-    let(:expected_output) {
+    let(:expected_output) do
       <<~MSG
         brew bundle can't satisfy your Brewfile's dependencies.
         → Service def needs to be started.
         Satisfy missing dependencies with `brew bundle install`.
       MSG
-    }
+    end
 
     before do
       Bundle::Checker.reset!

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -3,6 +3,18 @@
 require "spec_helper"
 
 describe Bundle::Dsl do
+  describe described_class::Entry do
+    subject { described_class.new(:brew, entry_name) }
+
+    let(:entry_name) { :foo }
+
+    describe "#to_s" do
+      it "overrides the default struct implementation" do
+        expect(subject.to_s).to eq entry_name
+      end
+    end
+  end
+
   context "with a DSL example" do
     subject(:dsl) do
       described_class.new <<~EOS

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -4,13 +4,13 @@ require "spec_helper"
 
 describe Bundle::Dsl do
   describe described_class::Entry do
-    subject { described_class.new(:brew, entry_name) }
+    subject(:entry) { described_class.new(:brew, entry_name) }
 
     let(:entry_name) { :foo }
 
     describe "#to_s" do
       it "overrides the default struct implementation" do
-        expect(subject.to_s).to eq entry_name
+        expect(entry.to_s).to eq entry_name
       end
     end
   end

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -3,18 +3,6 @@
 require "spec_helper"
 
 describe Bundle::Dsl do
-  describe described_class::Entry do
-    subject(:entry) { described_class.new(:brew, entry_name) }
-
-    let(:entry_name) { :foo }
-
-    describe "#to_s" do
-      it "overrides the default struct implementation" do
-        expect(entry.to_s).to eq entry_name
-      end
-    end
-  end
-
   context "with a DSL example" do
     subject(:dsl) do
       described_class.new <<~EOS


### PR DESCRIPTION
The current `brew bundle check` output for a brewfile that specifies a service
is the somewhat unhelpful default `to_s` of the `Bundle::Dsl::Entry` struct.

```
brew bundle can't satisfy your Brewfile's dependencies.
→ Service #<Bundle::Dsl::Entry:0x00007fcf5285b7a8> needs to be started.
Satisfy missing dependencies with `brew bundle install`.
```

This PR adds a trivial `to_s` implementation to improve the output:

```
brew bundle can't satisfy your Brewfile's dependencies.
→ Service def needs to be started.
Satisfy missing dependencies with `brew bundle install`.
```

Fixes #534.