### PR TITLE
Let users choose to install things even if no bottle exists

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -18,6 +18,8 @@ module Homebrew
 
         You can skip the installation of dependencies by adding space-separated values to one or more of the following environment variables: `HOMEBREW_BUNDLE_BREW_SKIP`, `HOMEBREW_BUNDLE_CASK_SKIP`, `HOMEBREW_BUNDLE_MAS_SKIP`, `HOMEBREW_BUNDLE_WHALEBREW_SKIP`, `HOMEBREW_BUNDLE_TAP_SKIP`.
 
+	You can force installation of a formula that does not have a bottle by setting the `HOMEBREW_INSTALL_IF_BOTTLE_MISSING` environment variable to `true`.
+
         `brew bundle` will output a `Brewfile.lock.json` in the same directory as the `Brewfile` if all dependencies are installed successfully. This contains dependency and system status information which can be useful in debugging `brew bundle` failures and replicating a "last known good build" state. You can opt-out of this behaviour by setting the `HOMEBREW_BUNDLE_NO_LOCK` environment variable or passing the `--no-lock` option. You may wish to check this file into the same version control system as your `Brewfile` (or ensure your version control system ignores it if you'd prefer to rely on debugging information from a local machine).
 
         `brew bundle dump`:

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -18,7 +18,7 @@ module Homebrew
 
         You can skip the installation of dependencies by adding space-separated values to one or more of the following environment variables: `HOMEBREW_BUNDLE_BREW_SKIP`, `HOMEBREW_BUNDLE_CASK_SKIP`, `HOMEBREW_BUNDLE_MAS_SKIP`, `HOMEBREW_BUNDLE_WHALEBREW_SKIP`, `HOMEBREW_BUNDLE_TAP_SKIP`.
 
-	You can force installation of a formula that does not have a bottle by setting the `HOMEBREW_INSTALL_IF_BOTTLE_MISSING` environment variable to `true`.
+        You can force installation of a formula that does not have a bottle by setting the `HOMEBREW_INSTALL_IF_BOTTLE_MISSING` environment variable to `true`.
 
         `brew bundle` will output a `Brewfile.lock.json` in the same directory as the `Brewfile` if all dependencies are installed successfully. This contains dependency and system status information which can be useful in debugging `brew bundle` failures and replicating a "last known good build" state. You can opt-out of this behaviour by setting the `HOMEBREW_BUNDLE_NO_LOCK` environment variable or passing the `--no-lock` option. You may wish to check this file into the same version control system as your `Brewfile` (or ensure your version control system ignores it if you'd prefer to rely on debugging information from a local machine).
 

--- a/lib/bundle/skipper.rb
+++ b/lib/bundle/skipper.rb
@@ -18,8 +18,9 @@ module Bundle
 
           # If the user wants to install things from a bundle even if no bottle exists
           # we should let them.
-          if ENV['HOMEBREW_INSTALL_IF_BOTTLE_MISSING'] == "true"
-            puts Formatter.warning "... but HOMEBREW_INSTALL_IF_BOTTLE_MISSING is set to true. Installing anyway!" unless silent
+          if ENV["HOMEBREW_INSTALL_IF_BOTTLE_MISSING"] == "true"
+            message = "... but HOMEBREW_INSTALL_IF_BOTTLE_MISSING is set to true. Installing anyway!"
+            puts Formatter.warning message unless silent
             return false
           end
 

--- a/lib/bundle/skipper.rb
+++ b/lib/bundle/skipper.rb
@@ -13,7 +13,16 @@ module Bundle
            formula[:official_tap] &&
            !formula[:bottled]
           reason = Hardware::CPU.arm? ? "Apple Silicon" : "Linux"
+
           puts Formatter.warning "Skipping #{entry.name} (no bottle for #{reason})" unless silent
+
+          # If the user wants to install things from a bundle even if no bottle exists
+          # we should let them.
+          if ENV['HOMEBREW_INSTALL_IF_BOTTLE_MISSING'] == "true"
+            puts Formatter.warning "... but HOMEBREW_INSTALL_IF_BOTTLE_MISSING is set to true. Installing anyway!" unless silent
+            return false
+          end
+
           return true
         end
 

--- a/spec/bundle/skipper_spec.rb
+++ b/spec/bundle/skipper_spec.rb
@@ -33,6 +33,14 @@ describe Bundle::Skipper do
 
         expect(skipper.skip?(entry)).to be true
       end
+      it "returns false when HOMEBREW_INSTALL_IF_BOTTLE_MISSING is true" do
+        allow(ENV).to receive(:[]).with("HOMEBREW_INSTALL_IF_BOTTLE_MISSING").and_return("true")
+        allow(Hardware::CPU).to receive(:arm?).and_return(true)
+        allow_any_instance_of(Formula).to receive(:bottled?).and_return(false)
+
+        expect(skipper.skip?(entry)).to be false 
+      end
+
     end
 
     context "with an unlisted cask", :needs_macos do


### PR DESCRIPTION
I have seen a few previous comments somewhat related to this but I think that users should be able to forcibly install things even if no bottle exists. An environment variable seemed like the least amount of surgery to accomplish this (and in-line with other toggles in general) but if there is a different, preferred, mechanism then let me know. 

For context, I have a setup where changing my `Brewfile` causes `brew bundle` to be run after my configs get updated (using `chezmoi`) and I would like to be able to have the `Brewfile` be a single source of truth because then I am less likely to install packages ad-hoc. Without the ability to override this skip behavior I can't install some packages this way (things like luajit, neovim and tree-sitter will not install via `Brewfile` without a way to override the no-bottle behavior.