### PR TITLE
brew_dumper: fix topological sort debugging output.

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -210,7 +210,7 @@ module Bundle
                       .map { |name| @formulae_by_full_name[name] || @formulae_by_name[name] }
                       .uniq { |f| f[:full_name] }
     rescue TSort::Cyclic => e
-      e.message =~ /\["(.*)", "(.*)"\]/
+      e.message =~ /\["([^"]*)".*"([^"]*)"\]/
       cycle_first = Regexp.last_match(1)
       cycle_last = Regexp.last_match(2)
       odie e.message if !cycle_first || !cycle_last


### PR DESCRIPTION
The current regex expression cannot handle more than 2 items in the message.

```ruby
e.message =~ /\["(.*)", "(.*)"\]/   # = 'topological sort failed: ["python@3.9", "util-linux", "gettext", "libxml2"]'
cycle_first = Regexp.last_match(1)  # = 'python@3.9", "util-linux", "gettext'
cycle_last = Regexp.last_match(2)   # = 'libxml2'
```


```console
$ brew bundle dump 
Error: Formulae dependency graph sorting failed (likely due to a circular dependency):
python@3.9", "util-linux", "gettext: 
libxml2: ["gdbm", "openssl@1.1", "ncurses", "readline", "zlib", "sqlite", "xz", "bzip2", "libffi", "unzip", "python@3.9"]
Please run the following commands and try again:
  brew update
  brew uninstall --ignore-dependencies --force python@3.9", "util-linux", "gettext libxml2
  brew install python@3.9", "util-linux", "gettext libxml2
```

After:

```ruby
e.message =~ /\["([^"]*)".*"([^"]*)"\]/  # = 'topological sort failed: ["python@3.9", "util-linux", "gettext", "libxml2"]'
cycle_first = Regexp.last_match(1)       # = 'python@3.9'
cycle_last = Regexp.last_match(2)        # = 'libxml2'
```

```console
$ brew bundle dump
Error: Formulae dependency graph sorting failed (likely due to a circular dependency):
python@3.9: ["gdbm", "mpdecimal", "openssl@1.1", "ncurses", "readline", "zlib", "sqlite", "xz", "bzip2", "expat", "libffi", "unzip", "util-linux"]
libxml2: ["gdbm", "openssl@1.1", "ncurses", "readline", "zlib", "sqlite", "xz", "bzip2", "libffi", "unzip", "python@3.9"]
Please run the following commands and try again:
  brew update
  brew uninstall --ignore-dependencies --force python@3.9 libxml2
  brew install python@3.9 libxml2
```