### PR TITLE
Exec: remove call to deprecated method

### DIFF
--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -41,7 +41,7 @@ module Bundle
 
         # Setup pkg-config, if present, to help locate packages
         pkgconfig = Formulary.factory("pkg-config")
-        ENV.prepend_path "PATH", pkgconfig.opt_bin.to_s if pkgconfig.installed?
+        ENV.prepend_path "PATH", pkgconfig.opt_bin.to_s if pkgconfig.any_version_installed?
 
         # Ensure the Ruby path we saved goes before anything else
         ENV.prepend_path "PATH", command_path

--- a/spec/stub/formula.rb
+++ b/spec/stub/formula.rb
@@ -24,7 +24,7 @@ class Formula
     false
   end
 
-  def installed?
+  def any_version_installed?
     true
   end
 


### PR DESCRIPTION
Fixes a deprecation warning in `brew bundle exec`:

```
Warning: Calling Formula#installed? is deprecated! Use Formula#latest_version_installed? (or Formula#any_version_installed? ) instead.
Please report this issue to the homebrew/bundle tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/commands/exec.rb:44
```