### PR TITLE
Use `no_install_from_api?` to check for API

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -40,7 +40,7 @@ module Bundle
     def cask_installed?
       @cask_installed ||= File.directory?("#{HOMEBREW_PREFIX}/Caskroom") &&
                           (File.directory?("#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask") ||
-                           Homebrew::EnvConfig.install_from_api?)
+                           !Homebrew::EnvConfig.no_install_from_api?)
     end
 
     def services_installed?

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -142,7 +142,7 @@ module Bundle
       {
         "HOMEBREW_VERSION"       => HOMEBREW_VERSION,
         "HOMEBREW_PREFIX"        => HOMEBREW_PREFIX.to_s,
-        "Homebrew/homebrew-core" => Homebrew::EnvConfig.install_from_api? ? "api" : CoreTap.instance.git_head,
+        "Homebrew/homebrew-core" => Homebrew::EnvConfig.no_install_from_api? ? CoreTap.instance.git_head : "api",
       }
     end
 

--- a/spec/stub/env_config.rb
+++ b/spec/stub/env_config.rb
@@ -2,8 +2,8 @@
 
 module Homebrew
   class EnvConfig
-    def self.install_from_api?
-      true
+    def self.no_install_from_api?
+      false
     end
   end
 end


### PR DESCRIPTION
This is private API really. https://github.com/Homebrew/brew/pull/14794 is deleting `install_from_api?` but I noticed this repo was already using it.