### PR TITLE
Add trailing newline to lock file

### DIFF
--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -72,7 +72,7 @@ module Bundle
       json = JSON.pretty_generate(lock)
       begin
         lockfile.unlink if lockfile.exist?
-        lockfile.write(json)
+        lockfile.write(json.to_s + "\n")
       rescue Errno::EPERM, Errno::EACCES, Errno::ENOTEMPTY => e
         opoo "Could not write to #{lockfile}!"
         return false


### PR DESCRIPTION
Adds a trailing newline to the lock file to make its last line conform to the [POSIX standard for lines](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206):

> 3.206 Line
>
> A sequence of zero or more non- \<newline\> characters plus a terminating \<newline\> character.

I'm not that fluent in rspec so I wasn't sure how to add a test that mocks `Pathname` to actually  check what is written to the lock file in the locker spec. Let me know if I should have a deeper look into that!