### PR TITLE
Include core tap hash in lock file only if tapped

### DIFF
--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -138,14 +138,17 @@ module Bundle
     end
 
     def system_macos
-      [MacOS.version.to_sym.to_s, {
+      details_hash = {
         "HOMEBREW_VERSION"       => HOMEBREW_VERSION,
         "HOMEBREW_PREFIX"        => HOMEBREW_PREFIX.to_s,
-        "Homebrew/homebrew-core" => CoreTap.instance.git_head,
         "CLT"                    => MacOS::CLT.version.to_s,
         "Xcode"                  => MacOS::Xcode.version.to_s,
         "macOS"                  => MacOS.full_version.to_s,
-      }]
+      }
+
+      details_hash["Homebrew/homebrew-core"] = CoreTap.instance.git_head if CoreTap.instance.installed?
+
+      [MacOS.version.to_sym.to_s, details_hash]
     end
 
     def system_linux

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -139,11 +139,11 @@ module Bundle
 
     def system_macos
       details_hash = {
-        "HOMEBREW_VERSION"       => HOMEBREW_VERSION,
-        "HOMEBREW_PREFIX"        => HOMEBREW_PREFIX.to_s,
-        "CLT"                    => MacOS::CLT.version.to_s,
-        "Xcode"                  => MacOS::Xcode.version.to_s,
-        "macOS"                  => MacOS.full_version.to_s,
+        "HOMEBREW_VERSION" => HOMEBREW_VERSION,
+        "HOMEBREW_PREFIX"  => HOMEBREW_PREFIX.to_s,
+        "CLT"              => MacOS::CLT.version.to_s,
+        "Xcode"            => MacOS::Xcode.version.to_s,
+        "macOS"            => MacOS.full_version.to_s,
       }
 
       details_hash["Homebrew/homebrew-core"] = CoreTap.instance.git_head if CoreTap.instance.installed?
@@ -160,9 +160,9 @@ module Bundle
       end
 
       details_hash = {
-        "HOMEBREW_VERSION"        => HOMEBREW_VERSION,
-        "HOMEBREW_PREFIX"         => HOMEBREW_PREFIX.to_s,
-        "GCC"                     => gcc_version,
+        "HOMEBREW_VERSION" => HOMEBREW_VERSION,
+        "HOMEBREW_PREFIX"  => HOMEBREW_PREFIX.to_s,
+        "GCC"              => gcc_version,
       }
 
       details_hash["Homebrew/linuxbrew-core"] = CoreTap.instance.git_head if CoreTap.instance.installed?

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -159,12 +159,15 @@ module Bundle
         DevelopmentTools.non_apple_gcc_version("gcc")
       end
 
-      [OS::Linux.os_version, {
+      details_hash = {
         "HOMEBREW_VERSION"        => HOMEBREW_VERSION,
         "HOMEBREW_PREFIX"         => HOMEBREW_PREFIX.to_s,
-        "Homebrew/linuxbrew-core" => CoreTap.instance.git_head,
         "GCC"                     => gcc_version,
-      }]
+      }
+
+      details_hash["Homebrew/linuxbrew-core"] = CoreTap.instance.git_head if CoreTap.instance.installed?
+
+      [OS::Linux.os_version, details_hash]
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-bundle/issues/1169

brew-bundle assumes homewbrew/core is tapped when writing the lock file. As of Homebrew 4, that is no longer a valid assumption. This PR modifies the locking behavior to only include a hash for homebrew/core if it is tapped.

n.b. I will close this if/when 1172 lands.