### PR TITLE
Instruct user that cleanup without --force takes no action

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -38,6 +38,8 @@ module Bundle
           cleanup = system_output_no_stderr(HOMEBREW_BREW_FILE, "cleanup")
           puts cleanup unless cleanup.empty?
         else
+          puts "Listing actions for cleanup, but not taking action..."
+          
           if casks.any?
             puts "Would uninstall casks:"
             puts Formatter.columns casks
@@ -58,6 +60,8 @@ module Bundle
             puts "Would `brew cleanup`:"
             puts cleanup
           end
+          
+          puts "Run 'brew bundle cleanup --force' to make changes."
         end
       end
 

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -59,7 +59,9 @@ module Bundle
             puts cleanup
           end
 
-          puts "Run `brew bundle cleanup --force` to make these changes."
+          if [casks.any?, formulae.any?, taps.any?, !cleanup.empty?].any?
+            puts "Run `brew bundle cleanup --force` to make these changes."
+          end
         end
       end
 

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -38,8 +38,6 @@ module Bundle
           cleanup = system_output_no_stderr(HOMEBREW_BREW_FILE, "cleanup")
           puts cleanup unless cleanup.empty?
         else
-          puts "Listing actions for cleanup, but not taking action..."
-
           if casks.any?
             puts "Would uninstall casks:"
             puts Formatter.columns casks
@@ -61,7 +59,7 @@ module Bundle
             puts cleanup
           end
 
-          puts "Run 'brew bundle cleanup --force' to make changes."
+          puts "Run `brew bundle cleanup --force` to make these changes."
         end
       end
 

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -59,7 +59,7 @@ module Bundle
             puts cleanup
           end
 
-          if [casks.any?, formulae.any?, taps.any?, !cleanup.empty?].any?
+          if casks.any? || formulae.any? || taps.any? || cleanup.any?
             puts "Run `brew bundle cleanup --force` to make these changes."
           end
         end

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -39,7 +39,7 @@ module Bundle
           puts cleanup unless cleanup.empty?
         else
           puts "Listing actions for cleanup, but not taking action..."
-          
+
           if casks.any?
             puts "Would uninstall casks:"
             puts Formatter.columns casks
@@ -60,7 +60,7 @@ module Bundle
             puts "Would `brew cleanup`:"
             puts cleanup
           end
-          
+
           puts "Run 'brew bundle cleanup --force' to make changes."
         end
       end

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -59,7 +59,7 @@ module Bundle
             puts cleanup
           end
 
-          if casks.any? || formulae.any? || taps.any? || cleanup.any?
+          if casks.any? || formulae.any? || taps.any? || !cleanup.empty?
             puts "Run `brew bundle cleanup --force` to make these changes."
           end
         end


### PR DESCRIPTION
#1099 surfaced a UX improvement that directly tells the user what's going on and what action to take since the default is safety-on.