### PR TITLE
Remove `devel` support

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -132,7 +132,6 @@ module Bundle
       if keg
         args = keg["used_options"].to_a.map { |option| option.delete_prefix("--") }
         args << "HEAD" if keg["version"].to_s.start_with?("HEAD")
-        args << "devel" if keg["version"].to_s.gsub(/_\d+$/, "") == formula["versions"]["devel"]
         args.uniq!
         version = keg["version"]
         installed_as_dependency = keg["installed_as_dependency"] || false

--- a/spec/bundle/brew_dumper_spec.rb
+++ b/spec/bundle/brew_dumper_spec.rb
@@ -241,27 +241,12 @@ describe Bundle::BrewDumper do
     end
   end
 
-  context "HEAD and devel formulae are installed" do
+  context "HEAD formulae are installed" do
     subject(:formulae_list) { described_class.formulae }
 
     before do
       described_class.reset!
       allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "foo",
-          full_name:                "foo",
-          aliases:                  [],
-          args:                     ["devel"],
-          version:                  "1.1beta",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
         {
           name:                     "bar",
           full_name:                "homebrew/tap/bar",
@@ -280,9 +265,8 @@ describe Bundle::BrewDumper do
       ]
     end
 
-    it "returns with args `devel` and `HEAD`" do
-      expect(formulae_list[0][:args]).to include("devel")
-      expect(formulae_list[1][:args]).to include("HEAD")
+    it "returns with args `HEAD`" do
+      expect(formulae_list.first[:args]).to include("HEAD")
     end
   end
 


### PR DESCRIPTION
This is deprecated in Homebrew/brew and getting disabled soon.