### PR TITLE
Remove remaining global `Homebrew.args`.

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -92,6 +92,7 @@ module Homebrew
           file:       args.file,
           no_lock:    args.no_lock?,
           no_upgrade: args.no_upgrade?,
+          verbose:    args.verbose?,
         )
       when "dump"
         Bundle::Commands::Dump.run(
@@ -113,6 +114,7 @@ module Homebrew
           global:     args.global?,
           file:       args.file,
           no_upgrade: args.no_upgrade?,
+          verbose:    args.verbose?,
         )
       when "exec"
         _subcommand, *named_args = args.named
@@ -137,7 +139,7 @@ module Homebrew
       end
     rescue SystemExit => e
       Homebrew.failed = true unless e.success?
-      puts "Kernel.exit" if Homebrew.args.debug?
+      puts "Kernel.exit" if args.debug?
     rescue Interrupt
       puts # seemingly a newline is typical
       Homebrew.failed = true
@@ -145,7 +147,7 @@ module Homebrew
       raise if e.message.empty?
 
       onoe e
-      puts e.backtrace if Homebrew.args.debug?
+      puts e.backtrace if args.debug?
       Homebrew.failed = true
     rescue => e
       onoe e

--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -8,17 +8,17 @@ module Bundle
       @started_services = nil
     end
 
-    def stop(name)
+    def stop(name, verbose: false)
       return true unless started?(name)
 
-      if Bundle.system "brew", "services", "stop", name
+      if Bundle.system "brew", "services", "stop", name, verbose: verbose
         started_services.delete(name)
         true
       end
     end
 
-    def restart(name)
-      if Bundle.system "brew", "services", "restart", name
+    def restart(name, verbose: false)
+      if Bundle.system "brew", "services", "restart", name, verbose: verbose
         started_services << name
         true
       end

--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -4,8 +4,8 @@ require "English"
 
 module Bundle
   class << self
-    def system(cmd, *args)
-      return super cmd, *args if Homebrew.args.verbose?
+    def system(cmd, *args, verbose: false)
+      return super cmd, *args if verbose
 
       logs = []
       success = nil

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -9,13 +9,13 @@ module Bundle
       @outdated_casks = nil
     end
 
-    def install(name, no_upgrade: false, **options)
+    def install(name, no_upgrade: false, verbose: false, **options)
       full_name = options.fetch(:full_name, name)
 
       if installed_casks.include? name
         if !no_upgrade && outdated_casks.include?(name)
-          puts "Upgrading #{name} cask. It is installed but not up-to-date." if Homebrew.args.verbose?
-          return :failed unless Bundle.system "brew", "cask", "upgrade", full_name
+          puts "Upgrading #{name} cask. It is installed but not up-to-date." if verbose
+          return :failed unless Bundle.system "brew", "cask", "upgrade", full_name, verbose: verbose
 
           return :success
         end
@@ -33,9 +33,9 @@ module Bundle
         end
       end.compact
 
-      puts "Installing #{name} cask. It is not currently installed." if Homebrew.args.verbose?
+      puts "Installing #{name} cask. It is not currently installed." if verbose
 
-      return :failed unless Bundle.system "brew", "cask", "install", full_name, *args
+      return :failed unless Bundle.system "brew", "cask", "install", full_name, *args, verbose: verbose
 
       installed_casks << name
       :success

--- a/lib/bundle/commands/check.rb
+++ b/lib/bundle/commands/check.rb
@@ -8,21 +8,18 @@ module Bundle
       ARROW = "→"
       FAILURE_MESSAGE = "brew bundle can't satisfy your Brewfile's dependencies."
 
-      def output_errors?
-        Homebrew.args.verbose?
-      end
-
-      def exit_on_first_error?
-        !Homebrew.args.verbose?
-      end
-
-      def run(global: false, file: nil, no_upgrade: false)
-        check_result = Bundle::Checker.check(exit_on_first_error?, global: global, file: file, no_upgrade: no_upgrade)
+      def run(global: false, file: nil, no_upgrade: false, verbose: false)
+        output_errors = verbose
+        exit_on_first_error = !verbose
+        check_result = Bundle::Checker.check(
+          global: global, file: file,
+          exit_on_first_error: exit_on_first_error, no_upgrade: no_upgrade, verbose: verbose
+        )
 
         if check_result.work_to_be_done
           puts FAILURE_MESSAGE
 
