### PR TITLE
Don't lowercase URL when those are specified in Brewfile

### DIFF
--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -89,7 +89,8 @@ module Bundle
     HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.@]+)$}.freeze
 
     def self.sanitize_brew_name(name)
-      name = name.downcase
+      name = name.downcase unless name.match(/\A#{URI.regexp(['http', 'https'])}\z/)
+
       if name =~ HOMEBREW_CORE_FORMULA_REGEX
         Regexp.last_match(1)
       elsif name =~ HOMEBREW_TAP_FORMULA_REGEX

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -18,6 +18,7 @@ describe Bundle::Dsl do
         cask 'firefox', args: { appdir: '~/my-apps/Applications' }
         mas '1Password', id: 443987910
         whalebrew 'whalebrew/wget'
+        brew 'https://raw.githubusercontent.com/Homebrew/homebrew-core/50c928c870001577ce6b7e28edf43e05df699852/Formula/etcd.rb'
       EOS
     end
 
@@ -47,6 +48,7 @@ describe Bundle::Dsl do
       expect(dsl.entries[8].name).to eql("1Password")
       expect(dsl.entries[8].options).to eql(id: 443_987_910)
       expect(dsl.entries[9].name).to eql("whalebrew/wget")
+      expect(dsl.entries[10].name).to eql("https://raw.githubusercontent.com/Homebrew/homebrew-core/50c928c870001577ce6b7e28edf43e05df699852/Formula/etcd.rb")
     end
   end
 
@@ -78,6 +80,7 @@ describe Bundle::Dsl do
     expect(described_class.send(:sanitize_brew_name, "homebrew/homebrew-bar/foo")).to eql("homebrew/bar/foo")
     expect(described_class.send(:sanitize_brew_name, "homebrew/bar/foo")).to eql("homebrew/bar/foo")
     expect(described_class.send(:sanitize_brew_name, "foo")).to eql("foo")
+    expect(described_class.send(:sanitize_brew_name, "https://raw.githubusercontent.com/Homebrew/homebrew-core/50c928c870001577ce6b7e28edf43e05df699852/Formula/etcd.rb")).to eql("https://raw.githubusercontent.com/Homebrew/homebrew-core/50c928c870001577ce6b7e28edf43e05df699852/Formula/etcd.rb")
   end
 
   it ".sanitize_tap_name" do


### PR DESCRIPTION
If a Brewfile defines a specific version of a package and this
package originates form an URL, the name shouldn't be lowercase.

An example of such file could be:

```
brew "https://raw.githubusercontent.com/Homebrew/homebrew-core/50c928c870001577ce6b7e28edf43e05df699852/Formula/etcd.rb"
```

Previous to this case this was falling with this error:

```
curl: (22) The requested URL returned error: 404 Not Found
Error: Failure while executing; `/usr/bin/curl -q --globoff --show-error --user-agent Homebrew/2.2.11\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.15.4\)\ curl/7.64.1 --fail --progress-bar --retry 3 --location --remote-time --continue-at 0 --output /Users/alexandru/Library/Caches/Homebrew/Formula/etcd.rb https://raw.githubusercontent.com/homebrew/homebrew-core/50c928c870001577ce6b7e28edf43e05df699852/formula/etcd.rb` exited with 22. Here's the output:

curl: (22) The requested URL returned error: 404 Not Found
```

The reason of the failure was due to the name been transformed
to lowercase.