### PR TITLE
Use CodeCov for coverage reporting.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Run RSpec tests
       run: bundle exec rspec
       env:
-        COVERALLS_REPO_TOKEN: glKUxWlZ56q0WwJhNh5znGTB8ZlFwfvZW
+        CODECOV_TOKEN: d8abdd06-9193-47d3-9da9-b4b25064e49b

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "activesupport"
-  gem "coveralls"
+  gem "codecov", require: false
   gem "guard-rspec"
   gem "guard-rubocop"
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,12 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.1)
+    codecov (0.1.17)
+      json
+      simplecov
+      url
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     diff-lcs (1.4.4)
     docile (1.3.2)
     ffi (1.13.1)
@@ -88,21 +86,16 @@ GEM
       parser (>= 2.7.0.1)
     ruby-progressbar (1.10.1)
     shellany (0.0.1)
-    simplecov (0.16.1)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    sync (0.5.0)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     thor (1.0.1)
     thread_safe (0.3.6)
-    tins (1.25.0)
-      sync
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    url (0.3.2)
     zeitwerk (2.3.1)
 
 PLATFORMS
@@ -110,7 +103,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  coveralls
+  codecov
   guard-rspec
   guard-rubocop
   rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,18 +35,10 @@ end
 
 formatters = [SimpleCov::Formatter::HTMLFormatter]
 
-if macos? && ENV["COVERALLS_REPO_TOKEN"]
-  require "coveralls"
+if macos? && ENV["CODECOV_TOKEN"]
+  require "codecov"
 
-  formatters << Coveralls::SimpleCov::Formatter
-
-  ENV["CI"] = "1"
-  ENV["CI_NAME"] = "github-actions"
-  ENV["CI_BUILD_NUMBER"] = ENV["GITHUB_REF"]
-  ENV["CI_BRANCH"] = ENV["HEAD_GITHUB_REF"]
-  %r{refs/pull/(?<pr>\d+)/merge} =~ ENV["GITHUB_REF"]
-  ENV["CI_PULL_REQUEST"] = pr
-  ENV["CI_BUILD_URL"] = "https://github.com/#{ENV["GITHUB_REPOSITORY"]}/pull/#{pr}/checks"
+  formatters << SimpleCov::Formatter::Codecov
 end
 
 SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)


### PR DESCRIPTION
We used to use them and then bailed due to lack of Azure Pipelines support. Looks like they support both Azure and GitHub Actions now and their gem seems significantly better maintained than Coveralls at this point.

See also: https://github.com/Homebrew/brew/pull/7828