### PR TITLE
mac_app_store_installer: fix flaky test, remove dead code.

### DIFF
--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -25,8 +25,7 @@ module Bundle
 
       unless Bundle.mas_signedin?
         puts "Not signed in to Mac App Store." if Homebrew.args.verbose?
-        Bundle.system "mas", "signin", "--dialog", "" if MacOS.version < :mojave
-        raise "Unable to install #{name} app. mas not signed in to Mac App Store." unless Bundle.mas_signedin?
+        raise "Unable to install #{name} app. mas not signed in to Mac App Store."
       end
 
       if app_id_installed?(id)

--- a/spec/bundle/mac_app_store_installer_spec.rb
+++ b/spec/bundle/mac_app_store_installer_spec.rb
@@ -55,12 +55,10 @@ describe Bundle::MacAppStoreInstaller do
     end
 
     context "when mas is not signed in" do
-      before do
-      end
-
-      it "tries to sign in with mas" do
-        expect(Kernel).to receive(:system).with("mas account &>/dev/null").and_return(false).twice
-        expect(Bundle).to receive(:system).with("mas", "signin", "--dialog", "").and_return(true)
+      it "outputs an error" do
+        allow(described_class).to receive(:installed_app_ids).and_return([123])
+        allow(described_class).to receive(:outdated_app_ids).and_return([123])
+        expect(Kernel).to receive(:system).with("mas account &>/dev/null").and_return(false)
         expect { do_install }.to raise_error(RuntimeError)
       end
     end


### PR DESCRIPTION
@colindean @jacobbednarz I'm not convinced it's a good ROI filing more flaky failure issues. They take a while to debug, they aren't harming end-users and this is not a particularly flaky test suite in general.

Fixes https://github.com/Homebrew/homebrew-bundle/issues/664