### PR TITLE
Gemfile.lock: downgrade "bundled with".

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install RubyGems
       run: |
-        gem install bundler
+        gem install bundler -v "~>1"
         bundle install --jobs 4 --retry 3
 
     - name: Run RSpec tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,4 +100,4 @@ DEPENDENCIES
   simplecov-cobertura
 
 BUNDLED WITH
-   2.0.1
+   1.17.2


### PR DESCRIPTION
This will allow use with the version bundled with Ruby 2.6.