### PR TITLE
dump: include args and description for casks

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -30,26 +30,20 @@ module Bundle
     def dump(casks_required_by_formulae, describe: false)
       [
         (cask_list & casks_required_by_formulae).map do |cask_token|
-          dump_cask(cask_hash[cask_token], describe)
+          dump_cask(cask_hash[cask_token], describe: describe)
         end.join("\n"),
         (cask_list - casks_required_by_formulae).map do |cask_token|
-          dump_cask(cask_hash[cask_token], describe)
+          dump_cask(cask_hash[cask_token], describe: describe)
         end.join("\n"),
       ]
     end
 
-    def dump_cask(cask, describe)
-      description = if describe && cask.desc.present?
-        "# #{cask.desc}\n"
-      else
-        ""
-      end
+    def dump_cask(cask, describe:)
+      description = "# #{cask.desc}\n" if describe && cask.desc.present?
       config = if cask.config.present? && cask.config.explicit.present?
         cask.config.explicit.map do |k, v|
           "#{k}: \"#{v.sub(/^#{ENV['HOME']}/, "~")}\""
         end.join(",").prepend(", args: { ").concat(" }")
-      else
-        ""
       end
       "#{description}cask \"#{cask}\"#{config}"
     end

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -57,7 +57,7 @@ module Bundle
     end
 
     def installed_casks
-      @installed_casks ||= Bundle::CaskDumper.casks
+      @installed_casks ||= Bundle::CaskDumper.cask_list
     end
 
     def outdated_casks

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -62,7 +62,7 @@ module Bundle
       end
 
       def casks_to_uninstall(global: false, file: nil)
-        Bundle::CaskDumper.casks - kept_casks(global: global, file: file)
+        Bundle::CaskDumper.cask_list - kept_casks(global: global, file: file)
       end
 
       def formulae_to_uninstall(global: false, file: nil)

--- a/lib/bundle/dumper.rb
+++ b/lib/bundle/dumper.rb
@@ -17,7 +17,7 @@ module Bundle
       content = []
       content << TapDumper.dump
       casks_required_by_formulae = BrewDumper.cask_requirements
-      cask_before_formula, cask_after_formula = CaskDumper.dump(casks_required_by_formulae)
+      cask_before_formula, cask_after_formula = CaskDumper.dump(casks_required_by_formulae, describe: describe)
       content << cask_before_formula
       content << BrewDumper.dump(describe: describe, no_restart: no_restart)
       content << cask_after_formula

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -16,9 +16,18 @@ describe Bundle::Dumper do
     Bundle::WhalebrewDumper.reset!
     Bundle::BrewServices.reset!
 
-    chrome = instance_double("Cask::Cask", full_name: "google-chrome", to_s: "google-chrome")
-    java = instance_double("Cask::Cask", full_name: "java", to_s: "java")
-    iterm2beta = instance_double("Cask::Cask", full_name: "homebrew/cask-versions/iterm2-beta", to_s: "iterm2-beta")
+    chrome     = instance_double("Cask::Cask",
+                                 full_name: "google-chrome",
+                                 to_s:      "google-chrome",
+                                 config:    nil)
+    java       = instance_double("Cask::Cask",
+                                 full_name: "java",
+                                 to_s:      "java",
+                                 config:    nil)
+    iterm2beta = instance_double("Cask::Cask",
+                                 full_name: "homebrew/cask-versions/iterm2-beta",
+                                 to_s:      "iterm2-beta",
+                                 config:    nil)
 
     allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java, iterm2beta])
     allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava\niterm2-beta")


### PR DESCRIPTION
Fixes #594: fetch any arguments used when installing casks and include them in the `brew bundle dump` output, substituting the current user's home folder path with `~` if present. Also, prepend cask descriptions if `--describe` is passed (fixes #809).