### PR TITLE
brew_services: use `HOMEBREW_BREW_FILE`

### DIFF
--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -31,7 +31,7 @@ module Bundle
     def started_services
       @started_services ||= if Bundle.services_installed?
         states_to_skip = %w[stopped none]
-        `brew services list`.lines.map do |line|
+        Utils.safe_popen_read(HOMEBREW_BREW_FILE, "services", "list").lines.map do |line|
           name, state, _plist = line.split(/\s+/)
           next if states_to_skip.include? state
 

--- a/spec/bundle/brew_dumper_spec.rb
+++ b/spec/bundle/brew_dumper_spec.rb
@@ -5,6 +5,7 @@ require "tsort"
 require "formula"
 require "tab"
 require "utils/bottles"
+require "utils/popen"
 
 describe Bundle::BrewDumper do
   subject(:dumper) { described_class }

--- a/spec/bundle/brew_services_spec.rb
+++ b/spec/bundle/brew_services_spec.rb
@@ -15,7 +15,7 @@ describe Bundle::BrewServices do
 
     it "returns started services" do
       allow(Bundle).to receive(:services_installed?).and_return(true)
-      allow(described_class).to receive(:`).and_return <<~EOS
+      allow(Utils).to receive(:safe_popen_read).and_return <<~EOS
         nginx  started  homebrew.mxcl.nginx.plist
         apache stopped  homebrew.mxcl.apache.plist
         mysql  started  homebrew.mxcl.mysql.plist

--- a/spec/stub/utils/popen.rb
+++ b/spec/stub/utils/popen.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Utils
+  class << self
+    def safe_popen_read(*args)
+      `#{args.join(" ")}`
+    end
+  end
+end


### PR DESCRIPTION
`brew` probably isn't in `PATH` here. While we're here, let's avoid the
backticks.

Fixes Homebrew/brew#13611.
