### PR TITLE
lib/bundle/installer: Set `preinstall` variable to `true`/`false`

### DIFF
--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -36,8 +36,10 @@ module Bundle
 
         preinstall = if cls.preinstall(*args, **options, no_upgrade: no_upgrade, verbose: verbose)
           puts Formatter.success("#{verb} #{name}")
+          true
         else
           puts "Using #{name}"
+          false
         end
 
         if cls.install(*args, **options, preinstall: preinstall, no_upgrade: no_upgrade, verbose: verbose)


### PR DESCRIPTION
- Assigning `preinstall` to the output of `puts` meant that it was `nil` when we used it in `cls.install`, which did not equal `true` in the `cls.install` method when we tried to use it (but as it was provided, it was not overridden by the default value `true`).  This makes sure that in the success case (when `cls.preinstall` succeeds, we print a green message), `preinstall` is true and in the inverse case preinstall is negative.
- This meant that while we printed "Installing", nothing was actually installed because `preinstall` was `nil` which is falsey, so we never called `install_change_state!` to do the actual installation.
- My first attempt at fixing this problem was the wrong approach, even though it technically fixed the problem. 😴

- Before:

```
$ brew bundle --file=./Brewfile-test
Installing k9s
Homebrew Bundle complete! 1 Brewfile dependency now installed.
$ k9s --help
zsh: command not found: k9s
```

- After:

```
$ brew bundle --file=./Brewfile-test
Installing k9s
Homebrew Bundle complete! 1 Brewfile dependency now installed.
$ k9s --help
K9s is a CLI to view and manage your Kubernetes clusters.
[...]
```

- Fixes https://github.com/Homebrew/brew/issues/11817.