### PR TITLE
Swap to `--json=v2`

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -26,10 +26,10 @@ module Bundle
     def formula_dependencies(cask_list)
       return [] unless cask_list.present?
 
-      cask_info_response = `brew info --cask #{cask_list.join(" ")} --json=v1`
+      cask_info_response = `brew info --cask #{cask_list.join(" ")} --json=v2`
       cask_info = JSON.parse(cask_info_response)
 
-      cask_info.flat_map do |cask|
+      cask_info["casks"].flat_map do |cask|
         cask.dig("depends_on", "formula")
       end.compact.uniq
     rescue JSON::ParserError => e

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -87,7 +87,7 @@ module Bundle
 
     def brew_list_info
       @brew_list_info ||= begin
-        name_bottles = JSON.parse(`brew info --json=v1 --installed --quiet`)
+        name_bottles = JSON.parse(`brew info --json=v2 --installed --quiet`)
                            .each_with_object({}) do |f, hash|
           bottle = f["bottle"]["stable"]
           bottle&.delete("rebuild")

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -57,8 +57,8 @@ describe Bundle::CaskDumper do
       before do
         allow(described_class)
           .to receive(:`)
-          .with("brew info --cask foo --json=v1")
-          .and_return("[{\"depends_on\":{}}]")
+          .with("brew info --cask foo --json=v2")
+          .and_return("{\"formulae\":[],\"casks\":[]")
       end
 
       it "returns an empty array" do
@@ -70,8 +70,8 @@ describe Bundle::CaskDumper do
       before do
         allow(described_class)
           .to receive(:`)
-          .with("brew info --cask foo --json=v1")
-          .and_return("Error: somethng from cask!")
+          .with("brew info --cask foo --json=v2")
+          .and_return("Error: something from cask!")
       end
 
       it "returns an empty array" do
@@ -80,11 +80,18 @@ describe Bundle::CaskDumper do
     end
 
     context "when multiple casks have the same dependency" do
+      let(:json_output) do
+        "{" \
+        "\"formulae\":[]," \
+        "\"casks\":[{\"depends_on\":{\"formula\":[\"baz\",\"qux\"]}},{\"depends_on\":{\"formula\":[\"baz\"]}}]" \
+        "}"
+      end
+
       before do
         allow(described_class)
           .to receive(:`)
-          .with("brew info --cask foo bar --json=v1")
-          .and_return("[{\"depends_on\":{\"formula\":[\"baz\",\"qux\"]}},{\"depends_on\":{\"formula\":[\"baz\"]}}]")
+          .with("brew info --cask foo bar --json=v2")
+          .and_return(json_output)
       end
 
       it "returns an array of unique formula dependencies" do

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -70,7 +70,7 @@ describe Bundle::Locker do
         allow(locker).to receive(:lockfile).and_return(lockfile)
         allow(brew_options).to receive(:deep_stringify_keys)
           .and_return("restart_service" => true)
-        allow(locker).to receive(:`).with("brew info --json=v1 --installed --quiet").and_return <<~EOS
+        allow(locker).to receive(:`).with("brew info --json=v2 --installed --quiet").and_return <<~EOS
           [
             {
               "name":"mysql",


### PR DESCRIPTION
Homebrew/brew@311c106 introduced a deprecation for using JSON output
with the v1 format so it's time to bump up to v2.

Looking over the occurrences and their usage, we should be :ok_hand:

```
$ rg -F "json=v1"
lib/bundle/locker.rb
90:        name_bottles = JSON.parse(`brew info --json=v1 --installed --quiet`)

lib/bundle/cask_dumper.rb
29:      cask_info_response = `brew info --cask #{cask_list.join(" ")} --json=v1`

spec/bundle/locker_spec.rb
73:        allow(locker).to receive(:`).with("brew info --json=v1 --installed --quiet").and_return <<~EOS

spec/bundle/cask_dumper_spec.rb
60:          .with("brew info --cask foo --json=v1")
73:          .with("brew info --cask foo --json=v1")
86:          .with("brew info --cask foo bar --json=v1")
```