-          check_result.errors.each { |package| puts "#{ARROW} #{package}" } if output_errors?
+          check_result.errors.each { |package| puts "#{ARROW} #{package}" } if output_errors
           puts "Satisfy missing dependencies with `brew bundle install`."
           exit 1
         else

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -4,7 +4,7 @@ module Bundle
   module Installer
     module_function
 
-    def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false)
+    def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false)
       success = 0
       failure = 0
 
@@ -32,7 +32,7 @@ module Bundle
 
         next if Bundle::Skipper.skip? entry
 
-        case cls.install(*args, **options, no_upgrade: no_upgrade)
+        case cls.install(*args, **options, no_upgrade: no_upgrade, verbose: verbose)
         when :success
           puts Formatter.success("#{verb} #{entry.name}")
           success += 1

--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -11,10 +11,10 @@ module Bundle
       @outdated_app_ids = nil
     end
 
-    def install(name, id, no_upgrade: false)
+    def install(name, id, no_upgrade: false, verbose: false)
       unless Bundle.mas_installed?
-        puts "Installing mas. It is not currently installed." if Homebrew.args.verbose?
-        Bundle.system "brew", "install", "mas"
+        puts "Installing mas. It is not currently installed." if verbose
+        Bundle.system "brew", "install", "mas", verbose: verbose
         raise "Unable to install #{name} app. mas installation failed." unless Bundle.mas_installed?
       end
 
@@ -24,20 +24,20 @@ module Bundle
       end
 
       unless Bundle.mas_signedin?
-        puts "Not signed in to Mac App Store." if Homebrew.args.verbose?
+        puts "Not signed in to Mac App Store." if verbose
         raise "Unable to install #{name} app. mas not signed in to Mac App Store."
       end
 
       if app_id_installed?(id)
-        puts "Upgrading #{name} app. It is installed but not up-to-date." if Homebrew.args.verbose?
-        return :failed unless Bundle.system "mas", "upgrade", id.to_s
+        puts "Upgrading #{name} app. It is installed but not up-to-date." if verbose
+        return :failed unless Bundle.system "mas", "upgrade", id.to_s, verbose: verbose
 
         return :success
       end
 
-      puts "Installing #{name} app. It is not currently installed." if Homebrew.args.verbose?
+      puts "Installing #{name} app. It is not currently installed." if verbose
 
-      return :failed unless Bundle.system "mas", "install", id.to_s
+      return :failed unless Bundle.system "mas", "install", id.to_s, verbose: verbose
 
       installed_app_ids << id
       :success

--- a/lib/bundle/tap_checker.rb
+++ b/lib/bundle/tap_checker.rb
@@ -6,7 +6,7 @@ module Bundle
       PACKAGE_TYPE = :tap
       PACKAGE_TYPE_NAME = "Tap"
 
-      def find_actionable(entries, no_upgrade: false)
+      def find_actionable(entries, exit_on_first_error: false, no_upgrade: false, verbose: false)
         requested_taps = format_checkable(entries)
         return [] if requested_taps.empty?
 

--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -4,19 +4,19 @@ module Bundle
   module TapInstaller
     module_function
 
-    def install(name, **options)
+    def install(name, verbose: false, **options)
       if installed_taps.include? name
-        puts "Skipping install of #{name} tap. It is already installed." if Homebrew.args.verbose?
-        return :failed unless check_pinning(name, options)
+        puts "Skipping install of #{name} tap. It is already installed." if verbose
+        return :failed unless check_pinning(name, verbose: verbose, **options)
 
         return :skipped
       end
 
-      puts "Installing #{name} tap. It is not currently installed." if Homebrew.args.verbose?
+      puts "Installing #{name} tap. It is not currently installed." if verbose
       success = if options[:clone_target]
-        Bundle.system "brew", "tap", name, options[:clone_target]
+        Bundle.system "brew", "tap", name, options[:clone_target], verbose: verbose
       else
-        Bundle.system "brew", "tap", name
+        Bundle.system "brew", "tap", name, verbose: verbose
       end
 
       return :failed unless success
