### PR TITLE
fix: use --quiet flag for brew_list_info

### DIFF
--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -87,7 +87,7 @@ module Bundle
 
     def brew_list_info
       @brew_list_info ||= begin
-        name_bottles = JSON.parse(`brew info --json=v1 --installed`)
+        name_bottles = JSON.parse(`brew info --json=v1 --installed --quiet`)
                            .each_with_object({}) do |f, hash|
           bottle = f["bottle"]["stable"]
           bottle&.delete("rebuild")

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -70,7 +70,7 @@ describe Bundle::Locker do
         allow(locker).to receive(:lockfile).and_return(lockfile)
         allow(brew_options).to receive(:deep_stringify_keys)
           .and_return("restart_service" => true)
-        allow(locker).to receive(:`).with("brew info --json=v1 --installed").and_return <<~EOS
+        allow(locker).to receive(:`).with("brew info --json=v1 --installed --quiet").and_return <<~EOS
           [
             {
               "name":"mysql",


### PR DESCRIPTION
When a formula uses the GitHubGitDownloadStrategy or GitDownloadStrategy (and perhaps others) `brew info --json=v1 --installed` may produce output related to fetching from git (e.g. to retrieve the latest version). This extraneous output breaks the JSON parsing. This PR adds the `--quiet` flag to suppress all non-json output from `brew info`.