### PR TITLE
Skip dependents if a tap fails

### DIFF
--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -39,6 +39,10 @@ module Bundle
         when :skipped
           puts "Using #{entry.name}"
           success += 1
+        when :aborted
+          puts Formatter.error("#{verb} #{entry.name} has failed! Aborting!")
+          failure += 1
+          break
         else
           puts Formatter.error("#{verb} #{entry.name} has failed!")
           failure += 1

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -40,9 +40,9 @@ module Bundle
           puts "Using #{entry.name}"
           success += 1
         when :aborted
-          puts Formatter.error("#{verb} #{entry.name} has failed! Aborting!")
+          Bundle::Skipper.skip entry
+          puts Formatter.error("#{verb} #{entry.name} has failed! Skipping dependents...")
           failure += 1
-          break
         else
           puts Formatter.error("#{verb} #{entry.name} has failed!")
           failure += 1

--- a/lib/bundle/skipper.rb
+++ b/lib/bundle/skipper.rb
@@ -32,8 +32,7 @@ module Bundle
       alias generic_skip? skip?
 
       def skip(entry)
-        skipped_entries[entry.type]&.<< entry.name ||
-          (skipped_entries[entry.type] = [entry.name])
+        (skipped_entries[entry.type] ||= []) << entry.name
       end
 
       private

--- a/lib/bundle/skipper.rb
+++ b/lib/bundle/skipper.rb
@@ -32,8 +32,8 @@ module Bundle
       alias generic_skip? skip?
 
       def skip(entry)
-        skipped_entries[entry.type] &.<< entry.name or
-          skipped_entries[entry.type] = [entry.name]
+        skipped_entries[entry.type]&.<< entry.name ||
+          (skipped_entries[entry.type] = [entry.name])
       end
 
       private

--- a/lib/bundle/skipper.rb
+++ b/lib/bundle/skipper.rb
@@ -12,6 +12,11 @@ module Bundle
           return true
         end
 
+        return true if skipped_entries[:tap]&.any? do |tap|
+          prefix = "#{tap}/"
+          entry.name.start_with?(prefix) || entry.options[:full_name]&.start_with?(prefix)
+        end
+
         entry_type_skips = Array(skipped_entries[entry.type])
         return false if entry_type_skips.empty?
 
@@ -25,6 +30,11 @@ module Bundle
         true
       end
       alias generic_skip? skip?
+
+      def skip(entry)
+        skipped_entries[entry.type] &.<< entry.name or
+          skipped_entries[entry.type] = [entry.name]
+      end
 
       private
 

--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -17,7 +17,7 @@ module Bundle
         Bundle.system HOMEBREW_BREW_FILE, "tap", name, verbose: verbose
       end
 
-      return :failed unless success
+      return :aborted unless success
 
       installed_taps << name
       :success

--- a/spec/bundle/commands/install_command_spec.rb
+++ b/spec/bundle/commands/install_command_spec.rb
@@ -56,5 +56,14 @@ describe Bundle::Commands::Install do
 
       expect { described_class.run }.to raise_error(SystemExit)
     end
+
+    it "exits early on a tap failure" do
+      expect(Bundle::BrewInstaller).not_to receive(:install)
+
+      allow(Bundle::TapInstaller).to receive(:install).and_return(:aborted)
+      allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
+
+      expect { described_class.run }.to raise_error(SystemExit)
+    end
   end
 end

--- a/spec/bundle/commands/install_command_spec.rb
+++ b/spec/bundle/commands/install_command_spec.rb
@@ -20,7 +20,7 @@ describe Bundle::Commands::Install do
       <<~EOS
         tap 'phinze/cask'
         brew 'mysql', conflicts_with: ['mysql56']
-        cask 'google-chrome', greedy: true
+        cask 'phinze/cask/google-chrome', greedy: true
         mas '1Password', id: 443987910
         whalebrew 'whalebrew/wget'
       EOS
@@ -57,12 +57,14 @@ describe Bundle::Commands::Install do
       expect { described_class.run }.to raise_error(SystemExit)
     end
 
-    it "exits early on a tap failure" do
-      expect(Bundle::BrewInstaller).not_to receive(:install)
-
+    it "skips installs from failed taps" do
       allow(Bundle::TapInstaller).to receive(:install).and_return(:aborted)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
 
+      expect(Bundle::BrewInstaller).to receive(:install).and_return(:success)
+      expect(Bundle::CaskInstaller).not_to receive(:install)
+      expect(Bundle::MacAppStoreInstaller).to receive(:install).and_return(:success)
+      expect(Bundle::WhalebrewInstaller).to receive(:install).and_return(:success)
       expect { described_class.run }.to raise_error(SystemExit)
     end
   end

--- a/spec/bundle/commands/install_command_spec.rb
+++ b/spec/bundle/commands/install_command_spec.rb
@@ -59,12 +59,12 @@ describe Bundle::Commands::Install do
 
     it "skips installs from failed taps" do
       allow(Bundle::TapInstaller).to receive(:install).and_return(:aborted)
+      allow(Bundle::BrewInstaller).to receive(:install).and_return(:success)
+      allow(Bundle::MacAppStoreInstaller).to receive(:install).and_return(:success)
+      allow(Bundle::WhalebrewInstaller).to receive(:install).and_return(:success)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
 