@@ -35,17 +35,17 @@ module Bundle
       @pinned_installed_taps ||= Bundle::TapDumper.pinned_tap_names
     end
 
-    def check_pinning(name, options)
+    def check_pinning(name, verbose: false, **options)
       pin = options[:pin]
       currently_pinned = pinned_installed_taps.include? name
       if pin && !currently_pinned
-        puts "Pinning #{name} tap." if Homebrew.args.verbose?
-        return :failed unless Bundle.system "brew", "tap-pin", name
+        puts "Pinning #{name} tap." if verbose
+        return :failed unless Bundle.system "brew", "tap-pin", name, verbose: verbose
 
         pinned_installed_taps << name
       elsif currently_pinned && !pin
-        puts "Unpinning #{name} tap." if Homebrew.args.verbose?
-        return :failed unless Bundle.system "brew", "tap-unpin", name
+        puts "Unpinning #{name} tap." if verbose
+        return :failed unless Bundle.system "brew", "tap-unpin", name, verbose: verbose
 
         pinned_installed_taps.delete(name)
       end

--- a/lib/bundle/whalebrew_installer.rb
+++ b/lib/bundle/whalebrew_installer.rb
@@ -8,18 +8,18 @@ module Bundle
       @installed_images = nil
     end
 
-    def install(name, **_options)
+    def install(name, verbose: false, **_options)
       unless Bundle.whalebrew_installed?
-        puts "Installing whalebrew. It is not currently installed." if Homebrew.args.verbose?
-        Bundle.system "brew", "install", "whalebrew"
+        puts "Installing whalebrew. It is not currently installed." if verbose
+        Bundle.system "brew", "install", "whalebrew", verbose: verbose
         raise "Unable to install #{name} app. Whalebrew installation failed." unless Bundle.whalebrew_installed?
       end
 
       return :skipped if image_installed?(name)
 
-      puts "Installing #{name} image. It is not currently installed." if Homebrew.args.verbose?
+      puts "Installing #{name} image. It is not currently installed." if verbose
 
-      return :failed unless Bundle.system "whalebrew", "install", name
+      return :failed unless Bundle.system "whalebrew", "install", name, verbose: verbose
 
       installed_images << name
       :success

--- a/spec/bundle/brew_installer_spec.rb
+++ b/spec/bundle/brew_installer_spec.rb
@@ -18,7 +18,7 @@ describe Bundle::BrewInstaller do
       end
 
       it "restart service" do
-        expect(Bundle::BrewServices).to receive(:restart).with(formula).and_return(true)
+        expect(Bundle::BrewServices).to receive(:restart).with(formula, verbose: false).and_return(true)
         described_class.install(formula, restart_service: true)
       end
     end
@@ -41,7 +41,7 @@ describe Bundle::BrewInstaller do
     end
 
     it "links formula" do
-      expect(Bundle).to receive(:system).with("brew", "link", "--force", "mysql").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "link", "--force", "mysql", verbose: false).and_return(true)
       described_class.install(formula, link: true)
     end
   end
@@ -52,7 +52,7 @@ describe Bundle::BrewInstaller do
     end
 
     it "unlinks formula" do
-      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql", verbose: false).and_return(true)
       described_class.install(formula, link: false)
     end
   end
@@ -64,7 +64,7 @@ describe Bundle::BrewInstaller do
 
     it "links formula" do
       allow_any_instance_of(described_class).to receive(:unlinked_and_not_keg_only?).and_return(true)
-      expect(Bundle).to receive(:system).with("brew", "link", "mysql").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "link", "mysql", verbose: false).and_return(true)
       described_class.install(formula, link: nil)
     end
   end
@@ -76,7 +76,7 @@ describe Bundle::BrewInstaller do
 
     it "unlinks formula" do
       allow_any_instance_of(described_class).to receive(:linked_and_keg_only?).and_return(true)
-      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql", verbose: false).and_return(true)
       described_class.install(formula, link: nil)
     end
   end
@@ -91,24 +91,23 @@ describe Bundle::BrewInstaller do
       allow_any_instance_of(described_class).to receive(:install).and_return(true)
     end
 
