### PR TITLE
bundle: use HOMEBREW_BREW_FILE

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -75,20 +75,20 @@ module Bundle
       when true
         unless linked_and_keg_only?
           puts "Force-linking #{@name} formula." if verbose
-          Bundle.system("brew", "link", "--force", @name, verbose: verbose)
+          Bundle.system(HOMEBREW_BREW_FILE, "link", "--force", @name, verbose: verbose)
         end
       when false
         unless unlinked_and_not_keg_only?
           puts "Unlinking #{@name} formula." if verbose
-          Bundle.system("brew", "unlink", @name, verbose: verbose)
+          Bundle.system(HOMEBREW_BREW_FILE, "unlink", @name, verbose: verbose)
         end
       when nil
         if unlinked_and_not_keg_only?
           puts "Linking #{@name} formula." if verbose
-          Bundle.system("brew", "link", @name, verbose: verbose)
+          Bundle.system(HOMEBREW_BREW_FILE, "link", @name, verbose: verbose)
         elsif linked_and_keg_only?
           puts "Unlinking #{@name} formula." if verbose
-          Bundle.system("brew", "unlink", @name, verbose: verbose)
+          Bundle.system(HOMEBREW_BREW_FILE, "unlink", @name, verbose: verbose)
         end
       end
     end
@@ -204,7 +204,7 @@ module Bundle
             It is currently installed and conflicts with #{@name}.
           EOS
         end
-        return false unless Bundle.system("brew", "unlink", conflict, verbose: verbose)
+        return false unless Bundle.system(HOMEBREW_BREW_FILE, "unlink", conflict, verbose: verbose)
 
         if @restart_service
           puts "Stopping #{conflict} service (if it is running)." if verbose
@@ -217,7 +217,7 @@ module Bundle
 
     def install!(verbose:)
       puts "Installing #{@name} formula. It is not currently installed." if verbose
-      unless Bundle.system("brew", "install", "--formula", @full_name, *@args, verbose: verbose)
+      unless Bundle.system(HOMEBREW_BREW_FILE, "install", "--formula", @full_name, *@args, verbose: verbose)
         @changed = nil
         return :failed
       end
@@ -235,7 +235,7 @@ module Bundle
       end
 
       puts "Upgrading #{@name} formula. It is installed but not up-to-date." if verbose
-      unless Bundle.system("brew", "upgrade", "--formula", @name, verbose: verbose)
+      unless Bundle.system(HOMEBREW_BREW_FILE, "upgrade", "--formula", @name, verbose: verbose)
         @changed = nil
         return :failed
       end

--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -11,14 +11,14 @@ module Bundle
     def stop(name, verbose: false)
       return true unless started?(name)
 
-      return unless Bundle.system "brew", "services", "stop", name, verbose: verbose
+      return unless Bundle.system HOMEBREW_BREW_FILE, "services", "stop", name, verbose: verbose
 
       started_services.delete(name)
       true
     end
 
     def restart(name, verbose: false)
-      return unless Bundle.system "brew", "services", "restart", name, verbose: verbose
+      return unless Bundle.system HOMEBREW_BREW_FILE, "services", "restart", name, verbose: verbose
 
       started_services << name
       true

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -18,7 +18,7 @@ module Bundle
         if !no_upgrade && (outdated_casks.include?(name) || all_outdated_casks.include?(name) && greedy)
           status = "#{greedy ? "may not be" : "not"} up-to-date"
           puts "Upgrading #{name} cask. It is installed but #{status}." if verbose
-          return :failed unless Bundle.system "brew", "upgrade", "--cask", full_name, verbose: verbose
+          return :failed unless Bundle.system HOMEBREW_BREW_FILE, "upgrade", "--cask", full_name, verbose: verbose
 
           return :success
         end
@@ -38,7 +38,7 @@ module Bundle
 
       puts "Installing #{name} cask. It is not currently installed." if verbose
 
