### PR TITLE
Don't get full cask name when dumping casks

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -13,7 +13,7 @@ module Bundle
 
       require "cask/caskroom"
 
-      @casks ||= Cask::Caskroom.casks.map(&:full_name)
+      @casks ||= Cask::Caskroom.casks.map(&:to_s)
       @casks.map { |cask| cask.chomp " (!)" }
             .uniq
     end

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -40,9 +40,9 @@ describe Bundle::CaskDumper do
     before do
       described_class.reset!
 
-      foo = instance_double("Cask::Cask", full_name: "foo")
-      bar = instance_double("Cask::Cask", full_name: "bar")
-      baz = instance_double("Cask::Cask", full_name: "baz")
+      foo = instance_double("Cask::Cask", to_s: "foo")
+      bar = instance_double("Cask::Cask", to_s: "bar")
+      baz = instance_double("Cask::Cask", to_s: "baz")
 
       allow(Bundle).to receive(:cask_installed?).and_return(true)
       allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar, baz])

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -16,8 +16,8 @@ describe Bundle::Dumper do
     Bundle::WhalebrewDumper.reset!
     Bundle::BrewServices.reset!
 
-    chrome = instance_double("Cask::Cask", full_name: "google-chrome")
-    java = instance_double("Cask::Cask", full_name: "java")
+    chrome = instance_double("Cask::Cask", to_s: "google-chrome")
+    java = instance_double("Cask::Cask", to_s: "java")
 
     allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java])
     allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava")

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -16,15 +16,16 @@ describe Bundle::Dumper do
     Bundle::WhalebrewDumper.reset!
     Bundle::BrewServices.reset!
 
-    chrome = instance_double("Cask::Cask", to_s: "google-chrome")
-    java = instance_double("Cask::Cask", to_s: "java")
+    chrome = instance_double("Cask::Cask", full_name: "google-chrome", to_s: "google-chrome")
+    java = instance_double("Cask::Cask", full_name: "java", to_s: "java")
+    iterm2beta = instance_double("Cask::Cask", full_name: "homebrew/cask-versions/iterm2-beta", to_s: "iterm2-beta")
 
-    allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java])
-    allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava")
+    allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java, iterm2beta])
+    allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava\niterm2-beta")
   end
 
   it "generates output" do
-    expect(dumper.build_brewfile).to eql("cask \"google-chrome\"\ncask \"java\"\n")
+    expect(dumper.build_brewfile).to eql("cask \"google-chrome\"\ncask \"java\"\ncask \"iterm2-beta\"\n")
   end
 
   it "determines the brewfile correctly" do

--- a/spec/stub/cask/cask.rb
+++ b/spec/stub/cask/cask.rb
@@ -2,7 +2,7 @@
 
 module Cask
   class Cask
-    def full_name
+    def to_s
       ""
     end
   end

--- a/spec/stub/cask/cask.rb
+++ b/spec/stub/cask/cask.rb
@@ -2,6 +2,10 @@
 
 module Cask
   class Cask
+    def full_name
+      ""
+    end
+
     def to_s
       ""
     end


### PR DESCRIPTION
When I switched to using `Cask::Caskroom` to get installed casks, I got the full name of the Cask (including the tap name, if any) instead of just the token. This PR should emulate the old behavior.

Fixes #866 