-    def sane?
-      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql55").and_return(true)
-      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql56").and_return(true)
-      expect(Bundle::BrewServices).to receive(:stop).with("mysql55").and_return(true)
-      expect(Bundle::BrewServices).to receive(:stop).with("mysql56").and_return(true)
-      expect(Bundle::BrewServices).to receive(:restart).with(formula).and_return(true)
+    def sane?(verbose:)
+      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql55", verbose: verbose).and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql56", verbose: verbose).and_return(true)
+      expect(Bundle::BrewServices).to receive(:stop).with("mysql55", verbose: verbose).and_return(true)
+      expect(Bundle::BrewServices).to receive(:stop).with("mysql56", verbose: verbose).and_return(true)
+      expect(Bundle::BrewServices).to receive(:restart).with(formula, verbose: verbose).and_return(true)
     end
 
     it "unlinks conflicts and stops their services" do
-      sane?
+      sane?(verbose: false)
       described_class.install(formula, restart_service: true, conflicts_with: ["mysql56"])
     end
 
     it "prints a message" do
-      allow(Homebrew).to receive(:args).and_return(OpenStruct.new(verbose?: true))
       allow_any_instance_of(described_class).to receive(:puts)
-      sane?
-      described_class.install(formula, restart_service: true, conflicts_with: ["mysql56"])
+      sane?(verbose: true)
+      described_class.install(formula, restart_service: true, conflicts_with: ["mysql56"], verbose: true)
     end
   end
 
@@ -184,12 +183,14 @@ describe Bundle::BrewInstaller do
       end
 
       it "install formula" do
-        expect(Bundle).to receive(:system).with("brew", "install", formula, "--with-option").and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "install", formula, "--with-option", verbose: false)
+                                          .and_return(true)
         expect(do_install).to be(:success)
       end
 
       it "reports a failure" do
-        expect(Bundle).to receive(:system).with("brew", "install", formula, "--with-option").and_return(false)
+        expect(Bundle).to receive(:system).with("brew", "install", formula, "--with-option", verbose: false)
+                                          .and_return(false)
         expect(do_install).to be(:failed)
       end
     end
@@ -207,12 +208,12 @@ describe Bundle::BrewInstaller do
         end
 
         it "upgrade formula" do
-          expect(Bundle).to receive(:system).with("brew", "upgrade", formula).and_return(true)
+          expect(Bundle).to receive(:system).with("brew", "upgrade", formula, verbose: false).and_return(true)
           expect(do_install).to be(:success)
         end
 
         it "reports a failure" do
-          expect(Bundle).to receive(:system).with("brew", "upgrade", formula).and_return(false)
+          expect(Bundle).to receive(:system).with("brew", "upgrade", formula, verbose: false).and_return(false)
           expect(do_install).to be(:failed)
         end
 
@@ -222,7 +223,7 @@ describe Bundle::BrewInstaller do
           end
 
           it "does not upgrade formula" do
-            expect(Bundle).not_to receive(:system).with("brew", "upgrade", formula)
+            expect(Bundle).not_to receive(:system).with("brew", "upgrade", formula, verbose: false)
             expect(do_install).to be(:skipped)
           end
         end

--- a/spec/bundle/brew_services_spec.rb
+++ b/spec/bundle/brew_services_spec.rb
@@ -28,14 +28,14 @@ describe Bundle::BrewServices do
     context "stops the service" do
       it "when the service is started" do
         allow(described_class).to receive(:started_services).and_return(%w[nginx])
-        expect(Bundle).to receive(:system).with("brew", "services", "stop", "nginx").and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "services", "stop", "nginx", verbose: false).and_return(true)
         expect(described_class.stop("nginx")).to be(true)
         expect(described_class.started_services).not_to include("nginx")
       end
 
       it "when the service is already stopped" do
         allow(described_class).to receive(:started_services).and_return(%w[])
-        expect(Bundle).not_to receive(:system).with("brew", "services", "stop", "nginx")
+        expect(Bundle).not_to receive(:system).with("brew", "services", "stop", "nginx", verbose: false)
         expect(described_class.stop("nginx")).to be(true)
         expect(described_class.started_services).not_to include("nginx")
       end
@@ -43,7 +43,7 @@ describe Bundle::BrewServices do
 
     it "restarts the service" do
       allow(described_class).to receive(:started_services).and_return([])