-      return :failed unless Bundle.system "brew", "install", "--cask", full_name, *args, verbose: verbose
+      return :failed unless Bundle.system HOMEBREW_BREW_FILE, "install", "--cask", full_name, *args, verbose: verbose
 
       installed_casks << name
       :success

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -24,18 +24,18 @@ module Bundle
         if force
           if casks.any?
             args = zap ? ["--zap"] : []
-            Kernel.system "brew", "uninstall", "--cask", *args, "--force", *casks
+            Kernel.system HOMEBREW_BREW_FILE, "uninstall", "--cask", *args, "--force", *casks
             puts "Uninstalled #{casks.size} cask#{(casks.size == 1) ? "" : "s"}"
           end
 
           if formulae.any?
-            Kernel.system "brew", "uninstall", "--formula", "--force", *formulae
+            Kernel.system HOMEBREW_BREW_FILE, "uninstall", "--formula", "--force", *formulae
             puts "Uninstalled #{formulae.size} formula#{(formulae.size == 1) ? "" : "e"}"
           end
 
-          Kernel.system "brew", "untap", *taps if taps.any?
+          Kernel.system HOMEBREW_BREW_FILE, "untap", *taps if taps.any?
 
-          cleanup = system_output_no_stderr("brew", "cleanup")
+          cleanup = system_output_no_stderr(HOMEBREW_BREW_FILE, "cleanup")
           puts cleanup unless cleanup.empty?
         else
           if casks.any?
@@ -53,7 +53,7 @@ module Bundle
             puts Formatter.columns taps
           end
 
-          cleanup = system_output_no_stderr("brew", "cleanup", "--dry-run")
+          cleanup = system_output_no_stderr(HOMEBREW_BREW_FILE, "cleanup", "--dry-run")
           unless cleanup.empty?
             puts "Would `brew cleanup`:"
             puts cleanup

--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -14,7 +14,7 @@ module Bundle
     def install(name, id, no_upgrade: false, verbose: false)
       unless Bundle.mas_installed?
         puts "Installing mas. It is not currently installed." if verbose
-        Bundle.system "brew", "install", "mas", verbose: verbose
+        Bundle.system HOMEBREW_BREW_FILE, "install", "mas", verbose: verbose
         raise "Unable to install #{name} app. mas installation failed." unless Bundle.mas_installed?
       end
 

--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -12,9 +12,9 @@ module Bundle
 
       puts "Installing #{name} tap. It is not currently installed." if verbose
       success = if options[:clone_target]
-        Bundle.system "brew", "tap", name, options[:clone_target], verbose: verbose
+        Bundle.system HOMEBREW_BREW_FILE, "tap", name, options[:clone_target], verbose: verbose
       else
-        Bundle.system "brew", "tap", name, verbose: verbose
+        Bundle.system HOMEBREW_BREW_FILE, "tap", name, verbose: verbose
       end
 
       return :failed unless success

--- a/lib/bundle/whalebrew_installer.rb
+++ b/lib/bundle/whalebrew_installer.rb
@@ -11,7 +11,7 @@ module Bundle
     def install(name, verbose: false, **_options)
       unless Bundle.whalebrew_installed?
         puts "Installing whalebrew. It is not currently installed." if verbose
-        Bundle.system "brew", "install", "whalebrew", verbose: verbose
+        Bundle.system HOMEBREW_BREW_FILE, "install", "whalebrew", verbose: verbose
         raise "Unable to install #{name} app. Whalebrew installation failed." unless Bundle.whalebrew_installed?
       end
 

--- a/spec/bundle/brew_installer_spec.rb
+++ b/spec/bundle/brew_installer_spec.rb
@@ -42,7 +42,8 @@ describe Bundle::BrewInstaller do
     end
 
     it "links formula" do
-      expect(Bundle).to receive(:system).with("brew", "link", "--force", "mysql", verbose: false).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "link", "--force", "mysql",
+                                              verbose: false).and_return(true)
       described_class.install(formula, link: true)
     end
   end
