### PR TITLE
Add groups for Brewfiles

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -45,6 +45,8 @@ module Homebrew
       EOS
       flag   "--file=",
              description: "Read the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout."
+      flag   "--without",
+             description: "Ignore entries tagged with these, comma separated, group names."
       switch "--global",
              description: "Read the `Brewfile` from `~/.Brewfile`."
       switch "-v", "--verbose",
@@ -84,6 +86,7 @@ module Homebrew
 
   def bundle
     args = bundle_args.parse
+    without_groups = args.without.split(',').map(&:to_sym)
 
     # Keep this after the .parse to keep --help fast.
     require_relative "../lib/bundle"
@@ -92,11 +95,12 @@ module Homebrew
       case subcommand = args.named.first.presence
       when nil, "install"
         Bundle::Commands::Install.run(
-          global:     args.global?,
-          file:       args.file,
-          no_lock:    args.no_lock?,
-          no_upgrade: args.no_upgrade?,
-          verbose:    args.verbose?,
+          global:         args.global?,
+          file:           args.file,
+          no_lock:        args.no_lock?,
+          no_upgrade:     args.no_upgrade?,
+          verbose:        args.verbose?,
+          without_groups: without_groups,
         )
 
         if args.cleanup?
@@ -133,19 +137,21 @@ module Homebrew
         _subcommand, *named_args = args.named
         Bundle::Commands::Exec.run(
           *named_args,
-          global: args.global?,
-          file:   args.file,
+          global:         args.global?,
+          file:           args.file,
+          without_groups: without_groups,
         )
       when "list"
         Bundle::Commands::List.run(
-          global:    args.global?,
-          file:      args.file,
-          all:       args.all?,
-          casks:     args.casks?,
-          taps:      args.taps?,
-          mas:       args.mas?,
-          whalebrew: args.whalebrew?,
-          brews:     args.brews?,
+          global:         args.global?,
+          file:           args.file,
+          all:            args.all?,
+          casks:          args.casks?,
+          taps:           args.taps?,
+          mas:            args.mas?,
+          whalebrew:      args.whalebrew?,
+          brews:          args.brews?,
+          without_groups: without_groups,
         )
       else
         raise UsageError, "unknown subcommand: #{subcommand}"

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -9,7 +9,7 @@ module Bundle
     module Exec
       module_function
 
-      def run(*args, global: false, file: nil)
+      def run(*args, global: false, file: nil, without_groups: [])
         # Setup Homebrew's ENV extensions
         ENV.activate_extensions!
         raise UsageError, "No command to execute was specified!" if args.blank?
@@ -32,6 +32,7 @@ module Bundle
 
         ENV.deps = brewfile.entries.map do |entry|
           next unless entry.type == :brew
+          next if entry.excluded_by?(without_groups)
 
           f = Formulary.factory(entry.name)
           [f, f.recursive_dependencies.map(&:to_formula)]

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -5,11 +5,11 @@ module Bundle
     module Install
       module_function
 
-      def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false)
+      def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, without_groups: [])
         parsed_entries = Bundle::Dsl.new(Brewfile.read(global: global, file: file)).entries
         Bundle::Installer.install(
           parsed_entries,
-          global: global, file: file, no_lock: no_lock, no_upgrade: no_upgrade, verbose: verbose,
+          global: global, file: file, no_lock: no_lock, no_upgrade: no_upgrade, verbose: verbose, without_groups: without_groups
         ) || exit(1)
       end
     end

--- a/lib/bundle/commands/list.rb
+++ b/lib/bundle/commands/list.rb
@@ -6,12 +6,12 @@ module Bundle
       module_function
 
       def run(
-        global: false, file: nil, all: false, casks: false, taps: false, mas: false, whalebrew: false, brews: false
+        global: false, file: nil, all: false, casks: false, taps: false, mas: false, whalebrew: false, brews: false, without_groups: []
       )
         parsed_entries = Bundle::Dsl.new(Brewfile.read(global: global, file: file)).entries
         Bundle::Lister.list(
           parsed_entries,
-          all: all, casks: casks, taps: taps, mas: mas, whalebrew: whalebrew, brews: brews,
+          all: all, casks: casks, taps: taps, mas: mas, whalebrew: whalebrew, brews: brews, without_groups: without_groups
         )
       end
     end

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -4,11 +4,16 @@ module Bundle
   module Installer
     module_function
 
-    def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false)
+    def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, without_groups: [])
       success = 0
       failure = 0
 
       entries.each do |entry|
+        if entry.excluded_by?(without_groups)
+          puts Formatter.warning("Skipping #{entry.name}") + " (in #{entry.options[:group].join(', ')} group#{entry.options[:group].one? ? '' : 's'})"
+          next
+        end
+
         name = entry.name
         args = [name]
         options = {}

--- a/lib/bundle/lister.rb
+++ b/lib/bundle/lister.rb
@@ -4,8 +4,10 @@ module Bundle
   module Lister
     module_function
 
-    def list(entries, all: false, casks: false, taps: false, mas: false, whalebrew: false, brews: false)
+    def list(entries, all: false, casks: false, taps: false, mas: false, whalebrew: false, brews: false, without_groups: [])
       entries.each do |entry|
+        next if entry.excluded_by?(without_groups)
+
         if show?(entry.type, all: all, casks: casks, taps: taps, mas: mas, whalebrew: whalebrew, brews: brews)
           puts entry.name
         end


### PR DESCRIPTION
✨ Extends the Brewfile DSL to allow 'group' declarations, and a new cli flag that excludes the given flags from being installed.

I ended up writing this before I realised how far I'd gotten, I figured I'd pause here and get feedback before I continue into tests and polish. **Does this seem interesting and/or supportable by the community?** I'd certainly find it useful (which is why I built it!) but maintenance of broadly unused code is hard!

## Example

A new `Brewfile` might look like this:

```Brewfile
# Naturally groups needn't be used at all, existing syntax is preserved entirely
brew "go"

# Groups can be specified as an option to all declarations
cask "slack", group: :work

# Specify a group with a block too
group :gaming do
  cask "discord"
  cask "steam"
end

# Multiple groups can be set at once, if needed
group :home, :work do
  brew "ipfs", restart_service: true
  mas "Synalyze It!", id: 417074533

  # The following line will break the Brewfile asgroups can't be declared as options within a group block
  cask "alfred", group: :anything
end
```

A user with the above `Brewfile` could bootstrap a new computer for home use like this:

```bash
$ brew bundle --without=gaming,work
## 
Installing go
Skipping slack (work group excluded)
Skipping discord (gaming group excluded)
Skipping steam (gaming group excluded)
Installing ipfs
Installing Synalyze It!
```
Notes:
- Items not in any groups can never be excluded, in the current implementation
- The last two are in the 'home' group, which isn't excluded, even though the 'work' group is — this matches `Gemfile`/bundler usage of the `--without-groups` parameter.
- I'm tempted to also offer an `--with` or `--with-only` option — but it is a little confusing as, unlike `bundle` this code doesn't have the concept of _optional_ groups.