### PR TITLE
Improve non-verbose output

### DIFF
--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -7,22 +7,33 @@ module Bundle
     def reset!
       @installed_casks = nil
       @outdated_casks = nil
-      @all_outdated_casks = nil
+      @greedy_outdated_casks = nil
+    end
+
+    def upgrading?(no_upgrade, name, options)
+      return false if no_upgrade
+      return true if outdated_casks.include?(name)
+      return false unless options[:greedy]
+
+      greedy_outdated_casks.include?(name)
+    end
+
+    def preinstall(name, no_upgrade: false, verbose: false, **options)
+      if installed_casks.include?(name) && !upgrading?(no_upgrade, name, options)
+        puts "Skipping install of #{name} cask. It is already installed." if verbose
+        return false
+      end
+
+      true
     end
 
     def install(name, no_upgrade: false, verbose: false, **options)
       full_name = options.fetch(:full_name, name)
-      greedy = options[:greedy]
 
-      if installed_casks.include? name
-        if !no_upgrade && (outdated_casks.include?(name) || all_outdated_casks.include?(name) && greedy)
-          status = "#{greedy ? "may not be" : "not"} up-to-date"
-          puts "Upgrading #{name} cask. It is installed but #{status}." if verbose
-          return :failed unless Bundle.system HOMEBREW_BREW_FILE, "upgrade", "--cask", full_name, verbose: verbose
-
-          return :success
-        end
-        return :skipped
+      if installed_casks.include?(name) && upgrading?(no_upgrade, name, options)
+        status = "#{options[:greedy] ? "may not be" : "not"} up-to-date"
+        puts "Upgrading #{name} cask. It is installed but #{status}." if verbose
+        return Bundle.system HOMEBREW_BREW_FILE, "upgrade", "--cask", full_name, verbose: verbose
       end
 
       args = options.fetch(:args, []).map do |k, v|
@@ -38,10 +49,10 @@ module Bundle
 
       puts "Installing #{name} cask. It is not currently installed." if verbose
 
-      return :failed unless Bundle.system HOMEBREW_BREW_FILE, "install", "--cask", full_name, *args, verbose: verbose
+      return false unless Bundle.system HOMEBREW_BREW_FILE, "install", "--cask", full_name, *args, verbose: verbose
 
       installed_casks << name
-      :success
+      true
     end
 
     def self.cask_installed_and_up_to_date?(cask, no_upgrade: false)
@@ -67,8 +78,8 @@ module Bundle
       @outdated_casks ||= Bundle::CaskDumper.outdated_cask_names
     end
 
-    def all_outdated_casks
-      @all_outdated_casks ||= Bundle::CaskDumper.outdated_cask_names(greedy: true)
+    def greedy_outdated_casks
+      @greedy_outdated_casks ||= Bundle::CaskDumper.outdated_cask_names(greedy: true)
     end
   end
 end

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -32,12 +32,14 @@ module Bundle
 
         next if Bundle::Skipper.skip? entry
 
-        case cls.install(*args, **options, no_upgrade: no_upgrade, verbose: verbose)
-        when :success
-          puts Formatter.success("#{verb} #{entry.name}")
-          success += 1
-        when :skipped
+        unless cls.preinstall(*args, **options, no_upgrade: no_upgrade, verbose: verbose)
           puts "Using #{entry.name}"
+          success += 1
+          next
+        end
+
+        puts Formatter.success("#{verb} #{entry.name}")
+        if cls.install(*args, **options, no_upgrade: no_upgrade, verbose: verbose)
           success += 1
         else
           puts Formatter.error("#{verb} #{entry.name} has failed!")

--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -4,12 +4,16 @@ module Bundle
   module TapInstaller
     module_function
 
-    def install(name, verbose: false, **options)
+    def preinstall(name, verbose: false, **_options)
       if installed_taps.include? name
         puts "Skipping install of #{name} tap. It is already installed." if verbose
-        return :skipped
+        return false
       end
 
+      true
+    end
+
+    def install(name, verbose: false, **options)
       puts "Installing #{name} tap. It is not currently installed." if verbose
       success = if options[:clone_target]
         Bundle.system HOMEBREW_BREW_FILE, "tap", name, options[:clone_target], verbose: verbose
@@ -17,10 +21,10 @@ module Bundle
         Bundle.system HOMEBREW_BREW_FILE, "tap", name, verbose: verbose
       end
 
-      return :failed unless success
+      return false unless success
 
       installed_taps << name
-      :success
+      true
     end
 
     def installed_taps

--- a/lib/bundle/whalebrew_installer.rb
+++ b/lib/bundle/whalebrew_installer.rb
@@ -8,21 +8,28 @@ module Bundle
       @installed_images = nil
     end
 
