### PR TITLE
Reference HOMEBREW_BUNDLE_FILE in documentation

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -14,6 +14,8 @@ module Homebrew
         `brew bundle` [`install`]:
         Install and upgrade (by default) all dependencies from the `Brewfile`.
 
+        You can specify the `Brewfile` location using `--file` or setting the `HOMEBREW_BUNDLE_FILE` environment variable.
+
         You can skip the installation of dependencies by adding space-separated values to one or more of the following environment variables: `HOMEBREW_BUNDLE_BREW_SKIP`, `HOMEBREW_BUNDLE_CASK_SKIP`, `HOMEBREW_BUNDLE_MAS_SKIP`, `HOMEBREW_BUNDLE_WHALEBREW_SKIP`, `HOMEBREW_BUNDLE_TAP_SKIP`
 
         `brew bundle` will output a `Brewfile.lock.json` in the same directory as the `Brewfile` if all dependencies are installed successfully. This contains dependency and system status information which can be useful in debugging `brew bundle` failures and replicating a "last known good build" state. You can opt-out of this behaviour by setting the `HOMEBREW_BUNDLE_NO_LOCK` environment variable or passing the `--no-lock` option. You may wish to check this file into the same version control system as your `Brewfile` (or ensure your version control system ignores it if you'd prefer to rely on debugging information from a local machine).

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -14,7 +14,7 @@ module Homebrew
         `brew bundle` [`install`]:
         Install and upgrade (by default) all dependencies from the `Brewfile`.
 
-        You can specify the `Brewfile` location using `--file` or setting the `HOMEBREW_BUNDLE_FILE` environment variable.
+        You can specify the `Brewfile` location using `--file` or by setting the `HOMEBREW_BUNDLE_FILE` environment variable.
 
         You can skip the installation of dependencies by adding space-separated values to one or more of the following environment variables: `HOMEBREW_BUNDLE_BREW_SKIP`, `HOMEBREW_BUNDLE_CASK_SKIP`, `HOMEBREW_BUNDLE_MAS_SKIP`, `HOMEBREW_BUNDLE_WHALEBREW_SKIP`, `HOMEBREW_BUNDLE_TAP_SKIP`
 


### PR DESCRIPTION
I was looking for a way to set the `Brewfile` location using an environment variable and didn't see anything in the docs. I went ahead and started to implement it and realized that the functionality was already there and just hadn't been documented!

This PR adds a mention of the `HOMEBREW_BUNDLE_FILE` environment variable to the docs.
