### PR TITLE
Brew dumper: add missing dependency

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/string/exclude"
+
 require "json"
 require "tsort"
 


### PR DESCRIPTION
Fixes a bug introduced by #834. That PR added the use of an ActiveSupport method (`String#exclude?`), then added a dependency on it in the spec helper but not in the actual code. This led to runtime `undefined method` errors when calling `brew bundle install`.

```
Error: undefined method `exclude?' for "libtermkey":String
Please report this bug:
  https://github.com/Homebrew/homebrew-bundle/issues
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_dumper.rb:192:in `block in sort!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_dumper.rb:191:in `sort!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_dumper.rb:191:in `sort!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_dumper.rb:21:in `formulae'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_dumper.rb:52:in `formula_names'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:138:in `installed_formulae'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:121:in `formula_installed?'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:166:in `installed?'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:36:in `install_change_state!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:27:in `run'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/brew_installer.rb:12:in `install'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/installer.rb:35:in `block in install'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/installer.rb:11:in `each'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/installer.rb:11:in `install'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/lib/bundle/commands/install.rb:10:in `run'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle/cmd/bundle.rb:94:in `bundle'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```

/cc @MikeMcQuaid 