### PR TITLE
rubocop: Fix `Naming/MethodParameterName` offenses for "f" name

### DIFF
--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -107,8 +107,8 @@ module Bundle
       @formula_oldnames
     end
 
-    def add_formula(f)
-      hash = formula_to_hash f
+    def add_formula(formula)
+      hash = formula_to_hash formula
 
       @formulae_by_name[hash[:name]] = hash
       @formulae_by_full_name[hash[:full_name]] = hash

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -55,7 +55,7 @@ describe Bundle::Commands::Cleanup do
         { name: "builddependency1", full_name: "builddependency1" },
         { name: "builddependency2", full_name: "builddependency2" },
         { name: "caskdependency", full_name: "homebrew/tap/caskdependency" },
-      ].map { |f| dependencies_arrays_hash.merge(f) }
+      ].map { |formula| dependencies_arrays_hash.merge(formula) }
       allow(Bundle::CaskDumper).to receive(:formula_dependencies).and_return(%w[caskdependency])
       expect(described_class.formulae_to_uninstall).to eql %w[
         c


### PR DESCRIPTION
- Part of https://github.com/Homebrew/brew/pull/14944.
- This stands for "formula".
