### PR TITLE
mac_app_store_installer: handle Monterey.

### DIFF
--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -24,6 +24,11 @@ module Bundle
         return false
       end
 
+      if MacOS.version == :monterey
+        puts "Skipping install of #{name} app. mas is not yet functional on Monterey" if verbose
+        return false
+      end
+
       unless Bundle.mas_signedin?
         puts "Not signed in to Mac App Store." if verbose
         raise "Unable to install #{name} app. mas not signed in to Mac App Store."

--- a/spec/bundle/mac_app_store_installer_spec.rb
+++ b/spec/bundle/mac_app_store_installer_spec.rb
@@ -76,6 +76,17 @@ describe Bundle::MacAppStoreInstaller do
         end
       end
 
+      context "when on Monterey" do
+        before do
+          allow(MacOS).to receive(:version).and_return(:monterey)
+        end
+
+        it "skips" do
+          expect(Bundle).not_to receive(:system)
+          expect(described_class.preinstall("foo", 123)).to be(false)
+        end
+      end
+
       context "when app is outdated" do
         before do
           allow(described_class).to receive(:installed_app_ids).and_return([123])


### PR DESCRIPTION
`mas` is not yet functional on Monterey. To track progress or to *contribute* to fixing this issue, please see: https://github.com/mas-cli/mas/issues/417