### PR TITLE
installer.rb: change verb to "Upgrading" on upgradable formula/cask

### DIFF
--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -17,9 +17,11 @@ module Bundle
         cls = case type
         when :brew
           options = entry.options
+          verb = "Upgrading" if Bundle::BrewInstaller.formula_upgradable?(name)
           Bundle::BrewInstaller
         when :cask
           options = entry.options
+          verb = "Upgrading" if Bundle::CaskInstaller.cask_upgradable?(name)
           Bundle::CaskInstaller
         when :mas
           args << entry.options[:id]


### PR DESCRIPTION
Currently `brew bundle` logs upgrading formulae as `Installing <formula/cask>`.

This commit changes the verbiage to `Upgrading <fomula/cask>` when the Installer class method `{formula,cask}_upgradable?()` returns `true`