### PR TITLE
Remove more `brew` and `Formula#to_hash` calls

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -135,7 +135,7 @@ module Bundle
     end
 
     def self.installed_formulae
-      @installed_formulae ||= Bundle::BrewDumper.formula_names
+      @installed_formulae ||= Bundle::BrewDumper.formulae.map { |f| f[:name] }
     end
 
     def self.upgradable_formulae
@@ -143,21 +143,23 @@ module Bundle
     end
 
     def self.outdated_formulae
-      @outdated_formulae ||= Bundle::BrewDumper.formulae.map { |f| f[:name] if f[:outdated?] }.compact
+      @outdated_formulae ||= formulae.map { |f| f[:name] if f[:outdated?] }.compact
     end
 
     def self.pinned_formulae
-      @pinned_formulae ||= Bundle::BrewDumper.formulae.map { |f| f[:name] if f[:pinned?] }.compact
+      @pinned_formulae ||= formulae.map { |f| f[:name] if f[:pinned?] }.compact
     end
 
     def self.linked_and_keg_only_formulae
-      @linked_and_keg_only_formulae ||= Bundle::BrewDumper.formulae.map { |f| f[:name] if f[:link?] == true }.compact
+      @linked_and_keg_only_formulae ||= formulae.map { |f| f[:name] if f[:link?] == true }.compact
     end
 
     def self.unlinked_and_not_keg_only_formulae
-      @unlinked_and_not_keg_only_formulae ||= Bundle::BrewDumper.formulae.map do |f|
-        f[:name] if f[:link?] == false
-      end.compact
+      @unlinked_and_not_keg_only_formulae ||= formulae.map { |f| f[:name] if f[:link?] == false }.compact
+    end
+
+    def self.formulae
+      Bundle::BrewDumper.formulae
     end
 
     private
@@ -183,8 +185,8 @@ module Bundle
         conflicts_with = Set.new
         conflicts_with += @conflicts_with_arg
 
-        if (formula_info = Bundle::BrewDumper.formula_info(@full_name)) &&
-           (formula_conflicts_with = formula_info[:conflicts_with])
+        if (formula = Bundle::BrewDumper.formulae_by_full_name(@full_name)) &&
+           (formula_conflicts_with = formula[:conflicts_with])
           conflicts_with += formula_conflicts_with
         end
 

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -29,15 +29,12 @@ module Bundle
       end
     end
 
-    def dump(casks_required_by_formulae, describe: false)
-      [
-        (cask_names & casks_required_by_formulae).map do |cask_token|
-          dump_cask(cask_hash[cask_token], describe: describe)
-        end.join("\n"),
-        (cask_names - casks_required_by_formulae).map do |cask_token|
-          dump_cask(cask_hash[cask_token], describe: describe)
-        end.join("\n"),
-      ]
+    def dump(describe: false)
+      casks.map do |cask|
+        description = "# #{cask.desc}\n" if describe && cask.desc.present?
+        config = ", args: { #{cask.config.explicit_s} }" if cask.config.present? && cask.config.explicit.present?
+        "#{description}cask \"#{cask}\"#{config}"
+      end.join("\n")
     end
 
     def formula_dependencies(cask_list)
@@ -58,19 +55,5 @@ module Bundle
       @casks ||= Cask::Caskroom.casks
     end
     private_class_method :casks
-
-    def cask_hash
-      return {} unless Bundle.cask_installed?
-
-      @cask_hash ||= casks.index_by(&:to_s)
-    end
-    private_class_method :cask_hash
-
-    def dump_cask(cask, describe:)
-      description = "# #{cask.desc}\n" if describe && cask.desc.present?
-      config = ", args: { #{cask.config.explicit_s} }" if cask.config.present? && cask.config.explicit.present?
-      "#{description}cask \"#{cask}\"#{config}"
-    end
-    private_class_method :dump_cask
   end
 end

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -29,7 +29,7 @@ module Bundle
           end
 
           if formulae.any?
-            Kernel.system "brew", "uninstall", "--force", *formulae
+            Kernel.system "brew", "uninstall", "--formula", "--force", *formulae
             puts "Uninstalled #{formulae.size} formula#{(formulae.size == 1) ? "" : "e"}"
           end
 

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -2,8 +2,6 @@
 
 require "exceptions"
 require "extend/ENV"
-require "formula"
-require "formulary"
 require "utils"
 
 module Bundle
@@ -25,6 +23,10 @@ module Bundle
         command_path = command_path.dirname.to_s
 
         brewfile = Bundle::Dsl.new(Brewfile.read(global: global, file: file))
+
+        require "formula"
+        require "formulary"
+
         ENV.deps = brewfile.entries.map do |entry|
           next unless entry.type == :brew
 

--- a/lib/bundle/dumper.rb
+++ b/lib/bundle/dumper.rb
@@ -16,11 +16,8 @@ module Bundle
     def build_brewfile(describe: false, no_restart: false)
       content = []
       content << TapDumper.dump
