### PR TITLE
Remove tap pinning

### DIFF
--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -74,14 +74,14 @@ module Bundle
       @entries << Entry.new(:whalebrew, name)
     end
 
-    def tap(name, clone_target = nil, pin: false)
+    def tap(name, clone_target = nil)
       raise "name(#{name.inspect}) should be a String object" unless name.is_a? String
       if clone_target && !clone_target.is_a?(String)
         raise "clone_target(#{clone_target.inspect}) should be nil or a String object"
       end
 
       name = Bundle::Dsl.sanitize_tap_name(name)
-      @entries << Entry.new(:tap, name, clone_target: clone_target, pin: pin)
+      @entries << Entry.new(:tap, name, clone_target: clone_target)
     end
 
     HOMEBREW_TAP_ARGS_REGEX = %r{^([\w-]+)/(homebrew-)?([\w-]+)$}.freeze

--- a/lib/bundle/tap_dumper.rb
+++ b/lib/bundle/tap_dumper.rb
@@ -20,17 +20,12 @@ module Bundle
     def dump
       taps.map do |tap|
         remote = ", \"#{tap["remote"]}\"" if tap["custom_remote"] && tap["remote"]
-        pinned = ", pin: #{tap["pinned"]}" if tap["pinned"]
-        "tap \"#{tap["name"]}\"#{remote}#{pinned}"
-      end.sort.join("\n")
+        "tap \"#{tap["name"]}\"#{remote}"
+      end.sort.uniq.join("\n")
     end
 
     def tap_names
       taps.map { |tap| tap["name"] }
-    end
-
-    def pinned_tap_names
-      taps.map { |tap| tap["name"] if tap["pinned"] }
     end
   end
 end

--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -7,8 +7,6 @@ module Bundle
     def install(name, verbose: false, **options)
       if installed_taps.include? name
         puts "Skipping install of #{name} tap. It is already installed." if verbose
-        return :failed unless check_pinning(name, verbose: verbose, **options)
-
         return :skipped
       end
 
@@ -21,35 +19,12 @@ module Bundle
 
       return :failed unless success
 
-      return :failed unless check_pinning(name, options)
-
       installed_taps << name
       :success
     end
 
     def installed_taps
       @installed_taps ||= Bundle::TapDumper.tap_names
-    end
-
-    def pinned_installed_taps
-      @pinned_installed_taps ||= Bundle::TapDumper.pinned_tap_names
-    end
-
-    def check_pinning(name, verbose: false, **options)
-      pin = options[:pin]
-      currently_pinned = pinned_installed_taps.include? name
-      if pin && !currently_pinned
-        puts "Pinning #{name} tap." if verbose
-        return :failed unless Bundle.system "brew", "tap-pin", name, verbose: verbose
-
-        pinned_installed_taps << name
-      elsif currently_pinned && !pin
-        puts "Unpinning #{name} tap." if verbose
-        return :failed unless Bundle.system "brew", "tap-unpin", name, verbose: verbose
-
-        pinned_installed_taps.delete(name)
-      end
-      :success
     end
   end
 end

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -9,7 +9,7 @@ describe Bundle::Dsl do
         # frozen_string_literal: true
         cask_args appdir: '/Applications'
         tap 'homebrew/cask'
-        tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git', pin: true
+        tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
         brew 'imagemagick'
         brew 'mysql@5.6', restart_service: true, link: true, conflicts_with: ['mysql']
         brew 'emacs', args: ['with-cocoa', 'with-gnutls']
@@ -33,7 +33,7 @@ describe Bundle::Dsl do
       expect(dsl.entries[0].name).to eql("homebrew/cask")
       expect(dsl.entries[1].name).to eql("telemachus/brew")
       expect(dsl.entries[1].options).to \
-        eql(clone_target: "https://telemachus@bitbucket.org/telemachus/brew.git", pin: true)
+        eql(clone_target: "https://telemachus@bitbucket.org/telemachus/brew.git")
       expect(dsl.entries[2].name).to eql("imagemagick")
       expect(dsl.entries[3].name).to eql("mysql@5.6")
       expect(dsl.entries[3].options).to eql(restart_service: true, link: true, conflicts_with: ["mysql"])

