### PR TITLE
Create `add` and `remove` subcommands for `brew bundle`

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -110,7 +110,7 @@ module Homebrew
       when "add"
         Bundle::Commands::Add.run(
           global: args.global?,
-          file:   args.file
+          file:   args.file,
         )
       when "dump"
         Bundle::Commands::Dump.run(

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -107,6 +107,11 @@ module Homebrew
             zap:    args.zap?,
           )
         end
+      when "add"
+        Bundle::Commands::Add.run(
+          global: args.global?,
+          file:   args.file
+        )
       when "dump"
         Bundle::Commands::Dump.run(
           global:     args.global?,

--- a/lib/bundle/commands/add.rb
+++ b/lib/bundle/commands/add.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Bundle
+  module Commands
+    module Add
+      module_function
+
+      def run(*args, global: false, file: nil)
+        raise UsageError, "No arguments were specified!" if args.blank?
+
+        type = :brew # default to brew
+        name = args.first # only support one formula at a time for now
+        options = {} # we don't currently support passing options
+
+        # read the relevant Brewfile
+        parsed_entries = Bundle::Dsl.new(Brewfile.read(global: global, file: file)).entries
+
+        # check each of the entries in the specified Brewfile
+        parsed_entries.each do |entry|
+          # raise an error if the entry already exists in the Brewfile
+          # this could also be a noop, or print a friendly message
+          raise RuntimeError if entry.name == name
+        end
+
+        # need some help / pointers here
+        # is it possible to use Bundle::Dsl to create an in memory representation
+        #of the brewfile that we read, add an entry and then dump that back to the file?
+      end
+    end
+  end
+end

--- a/lib/bundle/commands/add.rb
+++ b/lib/bundle/commands/add.rb
@@ -12,20 +12,20 @@ module Bundle
         name = args.first # only support one formula at a time for now
         options = {} # we don't currently support passing options
 
-        # read the relevant Brewfile
-        parsed_entries = Bundle::Dsl.new(Brewfile.read(global: global, file: file)).entries
+        # parse the relevant Brewfile
+        dsl = Bundle::Dsl.new(Brewfile.read(global: global, file: file))
 
         # check each of the entries in the specified Brewfile
-        parsed_entries.each do |entry|
+        dsl.entries.each do |entry|
           # raise an error if the entry already exists in the Brewfile
           # this could also be a noop, or print a friendly message
           opoo "'#{name}' already exists in Brewfile."
           raise RuntimeError if entry.name == name
         end
 
-        # need some help / pointers here
-        # is it possible to use Bundle::Dsl to create an in memory representation
-        # of the brewfile that we read, add an entry and then dump that back to the file?
+        dsl.brew(name, options)
+        # execute brew bundle
+        # execute brew bundle dump
       end
     end
   end

--- a/lib/bundle/commands/add.rb
+++ b/lib/bundle/commands/add.rb
@@ -19,12 +19,13 @@ module Bundle
         parsed_entries.each do |entry|
           # raise an error if the entry already exists in the Brewfile
           # this could also be a noop, or print a friendly message
+          opoo "'#{name}' already exists in Brewfile."
           raise RuntimeError if entry.name == name
         end
 
         # need some help / pointers here
         # is it possible to use Bundle::Dsl to create an in memory representation
-        #of the brewfile that we read, add an entry and then dump that back to the file?
+        # of the brewfile that we read, add an entry and then dump that back to the file?
       end
     end
   end

--- a/spec/bundle/commands/add_command_spec.rb
+++ b/spec/bundle/commands/add_command_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Bundle::Commands::Add do
+  context "when `--global` is passed" do
+  end
+end

--- a/spec/bundle/commands/add_command_spec.rb
+++ b/spec/bundle/commands/add_command_spec.rb
@@ -23,11 +23,11 @@ describe Bundle::Commands::Add do
 
     context "the formula is not in the Brewfile" do
       it "does not raise an error" do
-        expect { described_class.run("wget") }.to_not raise_error
+        expect { described_class.run("wget") }.not_to raise_error
       end
 
       it "adds the formula to the Brewfile" do
-        #TODO
+        # TODO
       end
     end
 

--- a/spec/bundle/commands/add_command_spec.rb
+++ b/spec/bundle/commands/add_command_spec.rb
@@ -3,6 +3,43 @@
 require "spec_helper"
 
 describe Bundle::Commands::Add do
-  context "when `--global` is passed" do
+  context "when a Brewfile is not found" do
+    it "raises an error" do
+      expect { described_class.run("wget") }.to raise_error(RuntimeError)
+    end
+  end
+
+  context "when a Brewfile is found" do
+    before do
+      allow_any_instance_of(Pathname).to receive(:read)
+        .and_return("brew 'openssl'")
+    end
+
+    context "when no arguments are passed" do
+      it "raises an error" do
+        expect { described_class.run }.to raise_error(UsageError)
+      end
+    end
+
+    context "the formula is not in the Brewfile" do
+      it "does not raise an error" do
+        expect { described_class.run("wget") }.to_not raise_error
+      end
+
+      it "adds the formula to the Brewfile" do
+        #TODO
+      end
+    end
+
+    context "the formula is in the Brewfile" do
+      before do
+        allow_any_instance_of(Pathname).to receive(:read)
+          .and_return("brew 'openssl'\nbrew 'wget'")
+      end
+
+      it "raises an error" do
+        expect { described_class.run("wget") }.to raise_error(RuntimeError)
+      end
+    end
   end
 end


### PR DESCRIPTION
As discussed in https://github.com/Homebrew/homebrew-bundle/issues/818

Add two subcommands `brew bundle add` and `brew bundle remove` which will add or remove a specified formula to the `Brewfile`. When the `--global` option is specified the formula is added or removed from the global `Brewfile`

I've figured out how to add new subcommands and also figured out how to read in the `Brewfile` and check if the requested formula is already in the `Brewfile`.

I'm looking for suggestions on how to add to the `Brewfile` and write it out to disk. My hope is that there is some in memory way to manipulate the Brewfile and call dump. I looked at `Bundle::Dumper` but that seems to operate based on what's installed on the system, not what was parsed from the `Brewfile`.

Additionally, looking for feedback on the command line syntax for how we should handle formulae that are not `:brew` but are `:cask`, `:tap`, `:mas`, or any other type. For example `brew bundle add cask atom`.