### PR TITLE
locker: handle permission errors.

### DIFF
--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -62,8 +62,13 @@ module Bundle
       end
 
       json = JSON.pretty_generate(lock)
-      lockfile.unlink if lockfile.exist?
-      lockfile.write(json)
+      begin
+        lockfile.unlink if lockfile.exist?
+        lockfile.write(json)
+      rescue Errno::EPERM, Errno::EACCES, Errno::ENOTEMPTY => e
+        opoo "Could not write to #{lockfile}!"
+        return false
+      end
 
       true
     end

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -67,9 +67,15 @@ describe Bundle::Locker do
           allow(locker).to receive(:`).with("mas list").and_return("497799835 Xcode (11.2)")
         end
 
-        it do
+        it "returns true" do
           expect(lockfile).to receive(:write)
           expect(locker.lock(entries)).to be true
+        end
+
+        it "returns false on a permission error" do
+          expect(lockfile).to receive(:write).and_raise(Errno::EPERM)
+          expect(locker).to receive(:opoo)
+          expect(locker.lock(entries)).to be false
         end
       end
 
@@ -79,7 +85,7 @@ describe Bundle::Locker do
           allow(OS).to receive(:linux?).and_return(true)
         end
 
-        it do
+        it "returns true" do
           expect(lockfile).to receive(:write)
           expect(locker.lock(entries)).to be true
         end


### PR DESCRIPTION
It may be the `Brewfile` is readable but not writable.