--- a/spec/bundle/tap_dumper_spec.rb
+++ b/spec/bundle/tap_dumper_spec.rb
@@ -49,7 +49,7 @@ describe Bundle::TapDumper do
     it "dumps output" do
       expect(dumper.dump).to eql \
         "tap \"bitbucket/bar\", \"https://bitbucket.org/bitbucket/bar.git\"\n" \
-        "tap \"homebrew/baz\"\ntap \"homebrew/foo\", pin: true"
+        "tap \"homebrew/baz\"\ntap \"homebrew/foo\""
     end
   end
 end

--- a/spec/bundle/tap_installer_spec.rb
+++ b/spec/bundle/tap_installer_spec.rb
@@ -7,45 +7,26 @@ describe Bundle::TapInstaller do
     Bundle::TapInstaller.install("homebrew/cask", **options)
   end
 
-  def do_pinning(**options)
-    Bundle::TapInstaller.check_pinning("homebrew/cask", **options)
-  end
-
   describe ".installed_taps" do
     it "calls Homebrew" do
       described_class.installed_taps
     end
   end
 
-  describe ".pinned_installed_taps" do
-    it "calls Homebrew" do
-      described_class.pinned_installed_taps
-    end
-  end
-
   context "when tap is installed" do
     before do
       allow(described_class).to receive(:installed_taps).and_return(["homebrew/cask"])
-      allow(described_class).to receive(:pinned_installed_taps).and_return([])
     end
 
     it "skips" do
       expect(Bundle).not_to receive(:system)
       expect(do_install).to be(:skipped)
     end
-
-    context "with pin true" do
-      it "pins" do
-        expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask", verbose: false).and_return(true)
-        expect(do_install(pin: true)).to be(:skipped)
-      end
-    end
   end
 
   context "when tap is not installed" do
     before do
       allow(described_class).to receive(:installed_taps).and_return([])
-      allow(described_class).to receive(:pinned_installed_taps).and_return([])
     end
 
     it "taps" do
@@ -59,50 +40,6 @@ describe Bundle::TapInstaller do
                                           .and_return(true)
         expect(do_install(clone_target: "clone_target_path")).to be(:success)
       end
-    end
-
-    context "with pin true" do
-      it "pins" do
-        expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask", verbose: false).and_return(true)
-        expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask", verbose: false).and_return(true)
-        expect(do_install(pin: true)).to be(:success)
-      end
-    end
-  end
-
-  context "when tap is pinned" do
-    before do
-      allow(described_class).to receive(:installed_taps).and_return(["homebrew/cask"])
-      allow(described_class).to receive(:pinned_installed_taps).and_return(["homebrew/cask"])
-    end
-
-    context "with pin false" do
-      it "unpins" do
-        expect(Bundle).to receive(:system).with("brew", "tap-unpin", "homebrew/cask", verbose: false).and_return(true)
-        expect(do_install).to be(:skipped)
-      end
-    end
-  end
-
-  context "when tap needs pinning" do
-    before do
-      allow(described_class).to receive(:pinned_installed_taps).and_return([])
-    end
-
-    it "pins" do
-      expect(Bundle).to receive(:system).with("brew", "tap-pin", "homebrew/cask", verbose: false).and_return(true)
-      expect(do_pinning(pin: true)).to be(:success)
-    end
-  end
-
-  context "when tap needs unpinning" do
-    before do
-      allow(described_class).to receive(:pinned_installed_taps).and_return(["homebrew/cask"])
-    end
-
-    it "pins" do
-      expect(Bundle).to receive(:system).with("brew", "tap-unpin", "homebrew/cask", verbose: false).and_return(true)
-      expect(do_pinning).to be(:success)
     end
   end
 end


### PR DESCRIPTION
This is removed from Homebrew/brew so it'll fail hard anyway so let's remove it here too.

While we're here: also ensure the dumped taps are unique (as they might not be if you'd weird and have both homebrew-core and linuxbrew-core tapped like I do).