### PR TITLE
mac_app_store_dumper: match name non-greedily

### DIFF
--- a/lib/bundle/mac_app_store_dumper.rb
+++ b/lib/bundle/mac_app_store_dumper.rb
@@ -13,7 +13,7 @@ module Bundle
     def apps
       @apps ||= if Bundle.mas_installed?
         `mas list 2>/dev/null`.split("\n").map do |app|
-          app_details = app.match(/\A(?<id>\d+)\s+(?<name>.*)\s+\((?<version>[\d.]*)\)\Z/)
+          app_details = app.match(/\A(?<id>\d+)\s+(?<name>.*?)\s+\((?<version>[\d.]*)\)\Z/)
 
           # Only add the application details should we have a valid match.
           [app_details[:id], app_details[:name]] if app_details

--- a/spec/bundle/mac_app_store_dumper_spec.rb
+++ b/spec/bundle/mac_app_store_dumper_spec.rb
@@ -133,4 +133,32 @@ describe Bundle::MacAppStoreDumper do
       expect(dumper.dump).to eq(expected_mas_dumped_output.strip)
     end
   end
+
+  context "with the new format after mas-cli/mas#339" do
+    let(:new_mas_output) do
+      <<~HEREDOC
+        1440147259  AdGuard for Safari  (1.9.13)
+        497799835   Xcode               (12.5)
+        425424353   The Unarchiver      (4.3.1)
+      HEREDOC
+    end
+
+    let(:expected_app_details_array) do
+      [
+        ["1440147259", "AdGuard for Safari"],
+        ["497799835", "Xcode"],
+        ["425424353", "The Unarchiver"],
+      ]
+    end
+
+    before do
+      described_class.reset!
+      allow(Bundle).to receive(:mas_installed?).and_return(true)
+      allow(described_class).to receive(:`).and_return(new_mas_output)
+    end
+
+    it "parses the app names without trailing whitespace" do
+      expect(dumper.apps).to eql(expected_app_details_array)
+    end
+  end
 end


### PR DESCRIPTION
This fixes parsing with the format used after the merge of https://github.com/mas-cli/mas/pull/339:

    emily@yuyuko ~> mas list
    1440147259  AdGuard for Safari  (1.9.13)
    497799835   Xcode               (12.5)
    425424353   The Unarchiver      (4.3.1)
    …

Before:

    irb(main):002:0> app.match(/\A(?<id>\d+)\s+(?<name>.*)\s+\((?<version>[\d.]*)\)\Z/)
    => #<MatchData "1440147259  AdGuard for Safari  (1.9.13)" id:"1440147259" name:"AdGuard for Safari " version:"1.9.13">

After:

    irb(main):003:0> app.match(/\A(?<id>\d+)\s+(?<name>.*?)\s+\((?<version>[\d.]*)\)\Z/)
    => #<MatchData "1440147259  AdGuard for Safari  (1.9.13)" id:"1440147259" name:"AdGuard for Safari" version:"1.9.13">

Fixes #952.