-      casks_required_by_formulae = BrewDumper.cask_requirements
-      cask_before_formula, cask_after_formula = CaskDumper.dump(casks_required_by_formulae, describe: describe)
-      content << cask_before_formula
       content << BrewDumper.dump(describe: describe, no_restart: no_restart)
-      content << cask_after_formula
+      content << CaskDumper.dump(describe: describe)
       content << MacAppStoreDumper.dump
       content << WhalebrewDumper.dump
       "#{content.reject(&:empty?).join("\n")}\n"

--- a/spec/bundle/brew_dumper_spec.rb
+++ b/spec/bundle/brew_dumper_spec.rb
@@ -2,751 +2,245 @@
 
 require "spec_helper"
 require "tsort"
+require "formula"
+require "tab"
 
 describe Bundle::BrewDumper do
   subject(:dumper) { described_class }
 
-  context "when no formula is installed" do
-    before do
-      described_class.reset!
-    end
-
-    it "returns empty list" do
-      expect(dumper.formulae).to be_empty
-    end
-
-    it "dumps as empty string" do
-      expect(dumper.dump).to eql("")
-    end
+  let(:foo) do
+    instance_double("Formula",
+                    name:                          "foo",
+                    desc:                          "foobar",
+                    oldname:                       "oldfoo",
+                    full_name:                     "qux/quuz/foo",
+                    aliases:                       ["foobar"],
+                    declared_runtime_dependencies: [],
+                    deps:                          [],
+                    conflicts:                     [],
+                    any_installed_prefix:          nil,
+                    linked?:                       false,
+                    keg_only?:                     true,
+                    pinned?:                       false,
+                    outdated?:                     false,
+                    bottle_defined?:               false)
   end
