### PR TITLE
rubocop: Fix RSpec/ContextWording offenses

### DIFF
--- a/spec/bundle/brew_installer_spec.rb
+++ b/spec/bundle/brew_installer_spec.rb
@@ -12,8 +12,8 @@ describe Bundle::BrewInstaller do
     installer.run
   end
 
-  context "restart_service option is true" do
-    context "formula is installed successfully" do
+  context "when the restart_service option is true" do
+    context "when the formula is installed successfully" do
       before do
         allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(:success)
       end
@@ -24,7 +24,7 @@ describe Bundle::BrewInstaller do
       end
     end
 
-    context "formula isn't installed" do
+    context "when a formula isn't installed" do
       before do
         allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(:failed)
       end
@@ -36,7 +36,7 @@ describe Bundle::BrewInstaller do
     end
   end
 
-  context "link option is true" do
+  context "when the link option is true" do
     before do
       allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(:success)
     end
@@ -47,7 +47,7 @@ describe Bundle::BrewInstaller do
     end
   end
 
-  context "link option is false" do
+  context "when the link option is false" do
     before do
       allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(:success)
     end
@@ -58,7 +58,7 @@ describe Bundle::BrewInstaller do
     end
   end
 
-  context "link option is nil and formula is unlinked and not keg-only" do
+  context "when the link option is nil and formula is unlinked and not keg-only" do
     before do
       allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(:success)
     end
@@ -70,7 +70,7 @@ describe Bundle::BrewInstaller do
     end
   end
 
-  context "link option is nil and formula is linked and keg-only" do
+  context "when the link option is nil and formula is linked and keg-only" do
     before do
       allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(:success)
     end
@@ -82,7 +82,7 @@ describe Bundle::BrewInstaller do
     end
   end
 
