### PR TITLE
Remove pre-2.6.0 logic.

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -26,13 +26,7 @@ module Bundle
     def formula_dependencies(cask_list)
       return [] if cask_list.blank?
 
-      # TODO: can be removed when Homebrew 2.6.0 ships
-      cask_info_command = if HOMEBREW_VERSION > "2.5.12"
-        "brew info --cask --json=v2 #{cask_list.join(" ")}"
-      else
-        "brew info --json=v2 #{cask_list.join(" ")}"
-      end
-
+      cask_info_command = "brew info --cask --json=v2"
       cask_info_response = `#{cask_info_command}`
       cask_info = JSON.parse(cask_info_response)
 

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -65,20 +65,6 @@ describe Bundle::CaskDumper do
       end
     end
 
-    # TODO: can be removed when Homebrew 2.6.0 ships
-    context "when the given casks don't have formula dependencies on newer HOMEBREW_VERSION" do
-      before do
-        allow(described_class)
-          .to receive(:`)
-          .and_return("{\"formulae\":[],\"casks\":[]")
-        stub_const("HOMEBREW_VERSION", "2.6.0")
-      end
-
-      it "returns an empty array" do
-        expect(dumper.formula_dependencies(["foo"])).to eql([])
-      end
-    end
-
     context "when cask info returns invalid JSON" do
       before do
         allow(described_class)

--- a/spec/stub/global.rb
+++ b/spec/stub/global.rb
@@ -2,4 +2,4 @@
 
 HOMEBREW_PREFIX = Pathname.new("/usr/local").freeze
 HOMEBREW_REPOSITORY = Pathname.new("/usr/local/Homebrew").freeze
-HOMEBREW_VERSION = "2.1.0"
+HOMEBREW_VERSION = "2.6.0"


### PR DESCRIPTION
Now that 2.6.0 has been released, this is no longer needed.