-    def install(name, verbose: false, **_options)
+    def preinstall(name, verbose: false, **_options)
       unless Bundle.whalebrew_installed?
         puts "Installing whalebrew. It is not currently installed." if verbose
         Bundle.system HOMEBREW_BREW_FILE, "install", "whalebrew", verbose: verbose
         raise "Unable to install #{name} app. Whalebrew installation failed." unless Bundle.whalebrew_installed?
       end
 
-      return :skipped if image_installed?(name)
+      if image_installed?(name)
+        puts "Skipping install of #{name} app. It is already installed." if verbose
+        return false
+      end
 
+      true
+    end
+
+    def install(name, verbose: false, **_options)
       puts "Installing #{name} image. It is not currently installed." if verbose
 
-      return :failed unless Bundle.system "whalebrew", "install", name, verbose: verbose
+      return false unless Bundle.system "whalebrew", "install", name, verbose: verbose
 
       installed_images << name
-      :success
+      true
     end
 
     def image_installed?(image)

--- a/spec/bundle/commands/install_command_spec.rb
+++ b/spec/bundle/commands/install_command_spec.rb
@@ -27,11 +27,14 @@ describe Bundle::Commands::Install do
     end
 
     it "does not raise an error" do
-      allow(Bundle::BrewInstaller).to receive(:install).and_return(:success)
-      allow(Bundle::CaskInstaller).to receive(:install).and_return(:skipped)
-      allow(Bundle::MacAppStoreInstaller).to receive(:install).and_return(:success)
-      allow(Bundle::TapInstaller).to receive(:install).and_return(:skipped)
-      allow(Bundle::WhalebrewInstaller).to receive(:install).and_return(:skipped)
+      allow(Bundle::BrewInstaller).to receive(:preinstall).and_return(true)
+      allow(Bundle::CaskInstaller).to receive(:preinstall).and_return(true)
+      allow(Bundle::MacAppStoreInstaller).to receive(:preinstall).and_return(true)
+      allow(Bundle::TapInstaller).to receive(:preinstall).and_return(false)
+      allow(Bundle::WhalebrewInstaller).to receive(:preinstall).and_return(false)
+      allow(Bundle::BrewInstaller).to receive(:install).and_return(true)
+      allow(Bundle::CaskInstaller).to receive(:install).and_return(true)
+      allow(Bundle::MacAppStoreInstaller).to receive(:install).and_return(true)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
       expect { described_class.run }.not_to raise_error
     end
@@ -46,11 +49,16 @@ describe Bundle::Commands::Install do
     end
 
     it "exits on failures" do
-      allow(Bundle::BrewInstaller).to receive(:install).and_return(:failed)
-      allow(Bundle::CaskInstaller).to receive(:install).and_return(:failed)
-      allow(Bundle::MacAppStoreInstaller).to receive(:install).and_return(:failed)
-      allow(Bundle::TapInstaller).to receive(:install).and_return(:failed)
-      allow(Bundle::WhalebrewInstaller).to receive(:install).and_return(:failed)
+      allow(Bundle::BrewInstaller).to receive(:preinstall).and_return(true)
+      allow(Bundle::CaskInstaller).to receive(:preinstall).and_return(true)
+      allow(Bundle::MacAppStoreInstaller).to receive(:preinstall).and_return(true)
+      allow(Bundle::TapInstaller).to receive(:preinstall).and_return(true)
+      allow(Bundle::WhalebrewInstaller).to receive(:preinstall).and_return(true)
+      allow(Bundle::BrewInstaller).to receive(:install).and_return(false)
+      allow(Bundle::CaskInstaller).to receive(:install).and_return(false)
+      allow(Bundle::MacAppStoreInstaller).to receive(:install).and_return(false)
+      allow(Bundle::TapInstaller).to receive(:install).and_return(false)
+      allow(Bundle::WhalebrewInstaller).to receive(:install).and_return(false)
       allow(Bundle::Locker).to receive(:lockfile).and_return(Pathname(__dir__))
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
 

--- a/spec/bundle/mac_app_store_installer_spec.rb
+++ b/spec/bundle/mac_app_store_installer_spec.rb
@@ -3,10 +3,6 @@
 require "spec_helper"
 
 describe Bundle::MacAppStoreInstaller do
-  def do_install
-    Bundle::MacAppStoreInstaller.install("foo", 123)
-  end
-
   describe ".installed_app_ids" do
     it "shells out" do
       described_class.installed_app_ids
@@ -29,7 +25,7 @@ describe Bundle::MacAppStoreInstaller do
 
     it "tries to install mas" do
       expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "mas", verbose: false).and_return(true)
-      expect { do_install }.to raise_error(RuntimeError)
+      expect { described_class.preinstall("foo", 123) }.to raise_error(RuntimeError)
     end
 
     describe ".outdated_app_ids" do
@@ -59,7 +55,7 @@ describe Bundle::MacAppStoreInstaller do
         allow(described_class).to receive(:installed_app_ids).and_return([123])
         allow(described_class).to receive(:outdated_app_ids).and_return([123])
         expect(Kernel).to receive(:system).with("mas account &>/dev/null").and_return(false)
