### PR TITLE
cask_dumper: handle bad JSON.

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -32,6 +32,9 @@ module Bundle
       cask_info.flat_map do |cask|
         cask.dig("depends_on", "formula")
       end.compact.uniq
+    rescue JSON::ParserError => e
+      opoo "Failed to parse `brew cask info --json`: #{e}"
+      []
     end
   end
 end

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -66,6 +66,19 @@ describe Bundle::CaskDumper do
       end
     end
 
+    context "when cask info returns invalid JSON" do
+      before do
+        allow(described_class)
+          .to receive(:`)
+          .with("brew cask info foo --json=v1")
+          .and_return("Error: somethng from cask!")
+      end
+
+      it "returns an empty array" do
+        expect(dumper.formula_dependencies(["foo"])).to eql([])
+      end
+    end
+
     context "when multiple casks have the same dependency" do
       before do
         allow(described_class)

--- a/spec/stub/utils.rb
+++ b/spec/stub/utils.rb
@@ -5,3 +5,5 @@ require "pathname"
 def which(command)
   Pathname.new("/usr/local/bin/#{command}")
 end
+
+def opoo(*); end


### PR DESCRIPTION
Print the error and carry on.