### PR TITLE
Emit brew install args when in verbose mode

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -236,7 +236,8 @@ module Bundle
     end
 
     def install!(verbose:)
-      puts "Installing #{@name} formula#{" with args #{@args}" if !@args.empty?}. It is not currently installed." if verbose
+      with_args = @args.empty? ? "" : " with args #{@args}"
+      puts "Installing #{@name} formula#{with_args}. It is not currently installed." if verbose
       unless Bundle.system(HOMEBREW_BREW_FILE, "install", "--formula", @full_name, *@args, verbose: verbose)
         @changed = nil
         return false

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -236,7 +236,7 @@ module Bundle
     end
 
     def install!(verbose:)
-      puts "Installing #{@name} formula. It is not currently installed." if verbose
+      puts "Installing #{@name} formula#{" with args #{@args}" if !@args.empty?}. It is not currently installed." if verbose
       unless Bundle.system(HOMEBREW_BREW_FILE, "install", "--formula", @full_name, *@args, verbose: verbose)
         @changed = nil
         return false

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -236,7 +236,7 @@ module Bundle
     end
 
     def install!(verbose:)
-      with_args = @args.empty? ? "" : " with args #{@args}"
+      with_args = " with args #{@args}" if @args.present?
       puts "Installing #{@name} formula#{with_args}. It is not currently installed." if verbose
       unless Bundle.system(HOMEBREW_BREW_FILE, "install", "--formula", @full_name, *@args, verbose: verbose)
         @changed = nil


### PR DESCRIPTION
I'm setting up a Brewfile that will install the dependencies for a package that is in Homebrew but we're needing to install the package itself outside of Homebrew. I added `args: ['only-dependencies']` to the brew line but it wasn't working: the package itself was getting installed. So, I added this logging facility and realized that I'd typed "only_dependencies" instead. It seems prudent to show all args passed to `brew install` when verbosity is requested.