### PR TITLE
linux/skipper: Refactor `unless` into `if`

### DIFF
--- a/lib/bundle/extend/os/linux/skipper.rb
+++ b/lib/bundle/extend/os/linux/skipper.rb
@@ -12,13 +12,14 @@ module Bundle
       end
 
       def skip?(entry, silent: false)
-        unless macos_only_entry?(entry) || macos_only_tap?(entry)
-          return generic_skip?(entry)
-        end
-        return true if silent
+        if macos_only_entry?(entry) || macos_only_tap?(entry)
+          return true if silent
 
-        puts Formatter.warning "Skipping #{entry.type} #{entry.name} (on Linux)"
-        true
+          puts Formatter.warning "Skipping #{entry.type} #{entry.name} (on Linux)"
+          true
+        else
+          generic_skip?(entry)
+        end
       end
     end
   end


### PR DESCRIPTION
- This `unless` with multiple conditions is hard to understand. This inverts the conditional to make it an `if`.
- As requested in https://github.com/Homebrew/homebrew-bundle/pull/660#discussion_r391892981 and https://github.com/Homebrew/homebrew-bundle/pull/660#discussion_r392193875.