### PR TITLE
Skip unbottled homebrew/core formulae on Apple Silicon

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -149,7 +149,13 @@ module Bundle
 
       runtime_dependencies ||= formula.runtime_dependencies.map(&:name)
 
-      bottle_hash = formula.bottle_hash if formula.bottle_defined?
+      if formula.bottle_defined?
+        bottle_hash = formula.bottle_hash.deep_symbolize_keys
+        if (bottle_files = bottle_hash[:files].presence)
+          bottled = bottle_files[:all].present?
+          bottled ||= bottle_files[Utils::Bottles.tag.to_sym].present?
+        end
+      end
 
       {
         name:                     formula.name,
@@ -170,6 +176,7 @@ module Bundle
         link?:                    link,
         poured_from_bottle?:      (poured_from_bottle || false),
         bottle:                   (bottle_hash || false),
+        bottled:                  (bottled || false),
       }
     end
     private_class_method :formula_to_hash

--- a/lib/bundle/extend/os/linux/skipper.rb
+++ b/lib/bundle/extend/os/linux/skipper.rb
@@ -13,9 +13,7 @@ module Bundle
 
       def skip?(entry, silent: false)
         if macos_only_entry?(entry) || macos_only_tap?(entry)
-          return true if silent
-
-          puts Formatter.warning "Skipping #{entry.type} #{entry.name} (on Linux)"
+          puts Formatter.warning "Skipping #{entry.type} #{entry.name} (on Linux)" unless silent
           true
         else
           generic_skip?(entry)

--- a/spec/bundle/brew_dumper_spec.rb
+++ b/spec/bundle/brew_dumper_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "tsort"
 require "formula"
 require "tab"
+require "utils/bottles"
 
 describe Bundle::BrewDumper do
   subject(:dumper) { described_class }
@@ -32,6 +33,7 @@ describe Bundle::BrewDumper do
       any_version_installed?:   true,
       args:                     [],
       bottle:                   false,
+      bottled:                  false,
       build_dependencies:       [],
       conflicts_with:           [],
       dependencies:             [],
@@ -91,6 +93,7 @@ describe Bundle::BrewDumper do
           },
         },
       },
+      bottled:                  true,
       build_dependencies:       [],
       conflicts_with:           [],
       dependencies:             [],
@@ -131,6 +134,7 @@ describe Bundle::BrewDumper do
       any_version_installed?:   true,
       args:                     [],
       bottle:                   false,
+      bottled:                  false,
       build_dependencies:       ["bar"],
       conflicts_with:           [],
       dependencies:             ["bar"],

--- a/spec/bundle/skipper_spec.rb
+++ b/spec/bundle/skipper_spec.rb
@@ -22,6 +22,16 @@ describe Bundle::Skipper do
       end
     end
 
+    context "with an unbottled formula on ARM", :needs_macos do
+      let(:entry) { Bundle::Dsl::Entry.new(:brew, "mysql") }
+
+      it "returns true" do
+        allow(Hardware::CPU).to receive(:arm?).and_return(true)
+
+        expect(skipper.skip?(entry)).to be true
+      end
+    end
+
     context "with an unlisted cask", :needs_macos do
       let(:entry) { Bundle::Dsl::Entry.new(:cask, "java") }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,7 @@ require "bundle"
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/string/exclude"
 require "active_support/core_ext/enumerable"
+require "active_support/core_ext/hash/keys"
 
 Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").sort.each do |file|
   next if file.include?("/extend/os/")

--- a/spec/stub/hardware.rb
+++ b/spec/stub/hardware.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Hardware
+  module CPU
+    module_function
+
+    def arm?
+      false
+    end
+  end
+end

--- a/spec/stub/utils/bottles.rb
+++ b/spec/stub/utils/bottles.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Utils
+  module Bottles
+    module_function
+
+    def tag
+      :big_sur
+    end
+  end
+end


### PR DESCRIPTION
Otherwise, a working `Brewfile` on Intel is likely to break on Apple Silicon.

When all of homebrew/core is bottled: we may consider enabling this more widely.