### PR TITLE
Support link `--overwrite` with `brew "formula", link: :overwrite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ tap "user/tap-repo", "https://user@bitbucket.org/user/homebrew-tap-repo.git", fo
 # set arguments for all 'brew install --cask' commands
 cask_args appdir: "~/Applications", require_sha: true
 
-# 'brew install'
-brew "imagemagick"
+# 'brew install', 'brew link'
+brew "imagemagick@6", link: true
 # 'brew install --with-rmtp', 'brew services restart' on version changes
 brew "denji/nginx/nginx-full", args: ["with-rmtp"], restart_service: :changed
-# 'brew install', always 'brew services restart', 'brew link', 'brew unlink mysql' (if it is installed)
-brew "mysql@5.6", restart_service: true, link: true, conflicts_with: ["mysql"]
+# 'brew install', always 'brew services restart', 'brew link --overwrite', 'brew unlink mysql' (if it is installed)
+brew "mysql@5.6", restart_service: true, link: :overwrite, conflicts_with: ["mysql"]
 
 # 'brew install --cask'
 cask "google-chrome"

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -92,6 +92,9 @@ module Bundle
 
     def link_change_state!(verbose: false)
       case @link
+      when :overwrite
+        puts "Overwriting links for #{@name} formula." if verbose
+        Bundle.system(HOMEBREW_BREW_FILE, "link", "--force", "--overwrite", @name, verbose: verbose)
       when true
         unless linked_and_keg_only?
           puts "Force-linking #{@name} formula." if verbose

--- a/spec/bundle/brew_installer_spec.rb
+++ b/spec/bundle/brew_installer_spec.rb
@@ -48,6 +48,19 @@ describe Bundle::BrewInstaller do
       end
     end
 
+    context "when the link option is :overwrite" do
+      before do
+        allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
+      end
+
+      it "links formula" do
+        expect(Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "link", "--force", "--overwrite", "mysql",
+                                                verbose: false).and_return(true)
+        described_class.preinstall(formula, link: :overwrite)
+        described_class.install(formula, link: :overwrite)
+      end
+    end
+
     context "when the link option is false" do
       before do
         allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -11,8 +11,8 @@ describe Bundle::Dsl do
         tap 'homebrew/cask'
         tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
         tap 'auto/update', 'https://bitbucket.org/auto/update.git', force_auto_update: true
-        brew 'imagemagick'
-        brew 'mysql@5.6', restart_service: true, link: true, conflicts_with: ['mysql']
+        brew 'imagemagick@6', link: true
+        brew 'mysql@5.6', restart_service: true, link: :overwrite, conflicts_with: ['mysql']
         brew 'emacs', args: ['with-cocoa', 'with-gnutls']
         cask 'google-chrome'
         cask 'java' unless system '/usr/libexec/java_home --failfast'
@@ -37,9 +37,10 @@ describe Bundle::Dsl do
         eql(clone_target: "https://telemachus@bitbucket.org/telemachus/brew.git")
       expect(dsl.entries[2].options).to \
         eql(clone_target: "https://bitbucket.org/auto/update.git", force_auto_update: true)
-      expect(dsl.entries[3].name).to eql("imagemagick")
+      expect(dsl.entries[3].name).to eql("imagemagick@6")
+      expect(dsl.entries[3].options).to eql(link: true)
       expect(dsl.entries[4].name).to eql("mysql@5.6")
-      expect(dsl.entries[4].options).to eql(restart_service: true, link: true, conflicts_with: ["mysql"])
+      expect(dsl.entries[4].options).to eql(restart_service: true, link: :overwrite, conflicts_with: ["mysql"])
       expect(dsl.entries[5].name).to eql("emacs")
       expect(dsl.entries[5].options).to eql(args: ["with-cocoa", "with-gnutls"])
       expect(dsl.entries[6].name).to eql("google-chrome")


### PR DESCRIPTION
Implies `--force` for uniform usage with keg-only formulae.

Closes #1062.