### PR TITLE
Remove `mas account` check

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -30,6 +30,10 @@ module Bundle
     end
 
     def mas_signedin?
+      # mas account doesn't work on Monterey (yet)
+      # https://github.com/mas-cli/mas/issues/417#issuecomment-957963271
+      return true if MacOS.version >= :monterey
+
       Kernel.system "mas account &>/dev/null"
     end
 

--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -24,11 +24,6 @@ module Bundle
         return false
       end
 
-      if MacOS.version == :monterey
-        puts "Skipping install of #{name} app. mas is not yet functional on Monterey" if verbose
-        return false
-      end
-
       unless Bundle.mas_signedin?
         puts "Not signed in to Mac App Store." if verbose
         raise "Unable to install #{name} app. mas not signed in to Mac App Store."

--- a/spec/bundle/mac_app_store_installer_spec.rb
+++ b/spec/bundle/mac_app_store_installer_spec.rb
@@ -76,17 +76,6 @@ describe Bundle::MacAppStoreInstaller do
         end
       end
 
-      context "when on Monterey" do
-        before do
-          allow(MacOS).to receive(:version).and_return(:monterey)
-        end
-
-        it "skips" do
-          expect(Bundle).not_to receive(:system)
-          expect(described_class.preinstall("foo", 123)).to be(false)
-        end
-      end
-
       context "when app is outdated" do
         before do
           allow(described_class).to receive(:installed_app_ids).and_return([123])

--- a/spec/bundle/mac_app_store_installer_spec.rb
+++ b/spec/bundle/mac_app_store_installer_spec.rb
@@ -54,6 +54,7 @@ describe Bundle::MacAppStoreInstaller do
       it "outputs an error" do
         allow(described_class).to receive(:installed_app_ids).and_return([123])
         allow(described_class).to receive(:outdated_app_ids).and_return([123])
+        allow(MacOS).to receive(:version).and_return(:big_sur)
         expect(Kernel).to receive(:system).with("mas account &>/dev/null").and_return(false)
         expect { described_class.preinstall("foo", 123) }.to raise_error(RuntimeError)
       end


### PR DESCRIPTION
As of macOS 12 Monterey, `mas-cli` is no longer able to query whether the user is signed into the App Store.
https://github.com/mas-cli/mas/issues/417

I propose that instead of querying `mas account`, `brew bundle` directly attempts the `mas install` operation it intends to perform. If the user is not yet signed into the App Store, the App Store app appears with a prompt to sign in. This should continue to address the concerns expressed in #233/#235 by @ffittschen.

I also reverted #1019 per my comments [here](https://github.com/Homebrew/homebrew-bundle/pull/1019#issuecomment-961501752).

FYI @phatblat