### PR TITLE
mac_app_store_installer: workaround `mas outdated` bug.

### DIFF
--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -70,13 +70,17 @@ module Bundle
     end
 
     def outdated_app_ids
-      @outdated_app_ids ||= if Bundle.mas_installed?
-        `mas outdated 2>/dev/null`.split("\n").map do |app|
-          app.split(" ", 2).first.to_i
-        end
-      else
-        []
-      end
+      []
+
+      # TODO: can't be trusted right now.
+      # Uncomment when https://github.com/mas-cli/mas/pull/496 is merged.
+      # @outdated_app_ids ||= if Bundle.mas_installed?
+      #   `mas outdated 2>/dev/null`.split("\n").map do |app|
+      #     app.split(" ", 2).first.to_i
+      #   end
+      # else
+      #   []
+      # end
     end
   end
 end

--- a/spec/bundle/mac_app_store_installer_spec.rb
+++ b/spec/bundle/mac_app_store_installer_spec.rb
@@ -42,13 +42,15 @@ describe Bundle::MacAppStoreInstaller do
       allow(Bundle).to receive(:mas_installed?).and_return(true)
     end
 
-    describe ".outdated_app_ids" do
-      it "returns app ids" do
-        expect(described_class).to receive(:`).and_return("foo 123")
-        described_class.reset!
-        described_class.outdated_app_ids
-      end
-    end
+    # TODO: can't be trusted right now.
+    # Uncomment when https://github.com/mas-cli/mas/pull/496 is merged.
+    # describe ".outdated_app_ids" do
+    #   it "returns app ids" do
+    #     expect(described_class).to receive(:`).and_return("foo 123")
+    #     described_class.reset!
+    #     described_class.outdated_app_ids
+    #   end
+    # end
 
     context "when mas is not signed in" do
       it "outputs an error" do


### PR DESCRIPTION
Until `mas outdated` is fixed, we can't trust its output. We're waiting on https://github.com/mas-cli/mas/pull/496 to be merged upstream and then this can be reverted.