-
-  context "when Homebrew returns JSON with a malformed linked_keg" do
-    installed_data = [{
-      "name"                     => "foo",
-      "full_name"                => "homebrew/tap/foo",
-      "desc"                     => "",
-      "homepage"                 => "",
-      "oldname"                  => nil,
-      "aliases"                  => [],
-      "versions"                 => { "stable" => "1.0", "bottle" => false },
-      "revision"                 => 0,
-      "installed"                => [{
-        "version"            => "1.0",
-        "used_options"       => [],
-        "built_as_bottle"    => nil,
-        "poured_from_bottle" => true,
-      }],
-      "linked_keg"               => "fish",
-      "keg_only"                 => nil,
-      "dependencies"             => [],
-      "recommended_dependencies" => [],
-      "optional_dependencies"    => [],
-      "build_dependencies"       => [],
-      "conflicts_with"           => [],
-      "caveats"                  => nil,
-      "requirements"             => [],
-      "options"                  => [],
-      "bottle"                   => {},
-    }]
-
-    parsed_data = {
-      name:                     "foo",
-      full_name:                "homebrew/tap/foo",
-      desc:                     "",
-      oldname:                  nil,
-      aliases:                  [],
+  let(:foo_hash) do
+    {
+      aliases:                  ["foobar"],
       args:                     [],
-      version:                  nil,
+      bottle:                   false,
+      build_dependencies:       [],
+      conflicts_with:           [],
+      dependencies:             [],
+      desc:                     "foobar",
+      full_name:                "qux/quuz/foo",
       installed_as_dependency?: false,
       installed_on_request?:    false,
-      dependencies:             [],
-      recommended_dependencies: [],
-      optional_dependencies:    [],
-      build_dependencies:       [],
-      requirements:             [],
-      conflicts_with:           [],
-      pinned?:                  false,
-      outdated?:                false,
       link?:                    nil,
+      name:                     "foo",
+      oldname:                  "oldfoo",
+      outdated?:                false,
+      pinned?:                  false,
       poured_from_bottle?:      false,
+      version:                  nil,
     }
-
-    before do
-      described_class.reset!
-      allow(Formula).to receive(:[]).and_return(nil)
-      allow(Formula).to receive(:installed).and_return(installed_data)
-    end
-
-    it "returns no version" do
-      expect(dumper.formulae).to contain_exactly(parsed_data)
-    end
   end
-
-  context "formulae `foo` and `bar` are installed" do
-    before do
-      described_class.reset!
-      allow(Formula).to receive(:[]).and_return(
-        "name"                     => "foo",
-        "full_name"                => "homebrew/tap/foo",
-        "desc"                     => "",
-        "homepage"                 => "",
-        "oldname"                  => nil,
-        "aliases"                  => [],
-        "versions"                 => { "stable" => "1.0", "bottle" => false },
-        "revision"                 => 0,
-        "installed"                => [{
-          "version"              => "1.0",
-          "used_options"         => [],
-          "built_as_bottle"      => nil,
-          "poured_from_bottle"   => true,
-          "runtime_dependencies" => [],
-        }],
-        "linked_keg"               => "1.0",
-        "keg_only"                 => nil,
-        "dependencies"             => [],
-        "recommended_dependencies" => [],
-        "optional_dependencies"    => [],
-        "build_dependencies"       => [],
-        "runtime_dependencies"     => [],
-        "conflicts_with"           => [],
-        "caveats"                  => nil,
-        "requirements"             => [],
-        "options"                  => [],
-        "bottle"                   => {},
-      )
-      allow(Formula).to receive(:installed).and_return(
-        [
-          {
-            "name"                     => "foo",
-            "full_name"                => "homebrew/tap/foo",
-            "desc"                     => "",
-            "homepage"                 => "",
-            "oldname"                  => nil,
-            "aliases"                  => [],
-            "versions"                 => { "stable" => "1.0", "bottle" => false },
-            "revision"                 => 0,
-            "installed"                => [{
-              "version"                 => "1.0",
-              "used_options"            => [],
-              "built_as_bottle"         => nil,
-              "poured_from_bottle"      => true,
-              "installed_as_dependency" => false,
-              "installed_on_request"    => true,
-              "runtime_dependencies"    => [],
-            }],
-            "linked_keg"               => "1.0",
-            "keg_only"                 => nil,
-            "dependencies"             => [],
-            "recommended_dependencies" => [],
-            "optional_dependencies"    => [],
-            "build_dependencies"       => [],
-            "runtime_dependencies"     => [],
-            "conflicts_with"           => [],
-            "caveats"                  => nil,
-            "requirements"             => [],
-            "options"                  => [],
-            "bottle"                   => {},
+  let(:bar) do
+    linked_keg = Pathname("/usr/local").join("var").join("homebrew").join("linked").join("bar")
+    bottle_spec = instance_double("BottleSpecification",
+                                  cellar:    :any,
+                                  collector: {
+                                    big_sur: {
+                                      checksum: OpenStruct.new(hexdigest: "abcdef"),
+                                    },
+                                  },
+                                  rebuild:   0,
+                                  root_url:  "https://brew.sh/")
+    instance_double("Formula",
+                    name:                          "bar",
+                    desc:                          "barfoo",
+                    oldname:                       nil,
+                    full_name:                     "bar",
+                    aliases:                       [],
+                    declared_runtime_dependencies: [],
+                    deps:                          [],
+                    conflicts:                     [],
+                    any_installed_prefix:          nil,
+                    linked?:                       true,
+                    keg_only?:                     false,
+                    pinned?:                       true,
+                    outdated?:                     true,
+                    bottle_defined?:               true,
+                    linked_keg:                    linked_keg,
+                    stable:                        OpenStruct.new(bottle_specification: bottle_spec))
+  end
+  let(:bar_hash) do
+    {
+      aliases:                  [],
+      args:                     [],
+      bottle:                   {
+        cellar: ":any",
+        files:  {
+          big_sur: {
+            sha256: "abcdef",
+            url:    "https://brew.sh//foo-1.0.big_sur.bottle.tar.gz",
           },
-          {
-            "name"                     => "bar",
-            "full_name"                => "bar",
-            "desc"                     => "",
-            "homepage"                 => "",
-            "oldname"                  => nil,
-            "aliases"                  => [],
-            "versions"                 => { "stable" => "2.1", "bottle" => false },
-            "revision"                 => 0,
-            "installed"                => [{
-              "version"                 => "2.0",
-              "used_options"            => ["--with-a", "--with-b"],
-              "built_as_bottle"         => nil,
-              "poured_from_bottle"      => false,
-              "installed_as_dependency" => true,
-              "installed_on_request"    => true,
-              "runtime_dependencies"    => [{
-                "full_name" => "baz",
-                "version"   => "1.0",
-              }],
-            }],
-            "linked_keg"               => nil,
-            "keg_only"                 => nil,
-            "dependencies"             => [],
-            "recommended_dependencies" => [],
-            "optional_dependencies"    => [],
-            "build_dependencies"       => [],
-            "conflicts_with"           => [],
-            "caveats"                  => nil,
-            "requirements"             => [],
-            "options"                  => [],
-            "bottle"                   => {},
-            "pinned"                   => true,
-            "outdated"                 => true,
-          },
-        ],
+        },
+      },
+      build_dependencies:       [],
+      conflicts_with:           [],
+      dependencies:             [],
+      desc:                     "barfoo",
+      full_name:                "bar",
+      installed_as_dependency?: false,
+      installed_on_request?:    false,
+      link?:                    nil,
+      name:                     "bar",
+      oldname:                  nil,
+      outdated?:                true,
+      pinned?:                  true,
+      poured_from_bottle?:      true,
+      version:                  "1.0",
+    }
+  end
+  let(:baz) do
+    instance_double("Formula",
+                    name:                          "baz",
+                    desc:                          "",
+                    oldname:                       nil,
+                    full_name:                     "bazzles/bizzles/baz",
+                    aliases:                       [],
+                    declared_runtime_dependencies: [OpenStruct.new(name: "bar")],
+                    deps:                          [OpenStruct.new(name: "bar", build?: true)],
+                    conflicts:                     [],
+                    any_installed_prefix:          nil,
+                    linked?:                       false,
+                    keg_only?:                     false,
+                    pinned?:                       false,
+                    outdated?:                     false,
+                    bottle_defined?:               false)
+  end
+  let(:baz_hash) do
+    {
+      aliases:                  [],
+      args:                     [],
+      bottle:                   false,
+      build_dependencies:       ["bar"],
+      conflicts_with:           [],
+      dependencies:             ["bar"],
+      desc:                     "",
+      full_name:                "bazzles/bizzles/baz",
+      installed_as_dependency?: false,
+      installed_on_request?:    false,
+      link?:                    false,
+      name:                     "baz",
+      oldname:                  nil,
+      outdated?:                false,
+      pinned?:                  false,
+      poured_from_bottle?:      false,
+      version:                  nil,
+    }
+  end
+
+  before do
+    described_class.reset!
+  end
+
+  describe "#formulae" do
+    it "returns an empty array when no formulae are installed" do
+      expect(dumper.formulae).to be_empty
+    end
+  end
+
+  describe "#formulae_by_full_name" do
+    it "returns an empty hash when no formulae are installed" do
+      expect(dumper.formulae_by_full_name).to eql({})
+    end
+
+    it "returns an empty hash for an unavailable formula" do
+      expect(Formula).to receive(:[]).with("bar").and_raise(FormulaUnavailableError)
+      expect(dumper.formulae_by_full_name("bar")).to eql({})
+    end
+
+    it "exits on cyclic exceptions" do
+      expect(Formula).to receive(:installed).and_return([foo, bar, baz])
+      expect_any_instance_of(Bundle::BrewDumper::Topo).to receive(:tsort).and_raise(
+        TSort::Cyclic,
+        'topological sort failed: ["foo", "bar"]',
       )
+      expect { dumper.formulae_by_full_name }.to raise_error(SystemExit)
     end
 
-    it "returns foo and bar with their information" do # rubocop:disable RSpec/ExampleLength
-      expect(dumper.formulae).to contain_exactly(
-        {
-          name:                     "foo",
-          full_name:                "homebrew/tap/foo",
-          desc:                     "",
-          oldname:                  nil,
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          installed_as_dependency?: false,
-          installed_on_request?:    true,
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-          link?:                    nil,
-          poured_from_bottle?:      true,
-        },
-        name:                     "bar",
-        full_name:                "bar",
-        desc:                     "",
-        oldname:                  nil,
-        aliases:                  [],
-        args:                     ["with-a", "with-b"],
-        version:                  "2.0",
-        installed_as_dependency?: true,
-        installed_on_request?:    true,
-        dependencies:             ["baz"],
-        recommended_dependencies: [],
-        optional_dependencies:    [],
-        build_dependencies:       [],
-        requirements:             [],
-        conflicts_with:           [],
-        pinned?:                  true,
-        outdated?:                true,
-        link?:                    false,
-        poured_from_bottle?:      false,
-      )
+    it "returns a hash for a formula" do
+      expect(Formula).to receive(:[]).with("qux/quuz/foo").and_return(foo)
+      expect(dumper.formulae_by_full_name("qux/quuz/foo")).to eql(foo_hash)
     end
 
-    it "dumps as foo and bar with args and link" do
-      expect(dumper.dump).to \
-        eql("brew \"bar\", args: [\"with-a\", \"with-b\"], link: false\nbrew \"homebrew/tap/foo\"")
-    end
-
-    it "formula_info returns the formula" do
-      expect(dumper.formula_info("foo")[:name]).to eql("foo")
+    it "returns an array for all formulae" do
+      expect(Formula).to receive(:installed).and_return([foo, bar, baz])
+      expect(bar.linked_keg).to receive(:realpath).and_return(OpenStruct.new(basename: "1.0"))
+      expect(Tab).to receive(:for_keg).with(bar.linked_keg).and_return \
+        instance_double("Tab",
+                        installed_as_dependency: false,
+                        installed_on_request:    false,
+                        poured_from_bottle:      true,
+                        runtime_dependencies:    [],
+                        used_options:            [])
+      expect(dumper.formulae_by_full_name).to eql({
+                                                    "bar"                 => bar_hash,
+                                                    "qux/quuz/foo"        => foo_hash,
+                                                    "bazzles/bizzles/baz" => baz_hash,
+                                                  })
     end
   end
 
-  context "HEAD formulae are installed" do
-    subject(:formulae_list) { described_class.formulae }
-
-    before do
-      described_class.reset!
-      allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "bar",
-          full_name:                "homebrew/tap/bar",
-          aliases:                  [],
-          args:                     ["HEAD"],
-          version:                  "HEAD",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-      ]
-    end
-
-    it "returns with args `HEAD`" do
-      expect(formulae_list.first[:args]).to include("HEAD")
+  describe "#formulae_by_name" do
+    it "returns a hash for a formula" do
+      expect(Formula).to receive(:[]).with("foo").and_return(foo)
+      expect(dumper.formulae_by_name("foo")).to eql(foo_hash)
     end
   end
 
-  context "A formula link to the old keg" do
-    subject(:formulae_list) { described_class.formulae }
-
-    before do
-      described_class.reset!
-      allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "foo",
-          full_name:                "homebrew/tap/foo",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-      ]
-    end
-
-    it "returns with linked keg" do
-      expect(formulae_list[0][:version]).to eql("1.0")
+  describe "#dump" do
+    it "returns a dump string with installed formulae" do
+      expect(Formula).to receive(:installed).and_return([foo, bar, baz])
+      expected = <<~EOS
+        # barfoo
+        brew "bar"
+        brew "bazzles/bizzles/baz", link: false
+        # foobar
+        brew "qux/quuz/foo"
+      EOS
+      expect(dumper.dump(describe: true)).to eql(expected.chomp)
     end
   end
 
-  context "A formula with no linked keg" do
-    subject(:formulae_list) { described_class.formulae }
-
-    before do
-      described_class.reset!
-      allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "foo",
-          full_name:                "homebrew/tap/foo",
-          aliases:                  [],
-          args:                     [],
-          version:                  "2.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-      ]
+  describe "#formula_aliases" do
+    it "returns an empty string when no formulae are installed" do
+      expect(dumper.formula_aliases).to eql({})
     end
 
-    it "returns with last one" do
-      expect(formulae_list[0][:version]).to eql("2.0")
-    end
-  end
-
-  context "several formulae with dependant relations" do
-    before do
-      described_class.reset!
-      allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "a",
-          full_name:                "a",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             ["b"],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "b",
-          full_name:                "b",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [{ "name" => "foo", "default_formula" => "c", "cask" => "bar" }],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "c",
-          full_name:                "homebrew/tap/c",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-      ]
-    end
-
-    it "returns formulae with correct order" do
-      expect(dumper.formulae.map { |f| f[:name] }).to eq %w[c b a]
-    end
-
-    it "returns all the cask requirements" do
-      expect(dumper.cask_requirements).to eq %w[bar]
-    end
-  end
-
-  context "formulae with unsorted dependencies" do
-    before do
-      described_class.reset!
-      allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "a",
-          full_name:                "a",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             ["b", "d", "c"],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "b",
-          full_name:                "b",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "c",
-          full_name:                "c",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "d",
-          full_name:                "d",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-      ]
-    end
-
-    it "returns formulae with correct order" do
-      expect(dumper.formulae.map { |f| f[:name] }).to eq %w[b c d a]
-    end
-
-    context "when performing a topological sort" do
-      before do
-        allow_any_instance_of(Bundle::BrewDumper::Topo).to \
-          receive(:tsort)
-          .and_raise(TSort::Cyclic, "topological sort failed: [\"libidn2\", \"wget\"]")
-        allow_any_instance_of(Object).to receive(:odie) { raise }
-      end
-
-      it "dies on cyclic exceptions" do
-        expect { dumper.formulae }.to raise_error(TSort::Cyclic)
-      end
-    end
-  end
-
-  context "when `describe` is false" do
-    subject(:dump) { described_class.dump(describe: false) }
-
-    before do
-      described_class.reset!
-      allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "a",
-          full_name:                "a",
-          desc:                     "z",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             ["b", "d", "c"],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "b",
-          full_name:                "b",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-      ]
-    end
-
-    it "does not output a comment with dependency description" do
-      expect(dump).not_to include("#")
-    end
-  end
-
-  context "when `describe` is true" do
-    subject(:dump) { described_class.dump(describe: true) }
-
-    before do
-      described_class.reset!
-      allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "a",
-          full_name:                "a",
-          desc:                     "z",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             ["b", "d", "c"],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "q",
-          full_name:                "q",
-          desc:                     "q\nq",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             ["a", "b"],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "b",
-          full_name:                "b",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-      ]
-    end
-
-    it "outputs a comment on the line before a dependency with a description" do
-      expect(dump).to include("# z")
-    end
-
-    it "outputs a comment for each line in the formula's desc before a dependency with a description" do
-      expect(dump).to include("# q\n# q")
-    end
-
-    it "does not output a comment if a formula lacks a description" do
-      lines_with_comments = dump.split.select { |line| line.include?("#") }
-      expect(lines_with_comments.size).to eq(3)
-    end
-  end
-
-  describe "restarting" do
-    before do
-      described_class.reset!
-      allow(described_class).to receive(:formulae_info).and_return [
-        {
-          name:                     "a",
-          full_name:                "a",
-          desc:                     "z",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             ["b", "d", "c"],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-        {
-          name:                     "b",
-          full_name:                "b",
-          aliases:                  [],
-          args:                     [],
-          version:                  "1.0",
-          dependencies:             [],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        },
-      ]
-      allow(Bundle::BrewServices).to receive(:started?).with("a").and_return(true)
-      allow(Bundle::BrewServices).to receive(:started?).with("b").and_return(false)
-    end
-
-    it "adds restart_service for started services" do
-      expect(described_class.dump).to include('brew "a", restart_service: true')
-    end
-
-    it "does not add restart_service for stopped services" do
-      expect(described_class.dump).to include('brew "b"')
-      expect(described_class.dump).not_to include('brew "b", restart_service: true')
-    end
-
-    context "when `no_restart` is true" do
-      subject(:dump) { described_class.dump(no_restart: true) }
-
-      it "does not add a restart_service bit if the service is running" do
-        expect(dump).not_to include("restart_service")
-      end
-    end
-  end
-
-  context "when order of args for a formula is different in different environment" do
-    let(:formula_info) do
-      [
-        [{
-          name:                     "a",
-          full_name:                "a",
-          aliases:                  [],
-          args:                     ["with-1", "with-2"],
-          version:                  "1.0",
-          dependencies:             ["b"],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        }],
-        [{
-          name:                     "a",
-          full_name:                "a",
-          aliases:                  [],
-          args:                     ["with-2", "with-1"],
-          version:                  "1.0",
-          dependencies:             ["b"],
-          recommended_dependencies: [],
-          optional_dependencies:    [],
-          build_dependencies:       [],
-          requirements:             [],
-          conflicts_with:           [],
-          pinned?:                  false,
-          outdated?:                false,
-        }],
-      ]
-    end
-
-    let(:dump_lines) do
-      formula_info.map do |info|
-        described_class.reset!
-        allow(described_class).to receive(:formulae_info).and_return(info)
-        described_class.dump
-      end
-    end
-
-    it "dumps args in same order" do
-      expect(dump_lines[0]).to eql(dump_lines[1])
+    it "returns a hash with installed formulae aliases" do
+      expect(Formula).to receive(:installed).and_return([foo, bar, baz])
+      expect(dumper.formula_aliases).to eql({
+                                              "qux/quuz/foobar" => "qux/quuz/foo",
+                                              "foobar"          => "qux/quuz/foo",
+                                            })
     end
   end
 
   describe "#formula_oldnames" do
-    before do
-      described_class.reset!
-      formula_info = [{
-        name:                     "a",
-        full_name:                "homebrew/versions/a",
-        oldname:                  "aold",
-        aliases:                  [],
-        args:                     ["with-1", "with-2"],
-        version:                  "1.0",
-        dependencies:             ["b"],
-        recommended_dependencies: [],
-        optional_dependencies:    [],
-        build_dependencies:       [],
-        requirements:             [],
-        conflicts_with:           [],
-        pinned?:                  false,
-        outdated?:                false,
-      }]
-      allow(described_class).to receive(:formulae_info).and_return(formula_info)
+    it "returns an empty string when no formulae are installed" do
+      expect(dumper.formula_oldnames).to eql({})
     end
 
-    it "works" do
-      expect(described_class.formula_oldnames["aold"]).to eql "homebrew/versions/a"
-    end
-  end
-
-  describe "#formula_info" do
-    it "handles formula syntax errors" do
-      allow(Formula).to receive(:[]).and_raise(NoMethodError)
-      expect(described_class).to receive(:opoo).once
-      described_class.instance_variable_set("@formula_info_name", nil)
-      described_class.formula_info("foo")
-    end
-  end
-
-  describe "#formulae_info" do
-    it "handles formula syntax errors" do
-      allow(Formula).to receive(:installed).and_raise(NoMethodError)
-      expect(described_class).to receive(:opoo).once
-      described_class.formulae_info
-    end
-  end
-
-  describe "#formula_hash" do
-    let(:f) { OpenStruct.new }
-
-    it "handles formula syntax errors" do
-      allow(f).to receive(:to_hash).and_raise(NoMethodError)
-      expect(described_class).to receive(:opoo).once
-      described_class.formula_hash(f)
+    it "returns a hash with installed formulae old names" do
+      expect(Formula).to receive(:installed).and_return([foo, bar, baz])
+      expect(dumper.formula_oldnames).to eql({
+                                               "qux/quuz/oldfoo" => "qux/quuz/foo",
+                                               "oldfoo"          => "qux/quuz/foo",
+                                             })
     end
   end
 end

--- a/spec/bundle/brew_installer_spec.rb
+++ b/spec/bundle/brew_installer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "formula"
 
 describe Bundle::BrewInstaller do
   let(:formula) { "mysql" }
@@ -83,7 +84,7 @@ describe Bundle::BrewInstaller do
 
   context "conflicts_with option is provided" do
     before do
-      allow(Bundle::BrewDumper).to receive(:formula_info).and_return(
+      allow(Bundle::BrewDumper).to receive(:formulae_by_full_name).and_return(
         name:           "mysql",
         conflicts_with: ["mysql55"],
       )

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -16,7 +16,7 @@ describe Bundle::CaskDumper do
     end
 
     it "dumps as empty string" do
-      expect(dumper.dump([])).to eql(["", ""])
+      expect(dumper.dump).to eql("")
     end
   end
 
@@ -32,7 +32,7 @@ describe Bundle::CaskDumper do
     end
 
     it "dumps as empty string" do
-      expect(dumper.dump([])).to eql(["", ""])
+      expect(dumper.dump).to eql("")
     end
   end
 
@@ -55,7 +55,6 @@ describe Bundle::CaskDumper do
 
       allow(Bundle).to receive(:cask_installed?).and_return(true)
       allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar, baz])
