### PR TITLE
Improvements for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store an
 
 [mas-cli](https://github.com/mas-cli/mas) is optional and used for installing Mac App Store applications.
 
-[whalebrew](https://github.com/whalebrew/whalebrew) is optional and used for installing Whalebrew images.
+[Whalebrew](https://github.com/whalebrew/whalebrew) is optional and used for installing Whalebrew images.
 
 ## Installation
 
@@ -28,7 +28,7 @@ tap "homebrew/cask"
 # 'brew tap' with custom Git URL
 tap "user/tap-repo", "https://user@bitbucket.org/user/homebrew-tap-repo.git"
 # set arguments for all 'brew cask install' commands
-cask_args appdir: "~/Applications"
+cask_args appdir: "~/Applications", require_sha: true
 
 # 'brew install'
 brew "imagemagick"

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -14,12 +14,12 @@ module Homebrew
         `brew bundle` [`install`]:
         Install and upgrade (by default) all dependencies from the `Brewfile`.
 
-        You can skip the installation of dependencies by adding space-separated values to one or more of the following environment variables: `HOMEBREW_BUNDLE_BREW_SKIP`, `HOMEBREW_BUNDLE_CASK_SKIP`, `HOMEBREW_BUNDLE_MAS_SKIP`, `HOMEBREW_BUNDLE_WHALEBREW_SKIP`, `HOMEBREW_BUNDLE_TAP_SKIP`
+        You can skip the installation of dependencies by adding space-separated values to one or more of the following environment variables: `HOMEBREW_BUNDLE_BREW_SKIP`, `HOMEBREW_BUNDLE_CASK_SKIP`, `HOMEBREW_BUNDLE_MAS_SKIP`, `HOMEBREW_BUNDLE_WHALEBREW_SKIP`, `HOMEBREW_BUNDLE_TAP_SKIP`.
 
         `brew bundle` will output a `Brewfile.lock.json` in the same directory as the `Brewfile` if all dependencies are installed successfully. This contains dependency and system status information which can be useful in debugging `brew bundle` failures and replicating a "last known good build" state. You can opt-out of this behaviour by setting the `HOMEBREW_BUNDLE_NO_LOCK` environment variable or passing the `--no-lock` option. You may wish to check this file into the same version control system as your `Brewfile` (or ensure your version control system ignores it if you'd prefer to rely on debugging information from a local machine).
 
         `brew bundle dump`:
-        Write all installed casks/formulae/images/taps into a `Brewfile`.
+        Write all installed casks/formulae/images/taps into a `Brewfile` in the current directory.
 
         `brew bundle cleanup`:
         Uninstall all dependencies not listed from the `Brewfile`.
@@ -27,12 +27,12 @@ module Homebrew
         This workflow is useful for maintainers or testers who regularly install lots of formulae.
 
         `brew bundle check`:
-        Check if all dependencies are installed from the `Brewfile` .
+        Check if all dependencies are installed from the `Brewfile`.
 
         This provides a successful exit code if everything is up-to-date, making it useful for scripting.
 
         `brew bundle list`:
-        List all dependencies present in a `Brewfile`.
+        List all dependencies present in the `Brewfile`.
 
         By default, only Homebrew dependencies are listed.
 


### PR DESCRIPTION
Minor grammar fixes and add to the `cask_args` sample to show the need to convert dashes to underscores when adding `brew cask install` options.