### PR TITLE
skipper: skip unbottled only on ARM/Linux default prefix.

### DIFF
--- a/lib/bundle/skipper.rb
+++ b/lib/bundle/skipper.rb
@@ -6,12 +6,14 @@ module Bundle
   module Skipper
     class << self
       def skip?(entry, silent: false)
-        if Hardware::CPU.arm? &&
+        if (Hardware::CPU.arm? || OS.linux?) &&
+           Homebrew.default_prefix? &&
            entry.type == :brew && entry.name.exclude?("/") &&
            (formula = BrewDumper.formulae_by_full_name(entry.name)) &&
            formula[:official_tap] &&
            !formula[:bottled_or_disabled]
-          puts Formatter.warning "Skipping #{entry.name} (no bottle for Apple Silicon)" unless silent
+          reason = Hardware::CPU.arm? ? "Apple Silicon" : "Linux"
+          puts Formatter.warning "Skipping #{entry.name} (no bottle for #{reason})" unless silent
           return true
         end
 

--- a/spec/stub/global.rb
+++ b/spec/stub/global.rb
@@ -4,3 +4,11 @@ HOMEBREW_PREFIX = Pathname("/usr/local").freeze
 HOMEBREW_REPOSITORY = Pathname("/usr/local/Homebrew").freeze
 HOMEBREW_BREW_FILE = Pathname(HOMEBREW_PREFIX/"bin/brew").freeze
 HOMEBREW_VERSION = "2.6.0"
+
+module Homebrew
+  module_function
+
+  def default_prefix?
+    true
+  end
+end


### PR DESCRIPTION
It doesn't make sense to do this when we expect to build bottles from source. Now that we've merged homebrew/core and linuxbrew/core, though, ARM and Linux are in the same boat so have this functionality for both.

Fixes #1028