-      allow(described_class).to receive(:`).and_return("foo\nbar\nbaz")
     end
 
     it "returns list %w[foo bar baz]" do
@@ -63,10 +62,13 @@ describe Bundle::CaskDumper do
     end
 
     it "dumps as `cask 'baz'` and `cask 'foo' cask 'bar'` plus descriptions and config values" do
-      expect(dumper.dump(%w[baz], describe: true)).to eql [
-        "# Software\ncask \"baz\"",
-        "cask \"foo\"\ncask \"bar\", args: { fontdir: \"/Library/Fonts\", language: \"zh-TW\" }",
-      ]
+      expected = <<~EOS
+        cask "foo"
+        cask "bar", args: { fontdir: "/Library/Fonts", language: "zh-TW" }
+        # Software
+        cask "baz"
+      EOS
+      expect(dumper.dump(describe: true)).to eql(expected.chomp)
     end
   end
 

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -125,7 +125,7 @@ describe Bundle::Commands::Cleanup do
     end
 
     it "uninstalls formulae" do
-      expect(Kernel).to receive(:system).with("brew", "uninstall", "--force", "a", "b")
+      expect(Kernel).to receive(:system).with("brew", "uninstall", "--formula", "--force", "a", "b")
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
       expect { described_class.run(force: true) }.to output(/Uninstalled 2 formulae/).to_stdout
     end

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "cask"
 
 describe Bundle::Dumper do
   subject(:dumper) { described_class }
@@ -30,7 +31,6 @@ describe Bundle::Dumper do
                                  config:    nil)
 
     allow(Cask::Caskroom).to receive(:casks).and_return([chrome, java, iterm2beta])
-    allow(Bundle::CaskDumper).to receive(:`).and_return("google-chrome\njava\niterm2-beta")
   end
 
   it "generates output" do

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -71,18 +71,13 @@ describe Bundle::Locker do
         allow(locker).to receive(:lockfile).and_return(lockfile)
         allow(brew_options).to receive(:deep_stringify_keys)
           .and_return("restart_service" => true)
