### PR TITLE
Fix brew bundle check -v

### DIFF
--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -9,11 +9,11 @@ module Bundle
       FAILURE_MESSAGE = "brew bundle can't satisfy your Brewfile's dependencies."
 
       def output_errors?
-        ARGV.include?("--verbose")
+        ARGV.verbose?
       end
 
       def exit_on_first_error?
-        !ARGV.include?("--verbose")
+        !ARGV.verbose?
       end
 
       def run


### PR DESCRIPTION
The option `brew bundle check -v` had no effect and should behave identically to `brew bundle check --verbose`.