### PR TITLE
Keep cask formula dependencies in "bundle cleanup"

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -29,5 +29,14 @@ module Bundle
         (full_name_casks - casks_required_by_formulae).map { |cask| "cask \"#{cask}\"" }.join("\n"),
       ]
     end
+
+    def formula_dependencies(cask_list)
+      cask_info_response = `brew cask info #{cask_list.join(" ")} --json=v1`
+      cask_info = JSON.parse(cask_info_response)
+
+      cask_info.flat_map do |cask|
+        cask.dig("depends_on", "formula")
+      end.compact.uniq
+    end
   end
 end

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -44,7 +44,9 @@ describe Bundle::Commands::Cleanup do
         { name: "hasbuilddependency2", full_name: "hasbuilddependency2", poured_from_bottle?: false, build_dependencies: ["builddependency2"] },
         { name: "builddependency1", full_name: "builddependency1" },
         { name: "builddependency2", full_name: "builddependency2" },
+        { name: "caskdependency", full_name: "homebrew/tap/caskdependency" },
       ].map { |f| { dependencies: [], build_dependencies: [] }.merge(f) }
+      allow(Bundle::CaskDumper).to receive(:formula_dependencies).and_return(%w[caskdependency])
       expect(described_class.formulae_to_uninstall).to eql %w[
         c
         homebrew/tap/e


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-bundle/issues/480

When running `brew bundle cleanup`, cask formula dependencies weren't being added to the list of kept formulae.

This change checks that for each kept cask, we add any formula dependencies to the list of kept formulae.

### Steps for testing:
1. `brew cask install qlcolorcode`
2. `brew bundle dump`
3. `brew bundle cleanup`

#### Before applying this PR's changes
When running `brew bundle cleanup` the listed formulae to be uninstalled **will** include `highlight` (a dependency of the `qlcolorcode` cask) and `lua` (a dependency of the `highlight` formula)

#### After applying this PR's changes
When running `brew bundle cleanup` the listed formulae to be uninstalled **won't** include `highlight` (a dependency of the `qlcolorcode` cask) or `lua` (a dependency of the `highlight` formula)