-        allow(locker).to receive(:`).with("brew info --json=v2 --installed --quiet").and_return <<~EOS
-          {
-            "formulae": [{
-                "name":"mysql",
-                "bottle":{
-                  "stable":{}
-                }
-              }
-            ]
-          }
-        EOS
-        allow(locker).to receive(:`).with("brew list --versions").and_return("mysql 8.0.18")
+        allow(Bundle::BrewDumper).to receive(:formulae_by_full_name).with("mysql").and_return({
+                                                                                                name:    "mysql",
+                                                                                                version: "8.0.18",
+                                                                                                bottle:  {
+                                                                                                  stable: {},
+                                                                                                },
+                                                                                              })
         allow(locker).to receive(:`).with("whalebrew list").and_return("COMMAND   IMAGE\nwget      whalebrew/wget")
         allow(locker).to receive(:`)
           .with("docker image inspect whalebrew/wget --format '{{ index .RepoDigests 0 }}'")

--- a/spec/stub/exceptions.rb
+++ b/spec/stub/exceptions.rb
@@ -2,3 +2,6 @@
 
 class UsageError < RuntimeError
 end
+
+class FormulaUnavailableError < RuntimeError
+end

--- a/spec/stub/formula.rb
+++ b/spec/stub/formula.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "software_spec"
 
 class Formula
   def initialize(name)
