### PR TITLE
Use `ruby-version` instead of `version`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        version: '>=2.3'
+        ruby-version: '>=2.3'
       if: matrix.os == 'ubuntu-latest'
 
     - name: Install RubyGems


### PR DESCRIPTION
While merging an automated bundle update, I seen an annoated beta message below the files section that pointed out we should be using `ruby-version` not `version` when using the `actions/setup-ruby@v1` container.

![](https://shares.jacobbednarz.com/vYaSArmeTCACiufhgn9BBtVXrF0Q2L3geF.png)

See https://github.com/Homebrew/homebrew-bundle/pull/568/files for the message.