### PR TITLE
locker_spec: force cask to be installed.

### DIFF
--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -88,6 +88,7 @@ describe Bundle::Locker do
       context "when on macOS" do
         before do
           allow(OS).to receive(:mac?).and_return(true)
+          allow(Bundle).to receive(:cask_installed?).and_return(true)
 
           adoptopenjdk8 = instance_double(Cask::Cask, to_s: "adoptopenjdk8", version: "8,232:b09")
           allow(Cask::Caskroom).to receive(:casks).and_return([adoptopenjdk8])


### PR DESCRIPTION
Otherwise we're not sufficiently always testing cask version logic.