-    @prefix = Pathname.new("/usr/local")
+    @prefix = Pathname("/usr/local")
     @name = name
   end
 
@@ -28,11 +29,73 @@ class Formula
     true
   end
 
+  def linked_keg
+    @prefix.join("var").join("homebrew").join("linked").join(@name)
+  end
+
+  def linked?
+    true
+  end
+
   def self.installed
     []
   end
 
   def self.[](name)
     new(name)
+  end
+
+  def bottle_defined?
+    true
+  end
+
+  def stable
+    OpenStruct.new(bottle_specification: BottleSpecification.new)
+  end
+
+  attr_reader :name
+
+  def full_name
+    @name
+  end
+
+  def desc
+    ""
+  end
+
+  def oldname
+    nil
+  end
+
+  def aliases
+    []
+  end
+
+  def runtime_dependencies
+    []
+  end
+
+  def declared_runtime_dependencies
+    []
+  end
+
+  def deps
+    []
+  end
+
+  def conflicts
+    []
+  end
+
+  def pinned?
+    false
+  end
+
+  def outdated?
+    false
+  end
+
+  def any_installed_prefix
+    opt_prefix
   end
 end

--- a/spec/stub/formulary.rb
+++ b/spec/stub/formulary.rb
@@ -4,4 +4,6 @@ class Formulary
   def self.factory(name)
     Formula.new(name)
   end
