### PR TITLE
`bundle`: fix `cask_installed?` with `HOMEBREW_INSTALL_FROM_API` set

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -35,7 +35,8 @@ module Bundle
 
     def cask_installed?
       @cask_installed ||= File.directory?("#{HOMEBREW_PREFIX}/Caskroom") &&
-                          File.directory?("#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask")
+                          (File.directory?("#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask") ||
+                           Homebrew::EnvConfig.install_from_api?)
     end
 
     def services_installed?


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-bundle/issues/1015

`Bundle::cask_installed?` now returns `true` even if the `homebrew/cask` directory doesn't exist as long as `HOMEBREW_INSTALL_FROM_API` is set.
