### PR TITLE
Switch to getting cask names from Cask module

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -11,7 +11,7 @@ module Bundle
     def casks
       return [] unless Bundle.cask_installed?
 
-      @casks ||= `brew list --cask 2>/dev/null`.split("\n")
+      @casks ||= Cask::Caskroom.casks.map(&:full_name).sort(&tap_and_name_comparison)
       @casks.map { |cask| cask.chomp " (!)" }
             .uniq
     end

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -13,7 +13,7 @@ module Bundle
 
       require "cask/caskroom"
 
-      @casks ||= Cask::Caskroom.casks.map(&:full_name).sort(&tap_and_name_comparison)
+      @casks ||= Cask::Caskroom.casks.map(&:full_name)
       @casks.map { |cask| cask.chomp " (!)" }
             .uniq
     end

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -11,6 +11,8 @@ module Bundle
     def casks
       return [] unless Bundle.cask_installed?
 
+      require "cask/caskroom"
+
       @casks ||= Cask::Caskroom.casks.map(&:full_name).sort(&tap_and_name_comparison)
       @casks.map { |cask| cask.chomp " (!)" }
             .uniq

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -40,21 +40,9 @@ describe Bundle::CaskDumper do
     before do
       described_class.reset!
 
-      foo = Object.new
-      bar = Object.new
-      baz = Object.new
-
-      def foo.full_name
-        "foo"
-      end
-
-      def bar.full_name
-        "bar"
-      end
-
-      def baz.full_name
-        "baz"
-      end
+      foo = instance_double("Cask::Cask", :full_name => "foo")
+      bar = instance_double("Cask::Cask", :full_name => "bar")
+      baz = instance_double("Cask::Cask", :full_name => "baz")
 
       allow(Bundle).to receive(:cask_installed?).and_return(true)
       allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar, baz])

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -39,7 +39,25 @@ describe Bundle::CaskDumper do
   context "cask `foo`, `bar` and `baz` are installed, while `baz` is required by formula" do
     before do
       described_class.reset!
+
+      foo = Object.new
+      bar = Object.new
+      baz = Object.new
+
+      def foo.full_name
+        "foo"
+      end
+
+      def bar.full_name
+        "bar"
+      end
+
+      def baz.full_name
+        "baz"
+      end
+
       allow(Bundle).to receive(:cask_installed?).and_return(true)
+      allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar, baz])
       allow(described_class).to receive(:`).and_return("foo\nbar\nbaz")
     end
 

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -40,9 +40,9 @@ describe Bundle::CaskDumper do
     before do
       described_class.reset!
 
-      foo = instance_double("Cask::Cask", :full_name => "foo")
-      bar = instance_double("Cask::Cask", :full_name => "bar")
-      baz = instance_double("Cask::Cask", :full_name => "baz")
+      foo = instance_double("Cask::Cask", full_name: "foo")
+      bar = instance_double("Cask::Cask", full_name: "bar")
+      baz = instance_double("Cask::Cask", full_name: "baz")
 
       allow(Bundle).to receive(:cask_installed?).and_return(true)
       allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar, baz])

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -16,8 +16,8 @@ describe Bundle::Dumper do
     Bundle::WhalebrewDumper.reset!
     Bundle::BrewServices.reset!
 
-    chrome = instance_double("Cask::Cask", :full_name => "google-chrome")
-    java = instance_double("Cask::Cask", :full_name => "java")
+    chrome = instance_double("Cask::Cask", full_name: "google-chrome")
+    java = instance_double("Cask::Cask", full_name: "java")
 
     allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java])
     allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava")

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -15,16 +15,10 @@ describe Bundle::Dumper do
     Bundle::MacAppStoreDumper.reset!
     Bundle::WhalebrewDumper.reset!
     Bundle::BrewServices.reset!
-    chrome = Object.new
-    java = Object.new
 
-    def chrome.full_name
-      "google-chrome"
-    end
+    chrome = instance_double("Cask::Cask", :full_name => "google-chrome")
+    java = instance_double("Cask::Cask", :full_name => "java")
 
-    def java.full_name
-      "java"
-    end
     allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java])
     allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava")
   end

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -15,6 +15,17 @@ describe Bundle::Dumper do
     Bundle::MacAppStoreDumper.reset!
     Bundle::WhalebrewDumper.reset!
     Bundle::BrewServices.reset!
+    chrome = Object.new
+    java = Object.new
+
+    def chrome.full_name
+      "google-chrome"
+    end
+
+    def java.full_name
+      "java"
+    end
+    allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java])
     allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava")
   end
 

--- a/spec/stub/cask.rb
+++ b/spec/stub/cask.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require "cask/cask"
 require "cask/caskroom"

--- a/spec/stub/cask.rb
+++ b/spec/stub/cask.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "cask/caskroom"

--- a/spec/stub/cask/cask.rb
+++ b/spec/stub/cask/cask.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cask
+  class Cask
+    def full_name
+      ""
+    end
+  end
+end

--- a/spec/stub/cask/caskroom.rb
+++ b/spec/stub/cask/caskroom.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cask
+  module Caskroom
+    def self.casks(config: nil)
+      []
+    end
+  end
+end

--- a/spec/stub/utils.rb
+++ b/spec/stub/utils.rb
@@ -7,3 +7,15 @@ def which(command)
 end
 
 def opoo(*); end
+
+def tap_and_name_comparison
+  proc do |a, b|
+    if a.include?("/") && b.exclude?("/")
+      1
+    elsif a.exclude?("/") && b.include?("/")
+      -1
+    else
+      a <=> b
+    end
+  end
+end

--- a/spec/stub/utils.rb
+++ b/spec/stub/utils.rb
@@ -7,15 +7,3 @@ def which(command)
 end
 
 def opoo(*); end
-
-def tap_and_name_comparison
-  proc do |a, b|
-    if a.include?("/") && b.exclude?("/")
-      1
-    elsif a.exclude?("/") && b.include?("/")
-      -1
-    else
-      a <=> b
-    end
-  end
-end


### PR DESCRIPTION
Originally the cask names were obtained by running `brew list --cask` and parsing the output. Now we're getting the cask with the `Cask::Caskroom.casks` method and stripping out the name.

Fixes #863 

I know @jacobbednarz had some concerns about this feature. It turned out to be a simple change so I just created this pull request.

This is my first time contributing so I might've missed something. I'd be happy to have feedback!