### PR TITLE
README: use GitHub Actions badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bundler for non-Ruby dependencies from Homebrew.
 
-[![Azure Pipelines](https://img.shields.io/vso/build/Homebrew/56a87eb4-3180-495a-9117-5ed6c79da737/5.svg)](https://dev.azure.com/Homebrew/Homebrew/_build/latest?definitionId=5)
+[![GitHub Actions](https://github.com/Homebrew/homebrew-bundle/workflows/GitHub%20Actions%20CI/badge.svg)](https://github.com/Homebrew/homebrew-bundle/actions)
 
 ## Requirements
 


### PR DESCRIPTION
Replaces badge for Azure Pipelines.