### PR TITLE
Adds brief at_exit tutorial to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,33 @@ Disable generation of the `Brewfile.lock.json` file by setting the environment v
 
 Tests can be run with `bundle install && bundle exec rspec`.
 
+## Running actions after Homebrew Bundle runs
+
+If you need to run commands after Homebrew Bundle runs, such as using a package that was just installed,
+you can set an [`at_exit`](https://ruby-doc.org/core-2.6.8/Kernel.html#method-i-at_exit) hook and
+use parts of Homebrew Bundle and Homebrew itself to determine paths and execute the commands programmatically.
+Note that errors within an `at_exit` block may have unintended behavior, so program safely.
+It's better to resolve the paths than to hardcode them.
+
+In this example `Brewfile`, after installing the [cowsay](https://formulae.brew.sh/formula/cowsay) package,
+Homebrew Bundle, or, really, Ruby, will execute the program with a friendly message of completion.
+
+```ruby
+brew 'cowsay'
+
+at_exit do
+  # parse the args, get only the first
+  brew_bundle_cmd = Homebrew.bundle_args.parse.named.first
+  # only if install, whether default or explicit
+  if ['install', nil].include? brew_bundle_cmd
+    # Load the Formula then get its bin directory path
+    cowsay_bin = Formulary.factory('cowsay').bin
+    # execute the command
+    system "#{cowsay_bin}/cowsay 'All done!'"
+  end
+end
+```
+
 ## Copyright
 
 Copyright (c) Homebrew maintainers and Andrew Nesbitt. See [LICENSE](https://github.com/Homebrew/homebrew-bundle/blob/HEAD/LICENSE) for details.


### PR DESCRIPTION
This has come up at least thrice now in filed issues. I've also been using it without a problem in some Brewfiles, so let's document it.

My _sole_ hesitation here is the level of support for reaching into Homebrew and HB Bundle internals like this. I'd appreciate thoughts and guidance in that area.

A possible extension of this could be the extension of the Brewfile DSL to provide some convenience methods for common tasks, e.g.

```ruby
brew 'cowsay'

post_install do
  formula 'cowsay' do |f|
    system "#{f.bin}/cowsay 'All done!'"
  end
end
```