### PR TITLE
cmd/bundle: fixes for help and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@
 
 ## Security
 
-Please report security issues to security@brew.sh.
+Please report security issues to our [HackerOne](https://hackerone.com/homebrew/).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bundler for non-Ruby dependencies from Homebrew.
 
 ## Requirements
 
-[Homebrew](https://github.com/Homebrew/brew) (on macOS or [Linux](https://docs.brew.sh/Homebrew-on-Linux)) for installing the dependencies.
+[Homebrew](https://github.com/Homebrew/brew) (on macOS or [Linux](https://docs.brew.sh/Homebrew-on-Linux)) for installing dependencies.
 
 [Homebrew Cask](https://github.com/Homebrew/homebrew-cask) is optional and used for installing Mac applications.
 
@@ -14,7 +14,7 @@ Bundler for non-Ruby dependencies from Homebrew.
 
 ## Installation
 
-`brew bundle` is automatically installed when run.
+`brew bundle` is automatically installed when first run.
 
 ## Usage
 
@@ -49,15 +49,15 @@ Other entries can be run only on (or not on) Linux with `if OS.mac?` or `if OS.l
 
 ### Install
 
-You can then easily install all of the dependencies with:
+You can then easily install all dependencies with:
 
 ```bash
 brew bundle
 ```
 
-If a dependency is already installed and there is an upgrade available it will be upgraded.
+Any previously-installed dependencies which have upgrades available will be upgraded.
 
-`brew bundle` will look for `Brewfile` in the current directory. Use `--file` to specify a path to a different `Brewfile`, or set the `HOMEBREW_BUNDLE_FILE` environment variable, with `--file` taking precedence if both are provided.
+`brew bundle` will look for a `Brewfile` in the current directory. Use `--file` to specify a path to a different `Brewfile`, or set the `HOMEBREW_BUNDLE_FILE` environment variable; `--file` takes precedence if both are provided.
 
 You can skip the installation of dependencies by adding space-separated values to one or more of the following environment variables:
 
@@ -83,11 +83,11 @@ brew bundle dump
 
 The `--force` option will allow an existing `Brewfile` to be overwritten as well.
 The `--describe` option will output a description comment above each line.
-The `--no-restart` option will prevent `restart_service` from being added to ``brew`` lines with running services.
+The `--no-restart` option will prevent `restart_service` from being added to `brew` lines with running services.
 
 ### Cleanup
 
-You can also use `Brewfile` to list the only packages that should be installed, removing any package not present or dependent. This workflow is useful for maintainers or testers who regularly install lots of formulae. To uninstall all Homebrew formulae not listed in `Brewfile`:
+You can also use a `Brewfile` to list the only packages that should be installed, removing any package not present or dependent. This workflow is useful for maintainers or testers who regularly install lots of formulae. To uninstall all Homebrew formulae not listed in the `Brewfile`:
 
 ```bash
 brew bundle cleanup
@@ -103,7 +103,7 @@ You can check there's anything to install/upgrade in the `Brewfile` by running:
 brew bundle check
 ```
 
-This provides a successful exit code if everything is up-to-date so is useful for scripting.
+This provides a successful exit code if everything is up-to-date, making it useful for scripting.
 
 For a list of dependencies that are missing, pass `--verbose`. This will also check _all_ dependencies by not exiting on the first missing dependency category.
 
@@ -121,7 +121,7 @@ Note that the _type_ of the package is **not** included in this output.
 
 ### Exec
 
-Runs an external command within Homebrew's superenv build environment:
+Runs an external command within Homebrew's superenv build environment.
 
 ```bash
 brew bundle exec -- bundle install
@@ -150,7 +150,7 @@ If your software needs specific versions then perhaps you'll want to look at usi
 
 ## Tests
 
-Tests can be run with `bundle install && bundle exec rspec`
+Tests can be run with `bundle install && bundle exec rspec`.
 
 ## Copyright
 

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -11,29 +11,23 @@ module Homebrew
 
         Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store and Whalebrew.
 
-        `brew bundle` [`install`]
-
+        `brew bundle` [`install`]:
         Install or upgrade all dependencies in a `Brewfile`.
 
-        `brew bundle dump`
-
+        `brew bundle dump`:
         Write all installed casks/formulae/images/taps into a `Brewfile`.
 
-        `brew bundle cleanup`
-
+        `brew bundle cleanup`:
         Uninstall all dependencies not listed in a `Brewfile`.
 
-        `brew bundle check`
-
+        `brew bundle check`:
         Check if all dependencies are installed in a `Brewfile`.
 
-        `brew bundle exec` <command>
-
+        `brew bundle exec` <command>:
         Run an external command in an isolated build environment.
 
-        `brew bundle list`
-
-        List all dependencies present in a Brewfile. By default, only Homebrew dependencies are listed.
+        `brew bundle list`:
+        List all dependencies present in a `Brewfile`. By default, only Homebrew dependencies are listed.
       EOS
       flag   "--file=",
              description: "Read the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout."

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -7,7 +7,7 @@ module Homebrew
   def bundle_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `bundle` <subcommand>
+        `bundle` [<subcommand>]
 
         Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store and Whalebrew.
 
@@ -35,19 +35,19 @@ module Homebrew
 
         List all dependencies present in a Brewfile. By default, only Homebrew dependencies are listed.
       EOS
-      flag "--file=",
-           description: "Read the `Brewfile` from this file. Use `--file=-` to pipe to stdin/stdout."
+      flag   "--file=",
+             description: "Read the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout."
       switch "--global",
              description: "Read the `Brewfile` from `~/.Brewfile`."
       switch :verbose,
-             description: "`install` output is printed from commands as they are run. " \
-                          "`check` prints all missing dependencies."
+             description: "`install` prints output from commands as they are run. " \
+                          "`check` lists all missing dependencies."
       switch "--no-upgrade",
              description: "`install` won't run `brew upgrade` on outdated dependencies. " \
                           "Note they may still be upgraded by `brew install` if needed."
       switch :force,
              description: "`dump` overwrites an existing `Brewfile`. " \
-                          "`cleanup` actually perform the cleanup operations."
+                          "`cleanup` actually performs its cleanup operations."
       switch "--no-lock",
              description: "`install` won't output a `Brewfile.lock.json`."
       switch "--all",
@@ -63,7 +63,7 @@ module Homebrew
       switch "--whalebrew",
              description: "`list` Whalebrew dependencies."
       switch "--describe",
-             description: "`dump` a description comment above each line, unless the " \
+             description: "`dump` adds a description comment above each line, unless the " \
                           "dependency does not have a description."
       switch "--no-restart",
              description: "`dump` does not add `restart_service` to formula lines."
@@ -93,7 +93,7 @@ module Homebrew
       when "list"
         Bundle::Commands::List.run
       else
-        raise UsageError, "Unknown subcommand `#{subcommand}`!"
+        raise UsageError, "unknown subcommand: #{subcommand}"
       end
     rescue SystemExit => e
       Homebrew.failed = true unless e.success?

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -74,7 +74,7 @@ module Bundle
       case @link
       when true
         unless linked_and_keg_only?
-          puts "Force linking #{@name} formula." if Homebrew.args.verbose?
+          puts "Force-linking #{@name} formula." if Homebrew.args.verbose?
           Bundle.system("brew", "link", "--force", @name)
         end
       when false

--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -9,7 +9,7 @@ module Bundle
 
       filename =
         if Homebrew.args.global?
-          raise "'HOMEBREW_BUNDLE_FILE' can not be specified with '--global'" if env_bundle_file.present?
+          raise "'HOMEBREW_BUNDLE_FILE' cannot be specified with '--global'" if env_bundle_file.present?
 
           "#{ENV["HOME"]}/.Brewfile"
         elsif Homebrew.args.file.present?

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -22,7 +22,7 @@ module Bundle
 
         # Save the command path, since this will be blown away by superenv
         command_path = which(command)
-        raise "Error: #{command} was not found on your PATH!" if command_path.nil?
+        raise "command was not found in your PATH: #{command}" if command_path.nil?
 
         command_path = command_path.dirname.to_s
 


### PR DESCRIPTION
Using colons before subcommand descriptions causes the man page output to indent them. Homebrew/brew#7393 applies the same effect to its `--help` output. This also cleans up the README prose.