-      expect(Bundle).to receive(:system).with("brew", "services", "restart", "nginx").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "services", "restart", "nginx", verbose: false).and_return(true)
       expect(described_class.restart("nginx")).to be(true)
       expect(described_class.started_services).to include("nginx")
     end

--- a/spec/bundle/cask_installer_spec.rb
+++ b/spec/bundle/cask_installer_spec.rb
@@ -66,7 +66,8 @@ describe Bundle::CaskInstaller do
       end
 
       it "upgrades" do
-        expect(Bundle).to receive(:system).with("brew", "cask", "upgrade", "google-chrome").and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "cask", "upgrade", "google-chrome", verbose: false)
+                                          .and_return(true)
         expect(do_install).to be(:success)
       end
     end
@@ -77,29 +78,33 @@ describe Bundle::CaskInstaller do
       end
 
       it "installs cask" do
-        expect(Bundle).to receive(:system).with("brew", "cask", "install", "google-chrome").and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "cask", "install", "google-chrome", verbose: false)
+                                          .and_return(true)
         expect(do_install).to be(:success)
       end
 
       it "installs cask with arguments" do
         expect(Bundle).to \
-          receive(:system).with("brew", "cask", "install", "firefox", "--appdir=/Applications").and_return(true)
+          receive(:system).with("brew", "cask", "install", "firefox", "--appdir=/Applications", verbose: false)
+                          .and_return(true)
         expect(described_class.install("firefox", args: { appdir: "/Applications" })).to eq(:success)
       end
 
       it "reports a failure" do
-        expect(Bundle).to receive(:system).with("brew", "cask", "install", "google-chrome").and_return(false)
+        expect(Bundle).to receive(:system).with("brew", "cask", "install", "google-chrome", verbose: false)
+                                          .and_return(false)
         expect(do_install).to be(:failed)
       end
 
       context "with boolean arguments" do
         it "includes a flag if true" do
-          expect(Bundle).to receive(:system).with("brew", "cask", "install", "iterm", "--force").and_return(true)
+          expect(Bundle).to receive(:system).with("brew", "cask", "install", "iterm", "--force", verbose: false)
+                                            .and_return(true)
           expect(described_class.install("iterm", args: { force: true })).to eq(:success)
         end
 
         it "does not include a flag if false" do
-          expect(Bundle).to receive(:system).with("brew", "cask", "install", "iterm").and_return(true)
+          expect(Bundle).to receive(:system).with("brew", "cask", "install", "iterm", verbose: false).and_return(true)
           expect(described_class.install("iterm", args: { force: false })).to eq(:success)
         end
       end

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -121,7 +121,6 @@ describe Bundle::Commands::Cleanup do
       allow(described_class).to receive(:casks_to_uninstall).and_return([])
       allow(described_class).to receive(:formulae_to_uninstall).and_return(%w[a b])
       allow(described_class).to receive(:taps_to_untap).and_return([])
-      allow(Homebrew).to receive(:args).and_return(OpenStruct.new(force?: true))
     end
 
     it "uninstalls formulae" do
@@ -175,13 +174,9 @@ describe Bundle::Commands::Cleanup do
     end
 
     context "with --force" do
-      before do
-        allow(Homebrew).to receive(:args).and_return(OpenStruct.new(force: true))
-      end
-
       it "prints output" do
         sane?
-        expect { described_class.run }.to output(/cleaned/).to_stdout
+        expect { described_class.run(force: true) }.to output(/cleaned/).to_stdout
       end
     end
 

--- a/spec/bundle/commands/exec_command_spec.rb
+++ b/spec/bundle/commands/exec_command_spec.rb
@@ -26,15 +26,6 @@ describe Bundle::Commands::Exec do
       expect { described_class.run("bundle", "install") }.not_to raise_error
     end
 
-    it "is able to accept arguments passed prior to the command" do
-      allow(Homebrew).to receive(:args).and_return(OpenStruct.new(verbose?: true))
-      allow(described_class).to receive(:exec).with("bundle", "install").and_return(nil)
-      allow_any_instance_of(Pathname).to receive(:read)
-        .and_return("brew 'openssl'")
-
-      expect { described_class.run("bundle", "install") }.not_to raise_error
-    end
-
     it "raises an exception if called without a command" do
       allow(described_class).to receive(:exec).and_return(nil)
       allow_any_instance_of(Pathname).to receive(:read)

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -25,7 +25,6 @@ describe Bundle::Dsl do
       allow_any_instance_of(described_class).to receive(:system)
         .with("/usr/libexec/java_home --failfast")
         .and_return(false)
