### PR TITLE
only remove lockfile if it is not symlink

### DIFF
--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -14,9 +14,9 @@ module Bundle
 
       # no need to call realpath if the lockfile is not a symlink
       # unnecessary call to fs, also breaks tests, which use filenames that are not in fs
-      return lock_file_path unless lock_file_path.symlink?
+      lock_file_path = lock_file_path.realpath if lock_file_path.symlink?
 
-      lock_file_path.realpath
+      lock_file_path
     end
 
     def write_lockfile?(global: false, file: nil, no_lock: false)

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -12,9 +12,10 @@ module Bundle
       brew_file_path = Brewfile.path(global: global, file: file)
       lock_file_path = brew_file_path.dirname/"#{brew_file_path.basename}.lock.json"
 
-      # will recursively resolve any symlinks to lock file, if present
-      # so that calling `unlink` on the lockfile will remove the original file
-      # not the symlinks
+      # no need to call realpath if the lockfile is not a symlink
+      # unnecessary call to fs, also breaks tests, which use filenames that are not in fs
+      return lock_file_path if !lock_file_path.symlink?
+
       lock_file_path.realpath
     end
 

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -75,7 +75,7 @@ module Bundle
 
       json = JSON.pretty_generate(lock)
       begin
-        lockfile.unlink if lockfile.exist?
+        lockfile.unlink if lockfile.exist? and not lockfile.symlink?
         lockfile.write("#{json}\n")
       rescue Errno::EPERM, Errno::EACCES, Errno::ENOTEMPTY
         opoo "Could not write to #{lockfile}!"

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -14,7 +14,7 @@ module Bundle
 
       # no need to call realpath if the lockfile is not a symlink
       # unnecessary call to fs, also breaks tests, which use filenames that are not in fs
-      return lock_file_path if !lock_file_path.symlink?
+      return lock_file_path unless lock_file_path.symlink?
 
       lock_file_path.realpath
     end

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -75,7 +75,7 @@ module Bundle
 
       json = JSON.pretty_generate(lock)
       begin
-        lockfile.unlink if lockfile.exist? and not lockfile.symlink?
+        lockfile.unlink if lockfile.exist? && !lockfile.symlink?
         lockfile.write("#{json}\n")
       rescue Errno::EPERM, Errno::EACCES, Errno::ENOTEMPTY
         opoo "Could not write to #{lockfile}!"


### PR DESCRIPTION
Currently, the Brewfile.lock.json is always deleted prior to being written to. However, this is breaking for workflows where the Brewfile.lock.json is symlinked into the same directory as the Brewfile, as the symlink is deleted, then a regular file is written in its place. As a result, the file that the symlink references is not updated with the new version info.

This workflow probably isn't super common, but for users of `stow` (https://github.com/aspiers/stow), this might be a nice improvement. They would keep the `.Brewfile` and `.Brewfile.lock.json` in their (e.g.) `~/dotfiles/brew/` folder, and symlink both `.Brewfile` and `.Brewfile.lock.json` to the `~` directory. When running `brew bundle install --global`, it would read from the `.Brewfile` symlinked to `~/.Brewfile`, and write to the `.Brewfile.lock.json` file symlinked to `~/.Brewfile.lock.json`. Since the symlink to the lockfile would not be deleted (after this change), the changes from running `brew bundle install --global` would be reflected in the `~/dotfiles/brew/.Brewfile.lock.json` file.

I wasn't sure of the reason why the lockfile is deleted with `lockfile.unlink` prior to writing, so I didn't remove that line, but instead special-cased the instance where the lockfile exists, but is a symlink. Another possible fix would be to never unlink the lockfile? Calling `lockfile.write` already replaces the entire contents of the file, so I think this only breaks workflows where the lockfile is a directory... but not 100% sure on that case.
