### PR TITLE
Use runtime_dependencies rather than declared_runtime_dependencies

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -144,7 +144,7 @@ module Bundle
         runtime_dependencies = tab.runtime_dependencies.map { |d| d["full_name"] }.compact
         poured_from_bottle = tab.poured_from_bottle
       else
-        runtime_dependencies = formula.declared_runtime_dependencies.map(&:name)
+        runtime_dependencies = formula.runtime_dependencies.map(&:name)
       end
 
       # TODO: use Formula#bottle_hash when in a stable release

--- a/spec/bundle/brew_dumper_spec.rb
+++ b/spec/bundle/brew_dumper_spec.rb
@@ -10,20 +10,20 @@ describe Bundle::BrewDumper do
 
   let(:foo) do
     instance_double("Formula",
-                    name:                          "foo",
-                    desc:                          "foobar",
-                    oldname:                       "oldfoo",
-                    full_name:                     "qux/quuz/foo",
-                    aliases:                       ["foobar"],
-                    declared_runtime_dependencies: [],
-                    deps:                          [],
-                    conflicts:                     [],
-                    any_installed_prefix:          nil,
-                    linked?:                       false,
-                    keg_only?:                     true,
-                    pinned?:                       false,
-                    outdated?:                     false,
-                    bottle_defined?:               false)
+                    name:                 "foo",
+                    desc:                 "foobar",
+                    oldname:              "oldfoo",
+                    full_name:            "qux/quuz/foo",
+                    aliases:              ["foobar"],
+                    runtime_dependencies: [],
+                    deps:                 [],
+                    conflicts:            [],
+                    any_installed_prefix: nil,
+                    linked?:              false,
+                    keg_only?:            true,
+                    pinned?:              false,
+                    outdated?:            false,
+                    bottle_defined?:      false)
   end
   let(:foo_hash) do
     {
@@ -58,22 +58,22 @@ describe Bundle::BrewDumper do
                                   rebuild:   0,
                                   root_url:  "https://brew.sh/")
     instance_double("Formula",
-                    name:                          "bar",
-                    desc:                          "barfoo",
-                    oldname:                       nil,
-                    full_name:                     "bar",
-                    aliases:                       [],
-                    declared_runtime_dependencies: [],
-                    deps:                          [],
-                    conflicts:                     [],
-                    any_installed_prefix:          nil,
-                    linked?:                       true,
-                    keg_only?:                     false,
-                    pinned?:                       true,
-                    outdated?:                     true,
-                    bottle_defined?:               true,
-                    linked_keg:                    linked_keg,
-                    stable:                        OpenStruct.new(bottle_specification: bottle_spec))
+                    name:                 "bar",
+                    desc:                 "barfoo",
+                    oldname:              nil,
+                    full_name:            "bar",
+                    aliases:              [],
+                    runtime_dependencies: [],
+                    deps:                 [],
+                    conflicts:            [],
+                    any_installed_prefix: nil,
+                    linked?:              true,
+                    keg_only?:            false,
+                    pinned?:              true,
+                    outdated?:            true,
+                    bottle_defined?:      true,
+                    linked_keg:           linked_keg,
+                    stable:               OpenStruct.new(bottle_specification: bottle_spec))
   end
   let(:bar_hash) do
     {
@@ -106,20 +106,20 @@ describe Bundle::BrewDumper do
   end
   let(:baz) do
     instance_double("Formula",
-                    name:                          "baz",
-                    desc:                          "",
-                    oldname:                       nil,
-                    full_name:                     "bazzles/bizzles/baz",
-                    aliases:                       [],
-                    declared_runtime_dependencies: [OpenStruct.new(name: "bar")],
-                    deps:                          [OpenStruct.new(name: "bar", build?: true)],
-                    conflicts:                     [],
-                    any_installed_prefix:          nil,
-                    linked?:                       false,
-                    keg_only?:                     false,
-                    pinned?:                       false,
-                    outdated?:                     false,
-                    bottle_defined?:               false)
+                    name:                 "baz",
+                    desc:                 "",
+                    oldname:              nil,
+                    full_name:            "bazzles/bizzles/baz",
+                    aliases:              [],
+                    runtime_dependencies: [OpenStruct.new(name: "bar")],
+                    deps:                 [OpenStruct.new(name: "bar", build?: true)],
+                    conflicts:            [],
+                    any_installed_prefix: nil,
+                    linked?:              false,
+                    keg_only?:            false,
+                    pinned?:              false,
+                    outdated?:            false,
+                    bottle_defined?:      false)
   end
   let(:baz_hash) do
     {

--- a/spec/stub/formula.rb
+++ b/spec/stub/formula.rb
@@ -75,10 +75,6 @@ class Formula
     []
   end
 
-  def declared_runtime_dependencies
-    []
-  end
-
   def deps
     []
   end


### PR DESCRIPTION
`declared_runtime_dependencies` is a protected method. Not sure how I didn't hit this during testing...

Fixes #905
Fixes #906