### PR TITLE
Add support for arbitrary args to tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ An example `Brewfile`:
 tap "homebrew/cask"
 # 'brew tap' with custom Git URL
 tap "user/tap-repo", "https://user@bitbucket.org/user/homebrew-tap-repo.git"
+# 'brew tap' with arguments
+tap "user/tap-repo", "https://user@bitbucket.org/user/homebrew-tap-repo.git", force_auto_update: true
+
 # set arguments for all 'brew install --cask' commands
 cask_args appdir: "~/Applications", require_sha: true
 

--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -74,14 +74,15 @@ module Bundle
       @entries << Entry.new(:whalebrew, name)
     end
 
-    def tap(name, clone_target = nil)
+    def tap(name, clone_target = nil, options = {})
       raise "name(#{name.inspect}) should be a String object" unless name.is_a? String
       if clone_target && !clone_target.is_a?(String)
         raise "clone_target(#{clone_target.inspect}) should be nil or a String object"
       end
 
+      options[:clone_target] = clone_target
       name = Bundle::Dsl.sanitize_tap_name(name)
-      @entries << Entry.new(:tap, name, clone_target: clone_target)
+      @entries << Entry.new(:tap, name, options)
     end
 
     HOMEBREW_TAP_ARGS_REGEX = %r{^([\w-]+)/(homebrew-)?([\w-]+)$}.freeze

--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -17,10 +17,13 @@ module Bundle
       return true unless preinstall
 
       puts "Installing #{name} tap. It is not currently installed." if verbose
+      args = []
+      args.append("--force-auto-update") if options[:force_auto_update]
+
       success = if options[:clone_target]
-        Bundle.system HOMEBREW_BREW_FILE, "tap", name, options[:clone_target], verbose: verbose
+        Bundle.system HOMEBREW_BREW_FILE, "tap", name, options[:clone_target], *args, verbose: verbose
       else
-        Bundle.system HOMEBREW_BREW_FILE, "tap", name, verbose: verbose
+        Bundle.system HOMEBREW_BREW_FILE, "tap", name, *args, verbose: verbose
       end
 
       unless success

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -10,6 +10,7 @@ describe Bundle::Dsl do
         cask_args appdir: '/Applications'
         tap 'homebrew/cask'
         tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
+        tap 'auto/update', 'https://bitbucket.org/auto/update.git', force_auto_update: true
         brew 'imagemagick'
         brew 'mysql@5.6', restart_service: true, link: true, conflicts_with: ['mysql']
         brew 'emacs', args: ['with-cocoa', 'with-gnutls']
@@ -34,18 +35,20 @@ describe Bundle::Dsl do
       expect(dsl.entries[1].name).to eql("telemachus/brew")
       expect(dsl.entries[1].options).to \
         eql(clone_target: "https://telemachus@bitbucket.org/telemachus/brew.git")
-      expect(dsl.entries[2].name).to eql("imagemagick")
-      expect(dsl.entries[3].name).to eql("mysql@5.6")
-      expect(dsl.entries[3].options).to eql(restart_service: true, link: true, conflicts_with: ["mysql"])
-      expect(dsl.entries[4].name).to eql("emacs")
-      expect(dsl.entries[4].options).to eql(args: ["with-cocoa", "with-gnutls"])
-      expect(dsl.entries[5].name).to eql("google-chrome")
-      expect(dsl.entries[6].name).to eql("java")
-      expect(dsl.entries[7].name).to eql("firefox")
-      expect(dsl.entries[7].options).to eql(args: { appdir: "~/my-apps/Applications" }, full_name: "firefox")
-      expect(dsl.entries[8].name).to eql("1Password")
-      expect(dsl.entries[8].options).to eql(id: 443_987_910)
-      expect(dsl.entries[9].name).to eql("whalebrew/wget")
+      expect(dsl.entries[2].options).to \
+        eql(clone_target: "https://bitbucket.org/auto/update.git", force_auto_update: true)
+      expect(dsl.entries[3].name).to eql("imagemagick")
+      expect(dsl.entries[4].name).to eql("mysql@5.6")
+      expect(dsl.entries[4].options).to eql(restart_service: true, link: true, conflicts_with: ["mysql"])
+      expect(dsl.entries[5].name).to eql("emacs")
+      expect(dsl.entries[5].options).to eql(args: ["with-cocoa", "with-gnutls"])
+      expect(dsl.entries[6].name).to eql("google-chrome")
+      expect(dsl.entries[7].name).to eql("java")
+      expect(dsl.entries[8].name).to eql("firefox")
+      expect(dsl.entries[8].options).to eql(args: { appdir: "~/my-apps/Applications" }, full_name: "firefox")
+      expect(dsl.entries[9].name).to eql("1Password")
+      expect(dsl.entries[9].options).to eql(id: 443_987_910)
+      expect(dsl.entries[10].name).to eql("whalebrew/wget")
     end
   end
 

--- a/spec/bundle/tap_installer_spec.rb
+++ b/spec/bundle/tap_installer_spec.rb
@@ -53,5 +53,25 @@ describe Bundle::TapInstaller do
         expect(described_class.install("homebrew/cask", clone_target: "clone_target_path")).to be(false)
       end
     end
+
+    context "with force_auto_update" do
+      it "taps" do
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask",
+                                                "--force-auto-update",
+                                                verbose: false)
+                                          .and_return(true)
+        expect(described_class.preinstall("homebrew/cask", force_auto_update: true)).to be(true)
+        expect(described_class.install("homebrew/cask", force_auto_update: true)).to be(true)
+      end
+
+      it "fails" do
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask",
+                                                "--force-auto-update",
+                                                verbose: false)
+                                          .and_return(false)
+        expect(described_class.preinstall("homebrew/cask", force_auto_update: true)).to be(true)
+        expect(described_class.install("homebrew/cask", force_auto_update: true)).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1063. Allows arguments to taps in a Brewfile with:

  tap "foo/bar", "https://host/path/to/tap", args: ["force-auto-update"]

Mostly useful for adding --force-auto-update for non-Github taps.

Syntax is an array of arguments, like with `brew`, rather than a
dictionary like `cask` - this is because none of the optional arguments
of `brew tap` take a value right now. In the future, we should be able
to add support for dictionaries as well without needing to change the
format, if that becomes necessary.