### PR TITLE
Skip tapping homebrew/cask when on Linux

### DIFF
--- a/lib/bundle/extend/os/linux/skipper.rb
+++ b/lib/bundle/extend/os/linux/skipper.rb
@@ -3,8 +3,18 @@
 module Bundle
   module Skipper
     class << self
+      def macos_only_entry?(entry)
+        [:cask, :mas].include?(entry.type)
+      end
+
+      def macos_only_tap?(entry)
+        entry.type == :tap && entry.name == "homebrew/cask"
+      end
+
       def skip?(entry, silent: false)
-        return generic_skip?(entry) unless [:cask, :mas].include?(entry.type)
+        unless macos_only_entry?(entry) || macos_only_tap?(entry)
+          return generic_skip?(entry)
+        end
         return true if silent
 
         puts Formatter.warning "Skipping #{entry.type} #{entry.name} (on Linux)"


### PR DESCRIPTION
- Casks are automatically skipped on Linux. When there's a Brewfile used on both macOS and Linux, there's usually Casks in it. This leads to `tap "homebrew/cask"` being present and causes the Cask tap to be installed on Linux too, even though Casks don't work on Linux and `cask` entries in Brewfiles are auto-skipped.
- A recent side effect of this behaviour is that because `brew update` now shows Cask data too, Linux users who cannot make use of Casks see a lot of noise, and may get their hopes up that Casks are available.
- Alternatives to this feature included:
    - Putting up with it.
    - Skipping outputting `brew update` info for Casks if on Linux.
    - Adding `tap "homebrew/cask" if OS.mac?` to my Brewfiles.