### PR TITLE
Add support for greedy cask upgrades 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ brew "mysql@5.6", restart_service: true, link: true, conflicts_with: ["mysql"]
 cask "google-chrome"
 # 'brew install --cask --appdir=~/my-apps/Applications'
 cask "firefox", args: { appdir: "~/my-apps/Applications" }
+# always upgrade auto-updated or unversioned cask to latest version even if already installed
+cask "opera", greedy: true
 # 'brew install --cask' only if '/usr/libexec/java_home --failfast' fails
 cask "java" unless system "/usr/libexec/java_home --failfast"
 

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -68,17 +68,7 @@ module Bundle
 
     def dump_cask(cask, describe:)
       description = "# #{cask.desc}\n" if describe && cask.desc.present?
-      config = if cask.config.present? && cask.config.explicit.present?
-        # TODO: replace this logic with an actual call in Library/Homebrew/cask/
-        cask.config.explicit.map do |key, value|
-          if key.to_s == "languages"
-            key = "language"
-            value = value.join(",")
-          end
-
-          "#{key}: \"#{value.sub(/^#{ENV['HOME']}/, "~")}\""
-        end.join(", ").prepend(", args: { ").concat(" }")
-      end
+      config = ", args: { #{cask.config.explicit_s} }" if cask.config.present? && cask.config.explicit.present?
       "#{description}cask \"#{cask}\"#{config}"
     end
     private_class_method :dump_cask

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -14,10 +14,10 @@ module Bundle
       @cask_names ||= casks.map(&:to_s)
     end
 
-    def outdated_cask_names
+    def outdated_cask_names(greedy: false)
       return [] unless Bundle.cask_installed?
 
-      casks.select(&:outdated?)
+      casks.select { |c| c.outdated?(greedy: greedy) }
            .map(&:to_s)
     end
 

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -42,13 +42,16 @@ describe Bundle::CaskDumper do
 
       foo = instance_double("Cask::Cask", to_s: "foo", desc: nil, config: nil)
       baz = instance_double("Cask::Cask", to_s: "baz", desc: "Software", config: nil)
-      bar = instance_double("Cask::Cask", to_s:   "bar",
-                                          desc:   nil,
-                                          config: instance_double("Cask::Cask.config",
-                                                                  explicit: {
-                                                                    fontdir:   "/Library/Fonts",
-                                                                    languages: ["zh-TW"],
-                                                                  }))
+      bar = instance_double(
+        "Cask::Cask", to_s:   "bar",
+                      desc:   nil,
+                      config: instance_double("Cask::Cask.config",
+                                              explicit:   {
+                                                fontdir:   "/Library/Fonts",
+                                                languages: ["zh-TW"],
+                                              },
+                                              explicit_s: 'fontdir: "/Library/Fonts", language: "zh-TW"')
+      )
 
       allow(Bundle).to receive(:cask_installed?).and_return(true)
       allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar, baz])

--- a/spec/bundle/cask_installer_spec.rb
+++ b/spec/bundle/cask_installer_spec.rb
@@ -7,6 +7,10 @@ describe Bundle::CaskInstaller do
     Bundle::CaskInstaller.install("google-chrome")
   end
 
+  def do_greedy_install
+    Bundle::CaskInstaller.install("opera", greedy: true)
+  end
+
   describe ".installed_casks" do
     before do
       Bundle::CaskDumper.reset!
@@ -71,6 +75,20 @@ describe Bundle::CaskInstaller do
         expect(Bundle).to receive(:system).with("brew", "upgrade", "--cask", "google-chrome", verbose: false)
                                           .and_return(true)
         expect(do_install).to be(:success)
+      end
+    end
+
+    context "when cask is outdated and uses auto-update" do
+      before do
+        allow(described_class).to receive(:installed_casks).and_return(["opera"])
+        allow(described_class).to receive(:outdated_casks).and_return([])
+        allow(described_class).to receive(:all_outdated_casks).and_return(["opera"])
+      end
+
+      it "upgrades" do
+        expect(Bundle).to receive(:system).with("brew", "upgrade", "--cask", "opera", verbose: false)
+                                          .and_return(true)
+        expect(do_greedy_install).to be(:success)
       end
     end
 

--- a/spec/bundle/commands/install_command_spec.rb
+++ b/spec/bundle/commands/install_command_spec.rb
@@ -20,7 +20,7 @@ describe Bundle::Commands::Install do
       <<~EOS
         tap 'phinze/cask'
         brew 'mysql', conflicts_with: ['mysql56']
-        cask 'google-chrome'
+        cask 'google-chrome', greedy: true
         mas '1Password', id: 443987910
         whalebrew 'whalebrew/wget'
       EOS


### PR DESCRIPTION
Allow currently-installed casks with `auto_updates true` or `version :latest` to be upgraded if `greedy: true` is appended to their Brewfile entry. Solves #897.

Also, start using [`explicit_s`](https://github.com/Homebrew/brew/pull/10462) to generate explicit cask config lines.