### PR TITLE
Fix `brew cask` deprecation warnings

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -11,7 +11,7 @@ module Bundle
     def casks
       return [] unless Bundle.cask_installed?
 
-      @casks ||= `brew cask list 2>/dev/null`.split("\n")
+      @casks ||= `brew list --cask 2>/dev/null`.split("\n")
       @casks.map { |cask| cask.chomp " (!)" }
             .uniq
     end

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -15,7 +15,7 @@ module Bundle
       if installed_casks.include? name
         if !no_upgrade && outdated_casks.include?(name)
           puts "Upgrading #{name} cask. It is installed but not up-to-date." if verbose
-          return :failed unless Bundle.system "brew", "cask", "upgrade", full_name, verbose: verbose
+          return :failed unless Bundle.system "brew", "upgrade", full_name, verbose: verbose
 
           return :success
         end

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -62,7 +62,7 @@ module Bundle
 
     def outdated_casks
       @outdated_casks ||= if Bundle.cask_installed?
-        `brew cask outdated 2>/dev/null`.split("\n")
+        `brew outdated --cask 2>/dev/null`.split("\n")
       else
         []
       end

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -110,8 +110,8 @@ module Bundle
       return {} unless OS.mac?
 
       @cask_list ||= begin
-        `brew cask list --versions`.lines
-                                   .each_with_object({}) do |line, name_versions|
+        `brew list --cask --versions`.lines
+                                     .each_with_object({}) do |line, name_versions|
           name, version, = line.split
           name_versions[name] = version
         end

--- a/spec/bundle/cask_installer_spec.rb
+++ b/spec/bundle/cask_installer_spec.rb
@@ -66,7 +66,7 @@ describe Bundle::CaskInstaller do
       end
 
       it "upgrades" do
-        expect(Bundle).to receive(:system).with("brew", "cask", "upgrade", "google-chrome", verbose: false)
+        expect(Bundle).to receive(:system).with("brew", "upgrade", "google-chrome", verbose: false)
                                           .and_return(true)
         expect(do_install).to be(:success)
       end

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -92,7 +92,7 @@ describe Bundle::Locker do
         before do
           allow(OS).to receive(:mac?).and_return(true)
 
-          allow(locker).to receive(:`).with("brew cask list --versions").and_return("adoptopenjdk8 8,232:b09")
+          allow(locker).to receive(:`).with("brew list --cask --versions").and_return("adoptopenjdk8 8,232:b09")
           allow(locker).to receive(:`).with("mas list").and_return("497799835 Xcode (11.2)")
         end
 


### PR DESCRIPTION
- A lot of the separation between Homebrew formulae and casks was deprecated in [Homebrew 2.5.0](https://brew.sh/2020/09/08/homebrew-2.5.0/), released last week. To avoid `brew bundle` showing deprecation warnings to users, update the invocations.
- Fixes #791.

