### PR TITLE
exec: Allow the use of commands not in the PATH

### DIFF
--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -17,10 +17,10 @@ module Bundle
         command = args.first
 
         # For commands which aren't either absolute or relative
-        unless command.include? "/"
+        if command.exclude? "/"
           # Save the command path, since this will be blown away by superenv
           command_path = which(command)
-          raise "command was not found in your PATH: #{command}" if command_path.nil?
+          raise "command was not found in your PATH: #{command}" if command_path.blank?
 
           command_path = command_path.dirname.to_s
         end
@@ -47,7 +47,7 @@ module Bundle
         ENV.prepend_path "PATH", pkgconfig.opt_bin.to_s if pkgconfig.any_version_installed?
 
         # Ensure the Ruby path we saved goes before anything else, if the command was in the PATH
-        ENV.prepend_path "PATH", command_path unless command_path.nil?
+        ENV.prepend_path "PATH", command_path if command_path.present?
 
         exec(*args)
       end

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -16,11 +16,14 @@ module Bundle
 
         command = args.first
 
-        # Save the command path, since this will be blown away by superenv
-        command_path = which(command)
-        raise "command was not found in your PATH: #{command}" if command_path.nil?
+        # For commands which aren't either absolute or relative
+        unless command.include? "/"
+          # Save the command path, since this will be blown away by superenv
+          command_path = which(command)
+          raise "command was not found in your PATH: #{command}" if command_path.nil?
 
-        command_path = command_path.dirname.to_s
+          command_path = command_path.dirname.to_s
+        end
 
         brewfile = Bundle::Dsl.new(Brewfile.read(global: global, file: file))
 
@@ -43,8 +46,8 @@ module Bundle
         pkgconfig = Formulary.factory("pkg-config")
         ENV.prepend_path "PATH", pkgconfig.opt_bin.to_s if pkgconfig.any_version_installed?
 
-        # Ensure the Ruby path we saved goes before anything else
-        ENV.prepend_path "PATH", command_path
+        # Ensure the Ruby path we saved goes before anything else, if the command was in the PATH
+        ENV.prepend_path "PATH", command_path unless command_path.nil?
 
         exec(*args)
       end

--- a/spec/bundle/commands/exec_command_spec.rb
+++ b/spec/bundle/commands/exec_command_spec.rb
@@ -52,5 +52,34 @@ describe Bundle::Commands::Exec do
         .and_return("brew 'openssl'")
       described_class.run("bundle", "install")
     end
+
+    describe "when running a command which exists but is not on the PATH" do
+      it "does not raise if the command is a relative path with current directory indicator" do
+        allow(described_class).to receive(:exec).with("./configure").and_return(nil)
+        expect(described_class).not_to receive(:which)
+        allow_any_instance_of(Pathname).to receive(:read)
+          .and_return("brew 'zlib'")
+
+        expect { described_class.run("./configure") }.not_to raise_error
+      end
+
+      it "does not raise if the command is a relative path without current directory indicator" do
+        allow(described_class).to receive(:exec).with("bin/install").and_return(nil)
+        expect(described_class).not_to receive(:which)
+        allow_any_instance_of(Pathname).to receive(:read)
+          .and_return("brew 'zlib'")
+
+        expect { described_class.run("bin/install") }.not_to raise_error
+      end
+
+      it "does not raise if the command is an absolute path" do
+        allow(described_class).to receive(:exec).with("/Users/admin/Downloads/command").and_return(nil)
+        expect(described_class).not_to receive(:which)
+        allow_any_instance_of(Pathname).to receive(:read)
+          .and_return("brew 'zlib'")
+
+        expect { described_class.run("/Users/admin/Downloads/command") }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This extends `brew bundle exec` with the ability to run a command which isn't in the path, for example, my use case was running a `./configure` script using the Brewfile magic, but this wasn't supported.

My patch basically just skips the storage of the path to the command in `command_path` as well as the related null if the command has a directory separator in it anywhere, and then uses `exec` as normal.

In effect, this brings it up to acting more like a shell would, meaning you can run a configure script via `brew bundle exec` as `./configure`, but not as `configure`. On the other hand, you can now run something like `brew bundle exec bin/setup`, or pass an absolute path to an executable.

Specs have been added for the three types of paths this should interact with; absolute and relative paths, and relative paths which do not contain a `.` indicating the current directory.

Note that this branch does not have 100% code coverage as requested in CONTRIBUTING.md, but this is not due to this change, and in fact already the case on `master`: https://github.com/Homebrew/homebrew-bundle/runs/1976844086?check_suite_focus=true#step:9:47