### PR TITLE
skipper: Specify the type of the formula being skipped on Linux

### DIFF
--- a/lib/bundle/extend/os/linux/skipper.rb
+++ b/lib/bundle/extend/os/linux/skipper.rb
@@ -6,7 +6,7 @@ module Bundle
       def skip?(entry)
         return generic_skip?(entry) unless [:cask, :mas].include?(entry.type)
 
-        puts Formatter.warning "Skipping #{entry.name} (on Linux)"
+        puts Formatter.warning "Skipping #{entry.type} #{entry.name} (on Linux)"
         true
       end
     end


### PR DESCRIPTION
- The output was unclear in the case that you had a Brewfile with a cask
  and then a standard formula (eg Linux formula) of the same name which
  installs fine.

Before:

```
Using aws-vault
Skipping aws-vault (on Linux)
```

After:

```
Using aws-vault
Skipping cask aws-vault (on Linux)
```