-        expect { do_install }.to raise_error(RuntimeError)
+        expect { described_class.preinstall("foo", 123) }.to raise_error(RuntimeError)
       end
     end
 
@@ -76,7 +72,7 @@ describe Bundle::MacAppStoreInstaller do
 
         it "skips" do
           expect(Bundle).not_to receive(:system)
-          expect(do_install).to be(:skipped)
+          expect(described_class.preinstall("foo", 123)).to be(false)
         end
       end
 
@@ -88,7 +84,8 @@ describe Bundle::MacAppStoreInstaller do
 
         it "upgrades" do
           expect(Bundle).to receive(:system).with("mas", "upgrade", "123", verbose: false).and_return(true)
-          expect(do_install).to be(:success)
+          expect(described_class.preinstall("foo", 123)).to be(true)
+          expect(described_class.install("foo", 123)).to be(true)
         end
       end
 
@@ -99,7 +96,8 @@ describe Bundle::MacAppStoreInstaller do
 
         it "installs app" do
           expect(Bundle).to receive(:system).with("mas", "install", "123", verbose: false).and_return(true)
-          expect(do_install).to be(:success)
+          expect(described_class.preinstall("foo", 123)).to be(true)
+          expect(described_class.install("foo", 123)).to be(true)
         end
       end
     end

--- a/spec/bundle/tap_installer_spec.rb
+++ b/spec/bundle/tap_installer_spec.rb
@@ -3,10 +3,6 @@
 require "spec_helper"
 
 describe Bundle::TapInstaller do
-  def do_install(**options)
-    Bundle::TapInstaller.install("homebrew/cask", **options)
-  end
-
   describe ".installed_taps" do
     before do
       Bundle::TapDumper.reset!
@@ -24,7 +20,7 @@ describe Bundle::TapInstaller do
 
     it "skips" do
       expect(Bundle).not_to receive(:system)
-      expect(do_install).to be(:skipped)
+      expect(described_class.preinstall("homebrew/cask")).to be(false)
     end
   end
 
@@ -36,7 +32,8 @@ describe Bundle::TapInstaller do
     it "taps" do
       expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask",
                                               verbose: false).and_return(true)
-      expect(do_install).to be(:success)
+      expect(described_class.preinstall("homebrew/cask")).to be(true)
+      expect(described_class.install("homebrew/cask")).to be(true)
     end
 
     context "with clone target" do
@@ -44,7 +41,8 @@ describe Bundle::TapInstaller do
         expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask", "clone_target_path",
                                                 verbose: false)
                                           .and_return(true)
-        expect(do_install(clone_target: "clone_target_path")).to be(:success)
+        expect(described_class.preinstall("homebrew/cask", clone_target: "clone_target_path")).to be(true)
+        expect(described_class.install("homebrew/cask", clone_target: "clone_target_path")).to be(true)
       end
     end
   end

--- a/spec/bundle/whalebrew_installer_spec.rb
+++ b/spec/bundle/whalebrew_installer_spec.rb
@@ -3,10 +3,6 @@
 require "spec_helper"
 
 describe Bundle::WhalebrewInstaller do
-  def do_install
-    Bundle::WhalebrewInstaller.install("whalebrew/wget")
-  end
-
   describe ".installed_images" do
     it "shells out" do
       described_class.installed_images
@@ -45,7 +41,7 @@ describe Bundle::WhalebrewInstaller do
     it "successfully installs whalebrew" do
       expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "install", "whalebrew", verbose: false)
                                         .and_return(true)
-      expect { do_install }.to raise_error(RuntimeError)
+      expect { described_class.preinstall("whalebrew/wget") }.to raise_error(RuntimeError)
     end
   end
 
@@ -56,18 +52,19 @@ describe Bundle::WhalebrewInstaller do
                                        .and_return(true)
     end
 
-    it "successfully installs an image" do
-      expect { do_install }.not_to raise_error
-    end
-
     context "when the requested image is already installed" do
       before do
         allow(described_class).to receive(:image_installed?).with("whalebrew/wget").and_return(true)
       end
 
       it "skips" do
-        expect(do_install).to be(:skipped)
+        expect(described_class.preinstall("whalebrew/wget")).to be(false)
       end
+    end
+
+    it "successfully installs an image" do
+      expect(described_class.preinstall("whalebrew/wget")).to be(true)
+      expect { described_class.install("whalebrew/wget") }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
When installing the verb (i.e. "installing", "tapping") is output after the installation is complete (rather than before). This means if an installation is taking a long time or frozen completely there's nothing in the (non-verbose) output to indicate which install is taking the time.

Instead, let's add a "preinstall" step before "install" for each installer which identifies whether an installation will be skipped or not. This will block output but is quicker (as it never does the actual installation but will do a network call for e.g. `mas`) and outputs `Using` _after_ the skip check but `Installing` _before_ actually beginning the installation.