### PR TITLE
Drops conditional usage of removed DevelopmentTools.gcc_version

### DIFF
--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -156,7 +156,7 @@ module Bundle
 
     def system_linux
       [OS::Linux.os_version, system.merge({
-        "GCC" => DevelopmentTools.non_apple_gcc_version("gcc"),
+        "GCC" => DevelopmentTools.gcc_version("gcc"),
       })]
     end
   end

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -155,15 +155,8 @@ module Bundle
     end
 
     def system_linux
-      # TODO: remove once https://github.com/Homebrew/brew/pull/13577 is merged and tagged.
-      gcc_version = if DevelopmentTools.respond_to?(:gcc_version)
-        DevelopmentTools.gcc_version("gcc")
-      else
-        DevelopmentTools.non_apple_gcc_version("gcc")
-      end
-
       [OS::Linux.os_version, system.merge({
-        "GCC" => gcc_version,
+        "GCC" => DevelopmentTools.non_apple_gcc_version("gcc"),
       })]
     end
   end

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -114,15 +114,6 @@ describe Bundle::Locker do
         end
 
         it "returns true" do
-          # TODO: remove once https://github.com/Homebrew/brew/pull/13577 is merged and tagged.
-          allow(DevelopmentTools).to receive(:respond_to?).and_return(true)
-          expect(lockfile).to receive(:write)
-          expect(locker.lock(entries)).to be true
-        end
-
-        # TODO: remove once https://github.com/Homebrew/brew/pull/13577 is merged and tagged.
-        it "returns true with non_apple_gcc_version" do
-          allow(DevelopmentTools).to receive(:respond_to?).and_return(false)
           expect(lockfile).to receive(:write)
           expect(locker.lock(entries)).to be true
         end

--- a/spec/stub/development_tools.rb
+++ b/spec/stub/development_tools.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class DevelopmentTools
-  def self.gcc_version(*)
-    "9.2.0"
-  end
-
   def self.non_apple_gcc_version(*)
     "9.2.0"
   end

--- a/spec/stub/development_tools.rb
+++ b/spec/stub/development_tools.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DevelopmentTools
-  def self.non_apple_gcc_version(*)
+  def self.gcc_version(*)
     "9.2.0"
   end
 end


### PR DESCRIPTION
Noticed this TODO while reading through for another task.

And just noticed #1173...

Closes #1173