### PR TITLE
Use codecov action instead of gem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,5 @@ jobs:
 
     - name: Run RSpec tests
       run: bundle exec rspec
-      env:
-        CODECOV_TOKEN: d8abdd06-9193-47d3-9da9-b4b25064e49b
+      
+    - uses: codecov/codecov-action@967e2b38a85a62bd61be5529ada27ebc109948c2

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "activesupport"
-  gem "codecov", require: false
   gem "rspec"
-  gem "simplecov"
+  gem "simplecov", require: false
+  gem "simplecov-cobertura", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    codecov (0.5.1)
-      simplecov (>= 0.15, < 0.22)
     concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
     docile (1.3.5)
@@ -32,6 +30,8 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (1.4.2)
+      simplecov (~> 0.8)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
     tzinfo (2.0.4)
@@ -43,9 +43,9 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  codecov
   rspec
   simplecov
+  simplecov-cobertura
 
 BUNDLED WITH
    1.17.3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,13 +9,32 @@ def linux?
 end
 
 require "simplecov"
+require "simplecov-cobertura"
+
 SimpleCov.start do
   add_filter "/spec/stub/"
   add_filter "/vendor/"
+
+  formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::CoberturaFormatter,
+  ]
+  formatter SimpleCov::Formatter::MultiFormatter.new(formatters)
+
   if macos?
     minimum_coverage 100
   else
     minimum_coverage 97
+  end
+
+  command_name "Job #{ENV["TEST_ENV_NUMBER"]}" if ENV["TEST_ENV_NUMBER"]
+end
+
+# may be unnecessary for homebrew-bundle, is present in brew spec_helper
+if macos? && ENV["TEST_ENV_NUMBER"]
+  SimpleCov.at_exit do
+    result = SimpleCov.result
+    result.format! if ParallelTests.number_of_running_processes <= 1
   end
 end
 
@@ -36,16 +55,6 @@ Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").sort.each do |file|
 
   require file
 end
-
-formatters = [SimpleCov::Formatter::HTMLFormatter]
-
-if macos? && ENV["CODECOV_TOKEN"]
-  require "codecov"
-
-  formatters << SimpleCov::Formatter::Codecov
-end
-
-SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
 
 require "bundler"
 require "rspec/support/object_formatter"


### PR DESCRIPTION
* Adds codecov action at end of test run
* Adds simplecov-cobertura gem
* Remove codecov gem
* No need to require simplecov, at least according to [this][1]

Closes #949 since it obsoletes the need to upgrade the codecov gem

[1]: https://github.com/simplecov-ruby/simplecov#getting-started