### PR TITLE
cask_dumper: Replace `brew cask info` for `brew info --cask`

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -26,14 +26,14 @@ module Bundle
     def formula_dependencies(cask_list)
       return [] unless cask_list.present?
 
-      cask_info_response = `brew cask info #{cask_list.join(" ")} --json=v1`
+      cask_info_response = `brew info --cask #{cask_list.join(" ")} --json=v1`
       cask_info = JSON.parse(cask_info_response)
 
       cask_info.flat_map do |cask|
         cask.dig("depends_on", "formula")
       end.compact.uniq
     rescue JSON::ParserError => e
-      opoo "Failed to parse `brew cask info --json`: #{e}"
+      opoo "Failed to parse `brew info --cask --json`: #{e}"
       []
     end
   end

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -57,7 +57,7 @@ describe Bundle::CaskDumper do
       before do
         allow(described_class)
           .to receive(:`)
-          .with("brew cask info foo --json=v1")
+          .with("brew info --cask foo --json=v1")
           .and_return("[{\"depends_on\":{}}]")
       end
 
@@ -70,7 +70,7 @@ describe Bundle::CaskDumper do
       before do
         allow(described_class)
           .to receive(:`)
-          .with("brew cask info foo --json=v1")
+          .with("brew info --cask foo --json=v1")
           .and_return("Error: somethng from cask!")
       end
 
@@ -83,7 +83,7 @@ describe Bundle::CaskDumper do
       before do
         allow(described_class)
           .to receive(:`)
-          .with("brew cask info foo bar --json=v1")
+          .with("brew info --cask foo bar --json=v1")
           .and_return("[{\"depends_on\":{\"formula\":[\"baz\",\"qux\"]}},{\"depends_on\":{\"formula\":[\"baz\"]}}]")
       end
 


### PR DESCRIPTION
Follows on #817 and #792 by updating the `brew cask info` commands to
use the new syntax of `brew info --cask` instead.

cc @issyl0 