-      allow(Homebrew).to receive(:args).and_return(OpenStruct.new(verbose?: true))
     end
 
     it "processes input" do
@@ -51,10 +50,6 @@ describe Bundle::Dsl do
   end
 
   context "with invalid input" do
-    before do
-      allow(Homebrew).to receive(:args).and_return(OpenStruct.new(verbose?: true))
-    end
-
     it "handles completely invalid code" do
       expect { described_class.new "abcdef" }.to raise_error(RuntimeError)
     end

--- a/spec/bundle/mac_app_store_installer_spec.rb
+++ b/spec/bundle/mac_app_store_installer_spec.rb
@@ -28,7 +28,7 @@ describe Bundle::MacAppStoreInstaller do
     end
 
     it "tries to install mas" do
-      expect(Bundle).to receive(:system).with("brew", "install", "mas").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "install", "mas", verbose: false).and_return(true)
       expect { do_install }.to raise_error(RuntimeError)
     end
 
@@ -87,7 +87,7 @@ describe Bundle::MacAppStoreInstaller do
         end
 
         it "upgrades" do
-          expect(Bundle).to receive(:system).with("mas", "upgrade", "123").and_return(true)
+          expect(Bundle).to receive(:system).with("mas", "upgrade", "123", verbose: false).and_return(true)
           expect(do_install).to be(:success)
         end
       end
@@ -98,7 +98,7 @@ describe Bundle::MacAppStoreInstaller do
         end
 
         it "installs app" do
-          expect(Bundle).to receive(:system).with("mas", "install", "123").and_return(true)
+          expect(Bundle).to receive(:system).with("mas", "install", "123", verbose: false).and_return(true)
           expect(do_install).to be(:success)
         end
       end

--- a/spec/bundle/tap_installer_spec.rb
+++ b/spec/bundle/tap_installer_spec.rb
@@ -3,12 +3,12 @@
 require "spec_helper"
 
 describe Bundle::TapInstaller do
-  def do_install(options = {})
-    Bundle::TapInstaller.install("homebrew/cask", options)
+  def do_install(**options)
+    Bundle::TapInstaller.install("homebrew/cask", **options)
   end
 
-  def do_pinning(options = {})
-    Bundle::TapInstaller.check_pinning("homebrew/cask", options)
+  def do_pinning(**options)
+    Bundle::TapInstaller.check_pinning("homebrew/cask", **options)
   end
 
   describe ".installed_taps" do
@@ -36,7 +36,7 @@ describe Bundle::TapInstaller do
 
     context "with pin true" do
       it "pins" do
-        expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask").and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask", verbose: false).and_return(true)
         expect(do_install(pin: true)).to be(:skipped)
       end
     end
@@ -49,21 +49,22 @@ describe Bundle::TapInstaller do
     end
 
     it "taps" do
-      expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask", verbose: false).and_return(true)
       expect(do_install).to be(:success)
     end
 
     context "with clone target" do
       it "taps" do
-        expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask", "clone_target_path").and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask", "clone_target_path", verbose: false)
+                                          .and_return(true)
         expect(do_install(clone_target: "clone_target_path")).to be(:success)
       end
     end
 
     context "with pin true" do
       it "pins" do
-        expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask").and_return(true)
-        expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask").and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask", verbose: false).and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask", verbose: false).and_return(true)
         expect(do_install(pin: true)).to be(:success)
       end
     end
@@ -77,7 +78,7 @@ describe Bundle::TapInstaller do
 
     context "with pin false" do
       it "unpins" do
-        expect(Bundle).to receive(:system).with("brew", "tap-unpin", "homebrew/cask").and_return(true)
+        expect(Bundle).to receive(:system).with("brew", "tap-unpin", "homebrew/cask", verbose: false).and_return(true)
         expect(do_install).to be(:skipped)
       end
     end