-  context "conflicts_with option is provided" do
+  context "when the conflicts_with option is provided" do
     before do
       allow(Bundle::BrewDumper).to receive(:formulae_by_full_name).and_return(
         name:           "mysql",
@@ -258,7 +258,7 @@ describe Bundle::BrewInstaller do
       expect(described_class.new(formula).start_service?).to be(false)
     end
 
-    context "start_service option is true" do
+    context "when the start_service option is true" do
       it "is true" do
         expect(described_class.new(formula, start_service: true).start_service?).to be(true)
       end
@@ -270,13 +270,13 @@ describe Bundle::BrewInstaller do
       expect(described_class.new(formula).restart_service?).to be(false)
     end
 
-    context "restart_service option is true" do
+    context "when the restart_service option is true" do
       it "is true" do
         expect(described_class.new(formula, restart_service: true).restart_service?).to be(true)
       end
     end
 
-    context "restart_service option is changed" do
+    context "when the restart_service option is changed" do
       it "is true" do
         expect(described_class.new(formula, restart_service: :changed).restart_service?).to be(true)
       end
@@ -288,7 +288,7 @@ describe Bundle::BrewInstaller do
       expect(described_class.new(formula).restart_service_needed?).to be(false)
     end
 
-    context "if a service is unchanged" do
+    context "when a service is unchanged" do
       before do
         allow_any_instance_of(described_class).to receive(:changed?).and_return(false)
       end
@@ -302,7 +302,7 @@ describe Bundle::BrewInstaller do
       end
     end
 
-    context "if a service is changed" do
+    context "when a service is changed" do
       before do
         allow_any_instance_of(described_class).to receive(:changed?).and_return(true)
       end

--- a/spec/bundle/brew_services_spec.rb
+++ b/spec/bundle/brew_services_spec.rb
@@ -25,7 +25,7 @@ describe Bundle::BrewServices do
   end
 
   context "when brew-services is installed" do
-    context "stops the service" do
+    context "when the service is stopped" do
       it "when the service is started" do
         allow(described_class).to receive(:started_services).and_return(%w[nginx])
         expect(Bundle).to receive(:system).with("brew", "services", "stop", "nginx", verbose: false).and_return(true)

--- a/spec/bundle/brewfile_spec.rb
+++ b/spec/bundle/brewfile_spec.rb
@@ -33,7 +33,7 @@ describe Bundle::Brewfile do
         expect(path).to eq(expected_pathname)
       end
 
-      context "and HOMEBREW_BUNDLE_FILE is set" do
+      context "with a configured HOMEBREW_BUNDLE_FILE" do
         let(:env_bundle_file_value) { "/path/to/Brewfile" }
 
         it "returns the value specified by `file` path" do
@@ -41,7 +41,7 @@ describe Bundle::Brewfile do
         end
       end
 
-      context "and HOMEBREW_BUNDLE_FILE is `` (empty)" do
+      context "with an empty HOMEBREW_BUNDLE_FILE" do
         let(:env_bundle_file_value) { "" }
 
         it "returns the value specified by `file` path" do
@@ -58,7 +58,7 @@ describe Bundle::Brewfile do
         expect(path).to eq(expected_pathname)
       end
 
-      context "and HOMEBREW_BUNDLE_FILE is set" do
+      context "with a configured HOMEBREW_BUNDLE_FILE" do
         let(:env_bundle_file_value) { "/path/to/Brewfile" }
 
         it "returns the value specified by `file` path" do
@@ -66,7 +66,7 @@ describe Bundle::Brewfile do
         end
       end
 
-      context "and HOMEBREW_BUNDLE_FILE is `` (empty)" do
+      context "with an empty HOMEBREW_BUNDLE_FILE" do
         let(:env_bundle_file_value) { "" }
 
         it "returns the value specified by `file` path" do
@@ -83,7 +83,7 @@ describe Bundle::Brewfile do
         expect(path).to eq(expected_pathname)
       end
 
-      context "and HOMEBREW_BUNDLE_FILE is set" do
+      context "with a configured HOMEBREW_BUNDLE_FILE" do
         let(:env_bundle_file_value) { "/path/to/Brewfile" }
 
         it "returns the value specified by `file` path" do
@@ -91,7 +91,7 @@ describe Bundle::Brewfile do
         end
       end
 
-      context "and HOMEBREW_BUNDLE_FILE is `` (empty)" do
+      context "with an empty HOMEBREW_BUNDLE_FILE" do
         let(:env_bundle_file_value) { "" }
 
         it "returns the value specified by `file` path" do
@@ -107,7 +107,7 @@ describe Bundle::Brewfile do
           expect(path).to eq(expected_pathname)
         end
 
-        context "and HOMEBREW_BUNDLE_FILE is set" do
+        context "with a configured HOMEBREW_BUNDLE_FILE" do
           let(:env_bundle_file_value) { "/path/to/Brewfile" }
 
           it "returns the value specified by `file` path" do
@@ -115,7 +115,7 @@ describe Bundle::Brewfile do
           end
         end
 
-        context "and HOMEBREW_BUNDLE_FILE is `` (empty)" do
+        context "with an empty HOMEBREW_BUNDLE_FILE" do
           let(:env_bundle_file_value) { "" }
 
           it "returns the value specified by `file` path" do
@@ -133,7 +133,7 @@ describe Bundle::Brewfile do
         expect(path).to eq(expected_pathname)
       end
 
-      context "and HOMEBREW_BUNDLE_FILE is set" do
+      context "when HOMEBREW_BUNDLE_FILE is set" do
         let(:env_bundle_file_value) { "/path/to/Brewfile" }
 
         it "returns the value specified by `file` path" do
@@ -141,7 +141,7 @@ describe Bundle::Brewfile do
         end
       end
 
-      context "and HOMEBREW_BUNDLE_FILE is `` (empty)" do
+      context "when HOMEBREW_BUNDLE_FILE is `` (empty)" do
         let(:env_bundle_file_value) { "" }
 
         it "returns the value specified by `file` path" do
@@ -150,14 +150,14 @@ describe Bundle::Brewfile do
       end
     end
 
-    context "and HOMEBREW_BUNDLE_FILE has a value" do
+    context "when HOMEBREW_BUNDLE_FILE has a value" do
       let(:env_bundle_file_value) { "/path/to/Brewfile" }
 
       it "returns the expected path" do
         expect(path).to eq(Pathname.new(env_bundle_file_value))
       end
 
-      context "that is `` (empty)" do
+      describe "that is `` (empty)" do
         let(:env_bundle_file_value) { "" }
 
         it "defaults to `${PWD}/Brewfile`" do
@@ -165,7 +165,7 @@ describe Bundle::Brewfile do
         end
       end
 
-      context "that is `nil`" do
+      describe "that is `nil`" do
         let(:env_bundle_file_value) { nil }
 
         it "defaults to `${PWD}/Brewfile`" do

--- a/spec/bundle/commands/check_command_spec.rb
+++ b/spec/bundle/commands/check_command_spec.rb
@@ -26,7 +26,7 @@ describe Bundle::Commands::Check do
     end
   end
 
-  context "no dependencies are specified" do
+  context "when no dependencies are specified" do
     it "does not raise an error" do
       allow_any_instance_of(Pathname).to receive(:read).and_return("")
       allow_any_instance_of(Bundle::Dsl).to receive(:entries).and_return([])
@@ -110,7 +110,7 @@ describe Bundle::Commands::Check do
       expect { do_check }.not_to raise_error
     end
 
-    context "restart_service is true" do
+    context "when restart_service is true" do
       it "raises an error" do
         allow_any_instance_of(Pathname).to \
           receive(:read).and_return("brew 'abc', restart_service: true\nbrew 'def', restart_service: true")
@@ -120,7 +120,7 @@ describe Bundle::Commands::Check do
       end
     end
 
-    context "start_service is true" do
+    context "when start_service is true" do
       it "raises an error" do
         allow_any_instance_of(Pathname).to \
           receive(:read).and_return("brew 'abc', start_service: true\nbrew 'def', start_service: true")

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Bundle::Commands::Cleanup do
-  context "read Brewfile and currently installation" do
+  describe "read Brewfile and current installation" do
     before do
       described_class.reset!
       allow_any_instance_of(Pathname).to receive(:read).and_return <<~EOS
@@ -71,7 +71,7 @@ describe Bundle::Commands::Cleanup do
     end
   end
 
-  context "no formulae to uninstall and no taps to untap" do
+  context "when there are no formulae to uninstall and no taps to untap" do
     before do
       described_class.reset!
       allow(described_class).to receive(:casks_to_uninstall).and_return([])
@@ -86,7 +86,7 @@ describe Bundle::Commands::Cleanup do
     end
   end
 
-  context "there are casks to uninstall" do
+  context "when there are casks to uninstall" do
     before do
       described_class.reset!
       allow(described_class).to receive(:casks_to_uninstall).and_return(%w[a b])
@@ -101,7 +101,7 @@ describe Bundle::Commands::Cleanup do
     end
   end
 
-  context "there are casks to zap" do
+  context "when there are casks to zap" do
     before do
       described_class.reset!
       allow(described_class).to receive(:casks_to_uninstall).and_return(%w[a b])
@@ -116,7 +116,7 @@ describe Bundle::Commands::Cleanup do
     end
   end
 
-  context "there are formulae to uninstall" do
+  context "when there are formulae to uninstall" do
     before do
       described_class.reset!
       allow(described_class).to receive(:casks_to_uninstall).and_return([])
@@ -131,7 +131,7 @@ describe Bundle::Commands::Cleanup do
     end
   end
 
-  context "there are taps to untap" do
+  context "when there are taps to untap" do
     before do
       described_class.reset!
       allow(described_class).to receive(:casks_to_uninstall).and_return([])
@@ -146,7 +146,7 @@ describe Bundle::Commands::Cleanup do
     end
   end
 
-  context "there are casks and formulae to uninstall and taps to untap but without passing `--force`" do
+  context "when there are casks and formulae to uninstall and taps to untap but without passing `--force`" do
     before do
       described_class.reset!
       allow(described_class).to receive(:casks_to_uninstall).and_return(%w[a b])
@@ -162,7 +162,7 @@ describe Bundle::Commands::Cleanup do
     end
   end
 
-  context "there is brew cleanup output" do
+  context "when there is brew cleanup output" do
     before do
       described_class.reset!
       allow(described_class).to receive(:casks_to_uninstall).and_return([])

--- a/spec/bundle/commands/list_command_spec.rb
+++ b/spec/bundle/commands/list_command_spec.rb
@@ -11,7 +11,7 @@ describe Bundle::Commands::List do
     allow_any_instance_of(IO).to receive(:puts)
   end
 
-  context "outputs dependencies to stdout" do
+  describe "outputs dependencies to stdout" do
     before do
       allow_any_instance_of(Pathname).to receive(:read).and_return \
         "tap 'phinze/cask'\nbrew 'mysql', " \
@@ -23,7 +23,7 @@ describe Bundle::Commands::List do
       expect { list }.to output("mysql\n").to_stdout
     end
 
-    context "limiting when certain options are passed" do
+    describe "limiting when certain options are passed" do
       types_and_deps = {
         taps:      "phinze/cask",
         brews:     "mysql",

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -54,7 +54,7 @@ describe Bundle::Locker do
   end
 
   describe ".lock" do
-    context "writes Brewfile.lock.json" do
+    describe "writes Brewfile.lock.json" do
       let(:lockfile) { Pathname("Brewfile.json.lock") }
       let(:brew_options) { { restart_service: true } }
       let(:entries) do
@@ -85,7 +85,7 @@ describe Bundle::Locker do
         allow(Bundle::WhalebrewDumper).to receive(:images).and_return(["whalebrew/wget"])
       end
 
-      context "on macOS" do
+      context "when on macOS" do
         before do
           allow(OS).to receive(:mac?).and_return(true)
 
@@ -106,7 +106,7 @@ describe Bundle::Locker do
         end
       end
 
-      context "on Linux" do
+      context "when on Linux" do
         before do
           allow(OS).to receive(:mac?).and_return(false)
           allow(OS).to receive(:linux?).and_return(true)

--- a/spec/bundle/mac_app_store_dumper_spec.rb
+++ b/spec/bundle/mac_app_store_dumper_spec.rb
@@ -36,7 +36,7 @@ describe Bundle::MacAppStoreDumper do
     end
   end
 
-  context "apps `foo`, `bar` and `baz` are installed" do
+  context "when apps `foo`, `bar` and `baz` are installed" do
     before do
       described_class.reset!
       allow(Bundle).to receive(:mas_installed?).and_return(true)

--- a/spec/bundle/tap_dumper_spec.rb
+++ b/spec/bundle/tap_dumper_spec.rb
@@ -19,7 +19,7 @@ describe Bundle::TapDumper do
     end
   end
 
-  context "there are tap `bitbucket/bar`, `homebrew/baz` and `homebrew/foo`" do
+  context "with `bitbucket/bar`, `homebrew/baz` and `homebrew/foo` taps" do
     before do
       described_class.reset!
       bar = instance_double("Tap", name: "bitbucket/bar", custom_remote?: true,

--- a/spec/bundle/whalebrew_dumper_spec.rb
+++ b/spec/bundle/whalebrew_dumper_spec.rb
@@ -54,7 +54,7 @@ describe Bundle::WhalebrewDumper do
       allow(dumper).to receive(:images).and_return(["whalebrew/wget", "whalebrew/dig"])
     end
 
-    context "images are installed" do
+    context "when images are installed" do
       let(:expected_whalebrew_dump) do
         %Q(whalebrew "whalebrew/wget"\nwhalebrew "whalebrew/dig")
       end

--- a/spec/bundle/whalebrew_installer_spec.rb
+++ b/spec/bundle/whalebrew_installer_spec.rb
@@ -60,7 +60,7 @@ describe Bundle::WhalebrewInstaller do
       expect { do_install }.not_to raise_error
     end
 
-    context "requested image is already installed" do
+    context "when the requested image is already installed" do
       before do
         allow(described_class).to receive(:image_installed?).with("whalebrew/wget").and_return(true)
       end

--- a/spec/bundle_utils_spec.rb
+++ b/spec/bundle_utils_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Bundle do
-  context "system call succeed" do
+  context "when the system call succeeds" do
     it "omits all stdout output if verbose is false" do
       expect { described_class.system "echo", "foo", verbose: false }.not_to output.to_stdout_from_any_process
     end
@@ -13,7 +13,7 @@ describe Bundle do
     end
   end
 
-  context "system call failed" do
+  context "when the system call fails" do
     before do
       allow_any_instance_of(Process::Status).to receive(:success?).and_return(false)
     end
@@ -27,7 +27,7 @@ describe Bundle do
     end
   end
 
-  context "check for homebrew/cask", :needs_macos do
+  context "when checking for homebrew/cask", :needs_macos do
     it "finds it when present" do
       allow(File).to receive(:directory?).with("#{HOMEBREW_PREFIX}/Caskroom").and_return(true)
       allow(File).to receive(:directory?)
@@ -37,14 +37,14 @@ describe Bundle do
     end
   end
 
-  context "check for brew services", :needs_macos do
+  context "when checking for brew services", :needs_macos do
     it "finds it when present" do
       allow(described_class).to receive(:which).and_return(true)
       expect(described_class.services_installed?).to be(true)
     end
   end
 
-  context "check for mas", :needs_macos do
+  context "when checking for mas", :needs_macos do
     it "finds it when present" do
       allow(described_class).to receive(:which).and_return(true)
       expect(described_class.mas_installed?).to be(true)


### PR DESCRIPTION
- This is newly enabled by https://github.com/Homebrew/brew/pull/10658.
