### PR TITLE
workflows/tests: hardcode coveralls token.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Run RSpec tests
       run: bundle exec rspec
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_REPO_TOKEN: glKUxWlZ56q0WwJhNh5znGTB8ZlFwfvZW


### PR DESCRIPTION
This is just used to set test coverage and GitHub Actions doesn't have a good 'secrets for forks' story yet.