### PR TITLE
Match Brewfile name in lockfile name

### DIFF
--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -9,7 +9,8 @@ module Bundle
     module_function
 
     def lockfile
-      Brewfile.path.dirname/"Brewfile.lock.json"
+      brew_file_path = Brewfile.path
+      brew_file_path.dirname/"#{brew_file_path.basename}.lock.json"
     end
 
     def write_lockfile?

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -10,6 +10,11 @@ describe Bundle::Locker do
       allow(Bundle::Brewfile).to receive(:path).and_return(Pathname("Brewfile"))
       expect(locker.lockfile.class).to be Pathname
     end
+
+    it "correctly matches the Brewfile name in the lockfile name" do
+      allow(Bundle::Brewfile).to receive(:path).and_return(Pathname("Personal.brewfile"))
+      expect(locker.lockfile).to eq Pathname.new("Personal.brewfile.lock.json")
+    end
   end
 
   context ".write_lockfile?" do


### PR DESCRIPTION
Name the lockfile after the name of the Brewfile when the default is overridden
using either `--file` or `HOMEBREW_BUNDLE_FILE`.

Fixes #595.