### PR TITLE
cleanup_command_spec: remove empty before block.

### DIFF
--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -190,9 +190,6 @@ describe Bundle::Commands::Cleanup do
     end
 
     context "without --force" do
-      before do
-      end
-
       it "prints output" do
         sane?
         expect { described_class.run }.to output(/cleaned/).to_stdout


### PR DESCRIPTION
Needed for https://github.com/Homebrew/brew/pull/7475