+
+  def self.enable_factory_cache!; end
 end

--- a/spec/stub/global.rb
+++ b/spec/stub/global.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-HOMEBREW_PREFIX = Pathname.new("/usr/local").freeze
-HOMEBREW_REPOSITORY = Pathname.new("/usr/local/Homebrew").freeze
+HOMEBREW_PREFIX = Pathname("/usr/local").freeze
+HOMEBREW_REPOSITORY = Pathname("/usr/local/Homebrew").freeze
 HOMEBREW_VERSION = "2.6.0"

--- a/spec/stub/software_spec.rb
+++ b/spec/stub/software_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class BottleSpecification
+  def cellar
+    :any
+  end
+
+  def collector
+    {}
+  end
+
+  def rebuild
+    0
+  end
+
+  def root_url
+    "https://brew.sh"
+  end
+end
+
+class Bottle
+  class Filename
+    def bintray
+      "foo-1.0.big_sur.bottle.tar.gz"
+    end
+
+    def self.create(_formula, _tag, _rebuild)
+      new
+    end
+  end
+end

--- a/spec/stub/tab.rb
+++ b/spec/stub/tab.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Tab
+  def self.for_keg(_keg)
+    Tab.new
+  end
+
+  def used_options
+    []
+  end
+
+  def installed_as_dependency; end
+
+  def installed_on_request; end
+
+  def runtime_dependencies
+    []
+  end
+
+  def poured_from_bottle; end
+end

