### PR TITLE
cleanup: graceful migration from `Brewfile` with no `vscode`.

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -144,6 +144,12 @@ module Bundle
       def vscode_extensions_to_uninstall(global: false, file: nil)
         @dsl ||= Bundle::Dsl.new(Brewfile.read(global: global, file: file))
         kept_extensions = @dsl.entries.select { |e| e.type == :vscode }.map(&:name)
+
+        # To provide a graceful migration from `Brewfile`s that don't yet or
+        # don't want to use `vscode`: don't remove any extensions if we don't
+        # find any in the `Brewfile`.
+        return [].freeze if kept_extensions.empty?
+
         current_extensions = Bundle::VscodeExtensionDumper.extensions
         current_extensions - kept_extensions
       end

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -20,6 +20,8 @@ describe Bundle::Commands::Cleanup do
         brew 'homebrew/tap/hasdependency'
         brew 'hasbuilddependency1'
         brew 'hasbuilddependency2'
+        mas 'appstoreapp1', id: 1
+        vscode 'vscodeextension1'
       EOS
     end
 


### PR DESCRIPTION
Don't uninstall all `vscode` extensions in this case.

Fixes https://github.com/Homebrew/homebrew-bundle/issues/1209