### PR TITLE
`BrewDumper`: use `stable` spec for querying formula metadata

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -118,6 +118,8 @@ module Bundle
     private_class_method :add_formula
 
     def formula_to_hash(formula)
+      formula.active_spec = :stable
+
       keg = if formula.linked?
         link = true if formula.keg_only?
         formula.linked_keg


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-bundle/pull/1117

This PR forces us to use the `stable` spec when getting formula information for determining whether to skip and other things like that. Bottle information is only available for the stable spec, so it makes sense to use it here.

At the moment, I haven't figured out how to update the tests to handle this without drastically rewriting them. Is there a way to allow an `instance_double` to receive `:active_spec=`? Even though that method is defined on the `Formula` class, `rspec` doesn't seem to like it. I don't have a ton of time at the moment to focus on this so I'm opening this as a draft in case anyone has any ideas. Feel free to push to fix.

Also, we may end up _wanting_ to use the `head` spec if `--HEAD` is specified as an argument since otherwise, we may not get accurate dependency information. I have to think about that more