### PR TITLE
Refer to default branch in links with HEAD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,4 +20,4 @@ Please report security issues to our [HackerOne](https://hackerone.com/homebrew/
 
 ## Code of Conduct
 
-Please note that this project is released with a [Code of Conduct](https://github.com/Homebrew/.github/blob/master/CODE_OF_CONDUCT.md#code-of-conduct). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Code of Conduct](https://github.com/Homebrew/.github/blob/HEAD/CODE_OF_CONDUCT.md#code-of-conduct). By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Tests can be run with `bundle install && bundle exec rspec`.
 
 ## Copyright
 
-Copyright (c) Homebrew maintainers and Andrew Nesbitt. See [LICENSE](https://github.com/Homebrew/homebrew-bundle/blob/master/LICENSE) for details.
+Copyright (c) Homebrew maintainers and Andrew Nesbitt. See [LICENSE](https://github.com/Homebrew/homebrew-bundle/blob/HEAD/LICENSE) for details.


### PR DESCRIPTION
Anywhere we can use `blob/master` we can use `blob/HEAD` instead. This will make life easier if we ever rename our default branch in future (once/if Git and GitHub provides the necessary tooling to do so).