### PR TITLE
Move backtick to include only the option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can skip the installation of dependencies by adding space-separated values t
 
 `brew bundle` will output a `Brewfile.lock.json` in the same directory as the `Brewfile` if all dependencies are installed successfully. This contains dependency and system status information which can be useful in debugging `brew bundle` failures and replicating a "last known good build" state.
 
-You can opt-out of this behaviour by setting the `HOMEBREW_BUNDLE_NO_LOCK` environment variable or passing the `--no-lock option`.
+You can opt-out of this behaviour by setting the `HOMEBREW_BUNDLE_NO_LOCK` environment variable or passing the `--no-lock` option.
 
 You may wish to check this file into the same version control system as your `Brewfile` (or ensure your version control system ignores it if you'd prefer to rely on debugging information from a local machine).
 


### PR DESCRIPTION
Fixes a typo in the README.