@@ -53,7 +54,7 @@ describe Bundle::BrewInstaller do
     end
 
     it "unlinks formula" do
-      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql", verbose: false).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql", verbose: false).and_return(true)
       described_class.install(formula, link: false)
     end
   end
@@ -65,7 +66,7 @@ describe Bundle::BrewInstaller do
 
     it "links formula" do
       allow_any_instance_of(described_class).to receive(:unlinked_and_not_keg_only?).and_return(true)
-      expect(Bundle).to receive(:system).with("brew", "link", "mysql", verbose: false).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "link", "mysql", verbose: false).and_return(true)
       described_class.install(formula, link: nil)
     end
   end
@@ -77,7 +78,7 @@ describe Bundle::BrewInstaller do
 
     it "unlinks formula" do
       allow_any_instance_of(described_class).to receive(:linked_and_keg_only?).and_return(true)
-      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql", verbose: false).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql", verbose: false).and_return(true)
       described_class.install(formula, link: nil)
     end
   end
@@ -93,8 +94,10 @@ describe Bundle::BrewInstaller do
     end
 
     def sane?(verbose:)
-      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql55", verbose: verbose).and_return(true)
-      expect(Bundle).to receive(:system).with("brew", "unlink", "mysql56", verbose: verbose).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql55",
+                                              verbose: verbose).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "unlink", "mysql56",
+                                              verbose: verbose).and_return(true)
       expect(Bundle::BrewServices).to receive(:stop).with("mysql55", verbose: verbose).and_return(true)
       expect(Bundle::BrewServices).to receive(:stop).with("mysql56", verbose: verbose).and_return(true)
       expect(Bundle::BrewServices).to receive(:restart).with(formula, verbose: verbose).and_return(true)
@@ -185,14 +188,14 @@ describe Bundle::BrewInstaller do
 
       it "install formula" do
         expect(Bundle).to receive(:system)
-          .with("brew", "install", "--formula", formula, "--with-option", verbose: false)
+          .with(HOMEBREW_BREW_FILE, "install", "--formula", formula, "--with-option", verbose: false)
           .and_return(true)
         expect(do_install).to be(:success)
       end
 
       it "reports a failure" do
         expect(Bundle).to receive(:system)
-          .with("brew", "install", "--formula", formula, "--with-option", verbose: false)
+          .with(HOMEBREW_BREW_FILE, "install", "--formula", formula, "--with-option", verbose: false)
           .and_return(false)
         expect(do_install).to be(:failed)
       end
@@ -211,13 +214,13 @@ describe Bundle::BrewInstaller do
         end
 
         it "upgrade formula" do
-          expect(Bundle).to receive(:system).with("brew", "upgrade", "--formula", formula, verbose: false)
+          expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "upgrade", "--formula", formula, verbose: false)
                                             .and_return(true)
           expect(do_install).to be(:success)
         end
 
         it "reports a failure" do
-          expect(Bundle).to receive(:system).with("brew", "upgrade", "--formula", formula, verbose: false)
+          expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "upgrade", "--formula", formula, verbose: false)
                                             .and_return(false)
           expect(do_install).to be(:failed)
         end
@@ -228,7 +231,8 @@ describe Bundle::BrewInstaller do
           end
 
           it "does not upgrade formula" do
-            expect(Bundle).not_to receive(:system).with("brew", "upgrade", "--formula", formula, verbose: false)
+            expect(Bundle).not_to receive(:system).with(HOMEBREW_BREW_FILE, "upgrade", "--formula", formula,
+                                                        verbose: false)
             expect(do_install).to be(:skipped)
           end
         end

--- a/spec/bundle/brew_services_spec.rb
+++ b/spec/bundle/brew_services_spec.rb
@@ -28,14 +28,15 @@ describe Bundle::BrewServices do
     context "when the service is stopped" do
       it "when the service is started" do
         allow(described_class).to receive(:started_services).and_return(%w[nginx])
