### PR TITLE
brew_dumper: check for bottles on stable spec.

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -149,9 +149,9 @@ module Bundle
 
       runtime_dependencies ||= formula.runtime_dependencies.map(&:name)
 
-      bottled = if formula.bottle_defined?
+      bottled = if (stable = formula.stable) && stable.bottle_defined?
         bottle_hash = formula.bottle_hash.deep_symbolize_keys
-        formula.bottled?
+        stable.bottled?
       end
 
       {

--- a/spec/bundle/brew_dumper_spec.rb
+++ b/spec/bundle/brew_dumper_spec.rb
@@ -25,8 +25,7 @@ describe Bundle::BrewDumper do
                     keg_only?:              true,
                     pinned?:                false,
                     outdated?:              false,
-                    bottle_defined?:        false,
-                    bottled?:               false,
+                    stable:                 OpenStruct.new(bottle_defined?: false, bottled?: false),
                     tap:                    OpenStruct.new(official?: false))
   end
   let(:foo_hash) do
@@ -70,9 +69,8 @@ describe Bundle::BrewDumper do
                     keg_only?:              false,
                     pinned?:                true,
                     outdated?:              true,
-                    bottle_defined?:        true,
-                    bottled?:               true,
                     linked_keg:             linked_keg,
+                    stable:                 OpenStruct.new(bottle_defined?: true, bottled?: true),
                     tap:                    OpenStruct.new(official?: true),
                     bottle_hash:            {
                       cellar: ":any",
@@ -132,8 +130,7 @@ describe Bundle::BrewDumper do
                     keg_only?:              false,
                     pinned?:                false,
                     outdated?:              false,
-                    bottle_defined?:        false,
-                    bottled?:               false,
+                    stable:                 OpenStruct.new(bottle_defined?: false, bottled?: false),
                     tap:                    OpenStruct.new(official?: false))
   end
   let(:baz_hash) do

--- a/spec/bundle/skipper_spec.rb
+++ b/spec/bundle/skipper_spec.rb
@@ -29,7 +29,8 @@ describe Bundle::Skipper do
 
       it "returns true" do
         allow(Hardware::CPU).to receive(:arm?).and_return(true)
-        allow_any_instance_of(Formula).to receive(:bottled?).and_return(false)
+        allow_any_instance_of(Formula).to receive(:stable).and_return(OpenStruct.new(bottled?:        false,
+                                                                                     bottle_defined?: true))
 
         expect(skipper.skip?(entry)).to be true
       end

--- a/spec/stub/formula.rb
+++ b/spec/stub/formula.rb
@@ -44,14 +44,6 @@ class Formula
     new(name)
   end
 
-  def bottle_defined?
-    true
-  end
-
-  def bottled?
-    true
-  end
-
   def bottle_hash
     {}
   end
@@ -99,6 +91,10 @@ class Formula
   end
 
   def tap
-    OpenStruct.new official?: true
+    OpenStruct.new(official?: true)
+  end
+
+  def stable
+    OpenStruct.new(bottled?: true, bottle_defined?: true)
   end
 end


### PR DESCRIPTION
Bottles are never present on `head` so don't look there, even if that's what's been installed.

Fixes #1117
Closes #1118