### PR TITLE
Update cask dumper to play nice with 2.5.12

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -27,7 +27,7 @@ module Bundle
       return [] if cask_list.blank?
 
       # TODO: can be removed when Homebrew 2.6.0 ships
-      cask_info_command = if HOMEBREW_VERSION > "2.5.11"
+      cask_info_command = if HOMEBREW_VERSION > "2.5.12"
         "brew info --cask --json=v2 #{cask_list.join(" ")}"
       else
         "brew info --json=v2 #{cask_list.join(" ")}"


### PR DESCRIPTION
Brew 2.5.12 was released yesterday and does not yet include the `--cask` arg on the info command, causing `brew bundle cleanup --global` for example to fail due to a parsing error on this sub-command.