-        expect(Bundle).to receive(:system).with("brew", "services", "stop", "nginx", verbose: false).and_return(true)
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "services", "stop", "nginx",
+                                                verbose: false).and_return(true)
         expect(described_class.stop("nginx")).to be(true)
         expect(described_class.started_services).not_to include("nginx")
       end
 
       it "when the service is already stopped" do
         allow(described_class).to receive(:started_services).and_return(%w[])
-        expect(Bundle).not_to receive(:system).with("brew", "services", "stop", "nginx", verbose: false)
+        expect(Bundle).not_to receive(:system).with(HOMEBREW_BREW_FILE, "services", "stop", "nginx", verbose: false)
         expect(described_class.stop("nginx")).to be(true)
         expect(described_class.started_services).not_to include("nginx")
       end
@@ -43,7 +44,8 @@ describe Bundle::BrewServices do
 
     it "restarts the service" do
       allow(described_class).to receive(:started_services).and_return([])
-      expect(Bundle).to receive(:system).with("brew", "services", "restart", "nginx", verbose: false).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "services", "restart", "nginx",
+                                              verbose: false).and_return(true)
       expect(described_class.restart("nginx")).to be(true)
       expect(described_class.started_services).to include("nginx")
     end

--- a/spec/bundle/cask_installer_spec.rb
+++ b/spec/bundle/cask_installer_spec.rb
@@ -72,7 +72,8 @@ describe Bundle::CaskInstaller do
       end
 
       it "upgrades" do
-        expect(Bundle).to receive(:system).with("brew", "upgrade", "--cask", "google-chrome", verbose: false)
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "upgrade", "--cask", "google-chrome",
+                                                verbose: false)
                                           .and_return(true)
         expect(do_install).to be(:success)
       end
@@ -86,7 +87,7 @@ describe Bundle::CaskInstaller do
       end
 
       it "upgrades" do
-        expect(Bundle).to receive(:system).with("brew", "upgrade", "--cask", "opera", verbose: false)
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "upgrade", "--cask", "opera", verbose: false)
                                           .and_return(true)
         expect(do_greedy_install).to be(:success)
       end
@@ -98,33 +99,37 @@ describe Bundle::CaskInstaller do
       end
 
       it "installs cask" do
-        expect(Bundle).to receive(:system).with("brew", "install", "--cask", "google-chrome", verbose: false)
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "--cask", "google-chrome",
+                                                verbose: false)
                                           .and_return(true)
         expect(do_install).to be(:success)
       end
 
       it "installs cask with arguments" do
         expect(Bundle).to \
-          receive(:system).with("brew", "install", "--cask", "firefox", "--appdir=/Applications", verbose: false)
+          receive(:system).with(HOMEBREW_BREW_FILE, "install", "--cask", "firefox", "--appdir=/Applications",
+                                verbose: false)
                           .and_return(true)
         expect(described_class.install("firefox", args: { appdir: "/Applications" })).to eq(:success)
       end
 
       it "reports a failure" do
-        expect(Bundle).to receive(:system).with("brew", "install", "--cask", "google-chrome", verbose: false)
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "--cask", "google-chrome",
+                                                verbose: false)
                                           .and_return(false)
         expect(do_install).to be(:failed)
       end
 
       context "with boolean arguments" do
         it "includes a flag if true" do
-          expect(Bundle).to receive(:system).with("brew", "install", "--cask", "iterm", "--force", verbose: false)
+          expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "--cask", "iterm", "--force",
+                                                  verbose: false)
                                             .and_return(true)
           expect(described_class.install("iterm", args: { force: true })).to eq(:success)
         end
 
         it "does not include a flag if false" do
-          expect(Bundle).to receive(:system).with("brew", "install", "--cask", "iterm", verbose: false)
+          expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "--cask", "iterm", verbose: false)
                                             .and_return(true)
           expect(described_class.install("iterm", args: { force: false })).to eq(:success)
         end

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -95,7 +95,7 @@ describe Bundle::Commands::Cleanup do
     end
 
     it "uninstalls casks" do
