### PR TITLE
run `setup-ruby` for all OS variants

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,7 @@ jobs:
     - run: brew test-bot --only-tap-syntax
 
     - name: Set up Ruby
-      if: matrix.os == 'ubuntu-latest'
-      uses: actions/setup-ruby@master
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
 
@@ -52,5 +51,5 @@ jobs:
         echo 'brew "hello"' > ./Brewfile
         brew bundle
         hello
-      
+
     - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70


### PR DESCRIPTION
Updates CI run `setup-ruby` on all OS versions since macos-12 has 3.0 for default however, we want to target 2.6 (for now).

Swaps the unmaintained `actions/setup-ruby` for `ruby/setup-ruby` actions while I'm here.