-      expect(Bundle::BrewInstaller).to receive(:install).and_return(:success)
       expect(Bundle::CaskInstaller).not_to receive(:install)
-      expect(Bundle::MacAppStoreInstaller).to receive(:install).and_return(:success)
-      expect(Bundle::WhalebrewInstaller).to receive(:install).and_return(:success)
       expect { described_class.run }.to raise_error(SystemExit)
     end
   end

--- a/spec/bundle/skipper_spec.rb
+++ b/spec/bundle/skipper_spec.rb
@@ -72,22 +72,51 @@ describe Bundle::Skipper do
       end
     end
 
-    [
-      Bundle::Dsl::Entry.new(:brew, "postgresql"), nil,
-      Bundle::Dsl::Entry.new(:cask, "docker"), nil,
-      Bundle::Dsl::Entry.new(:mas, "garageband"), :needs_macos,
-      Bundle::Dsl::Entry.new(:whalebrew, "whalebrew/whalesay"), nil,
-    ].each_slice(2) do |entry, option|
-      context "with a #{entry.type}", option do
-        let(:entry) { entry }
+    context "with a formula" do
+      let(:entry) { Bundle::Dsl::Entry.new(:brew, "postgresql") }
 
-        it "returns true" do
-          expect(skipper.skip?(entry)).to be false
+      it "returns true" do
+        expect(skipper.skip?(entry)).to be false
 
-          skipper.skip entry
+        skipper.skip entry
 
-          expect(skipper.skip?(entry)).to be true
-        end
+        expect(skipper.skip?(entry)).to be true
+      end
+    end
+
+    context "with a cask", :needs_macos do
+      let(:entry) { Bundle::Dsl::Entry.new(:cask, "docker") }
+
+      it "returns true" do
+        expect(skipper.skip?(entry)).to be false
+
+        skipper.skip entry
+
+        expect(skipper.skip?(entry)).to be true
+      end
+    end
+
+    context "with a mac app store", :needs_macos do
+      let(:entry) { Bundle::Dsl::Entry.new(:mas, "garageband") }
+
+      it "returns true" do
+        expect(skipper.skip?(entry)).to be false
+
+        skipper.skip entry
+
+        expect(skipper.skip?(entry)).to be true
+      end
+    end
+
+    context "with a whalebrew image" do
+      let(:entry) { Bundle::Dsl::Entry.new(:whalebrew, "whalebrew/whalesay") }
+
+      it "returns true" do
+        expect(skipper.skip?(entry)).to be false
+
+        skipper.skip entry
+
+        expect(skipper.skip?(entry)).to be true
       end
     end
   end

--- a/spec/bundle/skipper_spec.rb
+++ b/spec/bundle/skipper_spec.rb
@@ -73,12 +73,12 @@ describe Bundle::Skipper do
     end
 
     [
-      Bundle::Dsl::Entry.new(:brew, "postgresql"),
-      Bundle::Dsl::Entry.new(:cask, "docker"),
-      Bundle::Dsl::Entry.new(:mas, "garageband"),
-      Bundle::Dsl::Entry.new(:whalebrew, "whalebrew/whalesay"),
-    ].each do |entry|
-      context "with a #{entry.type}" do
+      Bundle::Dsl::Entry.new(:brew, "postgresql"), nil,
+      Bundle::Dsl::Entry.new(:cask, "docker"), nil,
+      Bundle::Dsl::Entry.new(:mas, "garageband"), :needs_macos,
+      Bundle::Dsl::Entry.new(:whalebrew, "whalebrew/whalesay"), nil,
+    ].each_slice(2) do |entry, option|
+      context "with a #{entry.type}", option do
         let(:entry) { entry }
 
         it "returns true" do

--- a/spec/bundle/skipper_spec.rb
+++ b/spec/bundle/skipper_spec.rb
@@ -78,7 +78,7 @@ describe Bundle::Skipper do
       Bundle::Dsl::Entry.new(:mas, "garageband"),
       Bundle::Dsl::Entry.new(:whalebrew, "whalebrew/whalesay"),
     ].each do |entry|
-      context "with a #{entry.type.to_s}" do
+      context "with a #{entry.type}" do
         let(:entry) { entry }
 
         it "returns true" do

--- a/spec/bundle/tap_installer_spec.rb
+++ b/spec/bundle/tap_installer_spec.rb
@@ -46,6 +46,13 @@ describe Bundle::TapInstaller do
                                           .and_return(true)
         expect(do_install(clone_target: "clone_target_path")).to be(:success)
       end
+
+      it "fails" do
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask", "clone_target_path",
+                                                verbose: false)
+                                          .and_return(false)
+        expect(do_install(clone_target: "clone_target_path")).to be(:aborted)
+      end
     end
   end
 end


### PR DESCRIPTION
If a `tap` fails, then any subsequent commands can grossly misbehave. For example:

```
tap 'example/formula', 'user@git.example.com:example/homebrew-formulas.git'

brew 'example/formula/internal-tool'
```

If `tap` fails, then bundle currently continues and will attempt to tap (and clone) `https://github.com/example/homebrew-formula` to much sad failure.

This PR changes `bundle` to skip any dependent installations when a tap fails. The other stanzas, `brew`, `cask`, `mas`, `whalebrew`, and others are unchanged and do not abort; my rationale is that their failures are isolated and don't impact each other.