### PR TITLE
Don't try to restart services with status `none`

### DIFF
--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -30,9 +30,10 @@ module Bundle
 
     def started_services
       @started_services ||= if Bundle.services_installed?
+        states_to_skip = %w[stopped none]
         `brew services list`.lines.map do |line|
           name, state, _plist = line.split(/\s+/)
-          next if state == "stopped"
+          next if states_to_skip.include? state
 
           name
         end.compact


### PR DESCRIPTION
I noticed that running `brew bundle dump` added the `restart_service: true` option for a few formulae that I had installed. I looked into it a bit more and found that this is set for all services with a status that is not `stopped`. I had a few services that I didn't think should be running, but had the status `none` rather than `stopped`. So, they were being given the `restart_service` parameter even though they were stopped and, in my opinion, shouldn't be restarted.

Here's what I did to troubleshoot:
1. `brew install mosquitto`
2. `brew services start mosquitto`
3. `brew services stop mosquitto`
4. `brew services list`

I poked around a bit in the services repository and it looks like the reason the status is showing as `stopped` instead of `none` is that the service isn't "loaded" (i.e. doesn't show up in `launchctl list`) and also isn't "timed" which I think means its service block doesn't have an `interval` call.

So, it _seems_ like all services except for the 9 times services in Homebrew/core, all services would have this `none` status instead of `stopped`. It seems, then, that services with the `none` status shouldn't be given the `restart_service` line in a Brewfile. It's possible that some of the [other statuses](https://github.com/Homebrew/homebrew-services/blob/0d503a251d67f5e93aaf376eb65ec9ed6cb62e9d/lib/service/formula_wrapper.rb#L200-L218) should be excluded here too, but I'm not super familiar with them and none seemed like they obviously should be.

Anyway, that's a really long winded explanation of my thinking because I've never really touched the service stuff before. All this PR does is change the condition for adding `restart_service: true` to be if the status is `stopped` _or_ `none`.
