### PR TITLE
workflows/tests: Test that `bundle`ing and running some software works

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,11 @@ jobs:
 
     - name: Run RSpec tests
       run: bundle exec rspec
+
+    - name: Test that installing works
+      run: |
+        echo 'brew "hello"' > ./Brewfile
+        brew bundle
+        hello
       
     - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47


### PR DESCRIPTION
- In light of 79441868a6a2e1002d8e080c8045483c41b411e3, to avoid future regressions, I was inspired by the `brew services start` tests in [the`brew services` repo](https://github.com/Homebrew/homebrew-services/blob/master/.github/workflows/tests.yml) to make a very simple functional test that this actually installs what it says it does.