### PR TITLE
brew_installer: fix dependency upgrades (again).

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -130,7 +130,8 @@ module Bundle
     end
 
     def self.formula_upgradable?(formula)
-      formula_in_array?(formula, upgradable_formulae)
+      # Check local cache first and then authoratitive Homebrew source.
+      formula_in_array?(formula, upgradable_formulae) && Formula[formula].outdated?
     end
 
     def self.installed_formulae
@@ -232,12 +233,8 @@ module Bundle
 
       puts "Upgrading #{@name} formula. It is installed but not up-to-date." if ARGV.verbose?
       unless Bundle.system("brew", "upgrade", @name)
-        # Formula may have been upgraded by a previous installation.
-        BrewInstaller.reset!
-        unless BrewInstaller.formula_installed_and_up_to_date?(@name)
-          @changed = nil
-          return :failed
-        end
+        @changed = nil
+        return :failed
       end
 
       @changed = true

--- a/spec/bundle/brew_installer_spec.rb
+++ b/spec/bundle/brew_installer_spec.rb
@@ -151,6 +151,7 @@ describe Bundle::BrewInstaller do
       Bundle::BrewDumper.reset!
       described_class.reset!
       allow(described_class).to receive(:outdated_formulae).and_return(%w[bar])
+      allow_any_instance_of(Formula).to receive(:outdated?).and_return(true)
       allow(Bundle::BrewDumper).to receive(:formulae).and_return [
         {
           name:         "foo",
@@ -207,6 +208,7 @@ describe Bundle::BrewInstaller do
       before do
         allow(described_class).to receive(:installed_formulae).and_return([formula])
         allow_any_instance_of(described_class).to receive(:conflicts_with).and_return([])
+        allow_any_instance_of(Formula).to receive(:outdated?).and_return(true)
       end
 
       context "when formula upgradable" do

--- a/spec/stub/formula.rb
+++ b/spec/stub/formula.rb
@@ -31,4 +31,8 @@ class Formula
   def self.installed
     []
   end
+
+  def self.[](name)
+    new(name)
+  end
 end


### PR DESCRIPTION
Check the authoritative source from `Formula#outdated?` rather than relying exclusively on our cache. This also avoids busting the cache or displaying weird messages in verbose mode where it fails but we handle it after the fact.

CC @kbd

Fixes #551