@@ -89,7 +90,7 @@ describe Bundle::TapInstaller do
     end
 
     it "pins" do
-      expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask", verbose: false).and_return(true)
       expect(do_pinning(pin: true)).to be(:success)
     end
   end
@@ -100,7 +101,7 @@ describe Bundle::TapInstaller do
     end
 
     it "pins" do
-      expect(Bundle).to receive(:system).with("brew", "tap-unpin", "homebrew/cask").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "tap-unpin", "homebrew/cask", verbose: false).and_return(true)
       expect(do_pinning).to be(:success)
     end
   end

--- a/spec/bundle/whalebrew_installer_spec.rb
+++ b/spec/bundle/whalebrew_installer_spec.rb
@@ -43,7 +43,8 @@ describe Bundle::WhalebrewInstaller do
     end
 
     it "successfully installs whalebrew" do
-      expect(Bundle).to receive(:system).with("brew", "install", "whalebrew").and_return(true)
+      expect(Bundle).to receive(:system).with("brew", "install", "whalebrew", verbose: false)
+                                        .and_return(true)
       expect { do_install }.to raise_error(RuntimeError)
     end
   end
@@ -51,7 +52,8 @@ describe Bundle::WhalebrewInstaller do
   context "when whalebrew is installed" do
     before do
       allow(Bundle).to receive(:whalebrew_installed?).and_return(true)
-      allow(Bundle).to receive(:system).with("whalebrew", "install", "whalebrew/wget").and_return(true)
+      allow(Bundle).to receive(:system).with("whalebrew", "install", "whalebrew/wget", verbose: false)
+                                       .and_return(true)
     end
 
     it "successfully installs an image" do

--- a/spec/bundle_utils_spec.rb
+++ b/spec/bundle_utils_spec.rb
@@ -4,13 +4,12 @@ require "spec_helper"
 
 describe Bundle do
   context "system call succeed" do
-    it "omits all stdout output if Homebrew.args.verbose? is false" do
-      expect { described_class.system "echo", "foo" }.not_to output.to_stdout_from_any_process
+    it "omits all stdout output if verbose is false" do
+      expect { described_class.system "echo", "foo", verbose: false }.not_to output.to_stdout_from_any_process
     end
 
-    it "emits all stdout output if Homebrew.args.verbose? is true" do
-      allow(Homebrew).to receive(:args).and_return(OpenStruct.new(verbose?: true))
-      expect { described_class.system "echo", "foo" }.to output("foo\n").to_stdout_from_any_process
+    it "emits all stdout output if verbose is true" do
+      expect { described_class.system "echo", "foo", verbose: true }.to output("foo\n").to_stdout_from_any_process
     end
   end
 
@@ -19,13 +18,12 @@ describe Bundle do
       allow_any_instance_of(Process::Status).to receive(:success?).and_return(false)
     end
 
-    it "emits all stdout output even if Homebrew.args.verbose? is false" do
-      expect { described_class.system "echo", "foo" }.to output("foo\n").to_stdout_from_any_process
+    it "emits all stdout output even if verbose is false" do
+      expect { described_class.system "echo", "foo", verbose: false }.to output("foo\n").to_stdout_from_any_process
     end
 
-    it "emits all stdout output only once if Homebrew.args.verbose? is true" do
-      allow(Homebrew).to receive(:args).and_return(OpenStruct.new(verbose?: true))
-      expect { described_class.system "echo", "foo" }.to output("foo\n").to_stdout_from_any_process
+    it "emits all stdout output only once if verbose is true" do
+      expect { described_class.system "echo", "foo", verbose: true }.to output("foo\n").to_stdout_from_any_process
     end
   end
 

--- a/spec/stub/global.rb
+++ b/spec/stub/global.rb
@@ -3,11 +3,3 @@
 HOMEBREW_PREFIX = Pathname.new("/usr/local").freeze
 HOMEBREW_REPOSITORY = Pathname.new("/usr/local/Homebrew").freeze
 HOMEBREW_VERSION = "2.1.0"
-
-module Homebrew
-  module_function
-
-  def args
-    OpenStruct.new
-  end
-end


### PR DESCRIPTION
Pass `verbose` instead of using global `Homebrew.args.verbose?`.