--- a/spec/stub/utils.rb
+++ b/spec/stub/utils.rb
@@ -3,7 +3,11 @@
 require "pathname"
 
 def which(command)
-  Pathname.new("/usr/local/bin/#{command}")
+  Pathname("/usr/local/bin/#{command}")
 end
 
 def opoo(*); end
+
+def odie(*)
+  exit 1
+end


### PR DESCRIPTION
This speeds up `brew bundle check` and `brew bundle` considerably on
my machine:

```console
$ hyperfine --warmup=1 "git checkout master; brew bundle check --global" "git checkout bundle_no_shell_hash; brew bundle check --global"
Benchmark #1: git checkout master; brew bundle check --global
  Time (mean ± σ):      4.944 s ±  0.258 s    [User: 1.440 s, System: 1.937 s]
  Range (min … max):    4.584 s …  5.338 s    10 runs

Benchmark #2: git checkout bundle_no_shell_hash; brew bundle check --global
  Time (mean ± σ):      4.500 s ±  0.100 s    [User: 1.136 s, System: 1.440 s]
  Range (min … max):    4.385 s …  4.684 s    10 runs

Summary
  'git checkout bundle_no_shell_hash; brew bundle check --global' ran
    1.10 ± 0.06 times faster than 'git checkout master; brew bundle check --global'

$ hyperfine --warmup=1 "git checkout master; brew bundle --global --cleanup" "git checkout bundle_no_shell_hash; brew bundle --global --cleanup"
Benchmark #1: git checkout master; brew bundle --global --cleanup
  Time (mean ± σ):     47.380 s ±  1.015 s    [User: 16.881 s, System: 10.906 s]
  Range (min … max):   45.887 s … 49.077 s    10 runs

Benchmark #2: git checkout bundle_no_shell_hash; brew bundle --global --cleanup
  Time (mean ± σ):     43.119 s ± 12.083 s    [User: 18.376 s, System: 9.671 s]
  Range (min … max):   32.361 s … 68.910 s    10 runs

Summary
  'git checkout bundle_no_shell_hash; brew bundle --global --cleanup' ran
    1.10 ± 0.31 times faster than 'git checkout master; brew bundle --global --cleanup
```

There's been a lot of changes made here so the chances of regressions or bugs are non-zero.