-      expect(Kernel).to receive(:system).with("brew", "uninstall", "--cask", "--force", "a", "b")
+      expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "uninstall", "--cask", "--force", "a", "b")
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
       expect { described_class.run(force: true) }.to output(/Uninstalled 2 casks/).to_stdout
     end
@@ -110,7 +110,7 @@ describe Bundle::Commands::Cleanup do
     end
 
     it "uninstalls casks" do
-      expect(Kernel).to receive(:system).with("brew", "uninstall", "--cask", "--zap", "--force", "a", "b")
+      expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "uninstall", "--cask", "--zap", "--force", "a", "b")
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
       expect { described_class.run(force: true, zap: true) }.to output(/Uninstalled 2 casks/).to_stdout
     end
@@ -125,7 +125,7 @@ describe Bundle::Commands::Cleanup do
     end
 
     it "uninstalls formulae" do
-      expect(Kernel).to receive(:system).with("brew", "uninstall", "--formula", "--force", "a", "b")
+      expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "uninstall", "--formula", "--force", "a", "b")
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
       expect { described_class.run(force: true) }.to output(/Uninstalled 2 formulae/).to_stdout
     end
@@ -140,7 +140,7 @@ describe Bundle::Commands::Cleanup do
     end
 
     it "untaps taps" do
-      expect(Kernel).to receive(:system).with("brew", "untap", "a", "b")
+      expect(Kernel).to receive(:system).with(HOMEBREW_BREW_FILE, "untap", "a", "b")
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
       described_class.run(force: true)
     end

--- a/spec/bundle/mac_app_store_installer_spec.rb
+++ b/spec/bundle/mac_app_store_installer_spec.rb
@@ -28,7 +28,7 @@ describe Bundle::MacAppStoreInstaller do
     end
 
     it "tries to install mas" do
-      expect(Bundle).to receive(:system).with("brew", "install", "mas", verbose: false).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "mas", verbose: false).and_return(true)
       expect { do_install }.to raise_error(RuntimeError)
     end
 

--- a/spec/bundle/tap_installer_spec.rb
+++ b/spec/bundle/tap_installer_spec.rb
@@ -34,13 +34,15 @@ describe Bundle::TapInstaller do
     end
 
     it "taps" do
-      expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask", verbose: false).and_return(true)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask",
+                                              verbose: false).and_return(true)
       expect(do_install).to be(:success)
     end
 
     context "with clone target" do
       it "taps" do
-        expect(Bundle).to receive(:system).with("brew", "tap", "homebrew/cask", "clone_target_path", verbose: false)
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask", "clone_target_path",
+                                                verbose: false)
                                           .and_return(true)
         expect(do_install(clone_target: "clone_target_path")).to be(:success)
       end

--- a/spec/bundle/whalebrew_installer_spec.rb
+++ b/spec/bundle/whalebrew_installer_spec.rb
@@ -43,7 +43,7 @@ describe Bundle::WhalebrewInstaller do
     end
 
     it "successfully installs whalebrew" do
-      expect(Bundle).to receive(:system).with("brew", "install", "whalebrew", verbose: false)
+      expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "whalebrew", verbose: false)
                                         .and_return(true)
       expect { do_install }.to raise_error(RuntimeError)
     end

--- a/spec/stub/global.rb
+++ b/spec/stub/global.rb
@@ -2,4 +2,5 @@
 
 HOMEBREW_PREFIX = Pathname("/usr/local").freeze
 HOMEBREW_REPOSITORY = Pathname("/usr/local/Homebrew").freeze
+HOMEBREW_BREW_FILE = Pathname(HOMEBREW_PREFIX/"bin/brew").freeze
 HOMEBREW_VERSION = "2.6.0"


### PR DESCRIPTION
`brew bundle` fails if `brew` binary is not present in directories present in PATH.
I just run into this issue while trying to execute `brew bundle` freshly after Homebrew installation.