### PR TITLE
locker: Only get `CoreTap.instance.git_head` if not using the API

### DIFF
--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -3,6 +3,7 @@
 require "tap"
 require "os"
 require "development_tools"
+require "env_config"
 
 module Bundle
   module Locker
@@ -141,7 +142,7 @@ module Bundle
       [MacOS.version.to_sym.to_s, {
         "HOMEBREW_VERSION"       => HOMEBREW_VERSION,
         "HOMEBREW_PREFIX"        => HOMEBREW_PREFIX.to_s,
-        "Homebrew/homebrew-core" => CoreTap.instance.git_head,
+        "Homebrew/homebrew-core" => Homebrew::EnvConfig.install_from_api? ? "api" : CoreTap.instance.git_head,
         "CLT"                    => MacOS::CLT.version.to_s,
         "Xcode"                  => MacOS::Xcode.version.to_s,
         "macOS"                  => MacOS.full_version.to_s,
@@ -159,7 +160,7 @@ module Bundle
       [OS::Linux.os_version, {
         "HOMEBREW_VERSION"        => HOMEBREW_VERSION,
         "HOMEBREW_PREFIX"         => HOMEBREW_PREFIX.to_s,
-        "Homebrew/linuxbrew-core" => CoreTap.instance.git_head,
+        "Homebrew/linuxbrew-core" => Homebrew::EnvConfig.install_from_api? ? "api" : CoreTap.instance.git_head,
         "GCC"                     => gcc_version,
       }]
     end

--- a/spec/stub/env_config.rb
+++ b/spec/stub/env_config.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Homebrew
+  class EnvConfig
+    def self.install_from_api?
+      true
+    end
+  end
+end


### PR DESCRIPTION
- Fixes https://github.com/Homebrew/homebrew-bundle/issues/1170.
- Fixes https://github.com/Homebrew/homebrew-bundle/issues/1169.
- Before, the lockfile would try to populate with `CoreTap.instance.git_head` which doesn't exist when using the API (now the default), leading to this error for the user:

```
> brew bundle --file=testBrewfile
Using asdf
Error: No available tap homebrew/core.
```

Now:

```
> brew bundle --file=testBrewfile
Using asdf
Homebrew Bundle complete! 1 Brewfile dependency now installed.

❯ tail testBrewfile.lock.json
        "HOMEBREW_VERSION": "4.0.1-60-gf0bcef6-dirty",
        "HOMEBREW_PREFIX": "/opt/homebrew",
        "Homebrew/homebrew-core": "api",
        "CLT": "14.1.0.0.1.1666437224",
        "Xcode": "14.1",
        "macOS": "13.0"
      }
    }
  }
}
```
