### PR TITLE
bundle: Check for cask tap using HOMEBREW_LIBRARY

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -43,7 +43,7 @@ module Bundle
 
     def cask_installed?
       @cask_installed ||= File.directory?("#{HOMEBREW_PREFIX}/Caskroom") &&
-                          (File.directory?("#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask") ||
+                          (File.directory?("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask") ||
                            !Homebrew::EnvConfig.no_install_from_api?)
     end
 

--- a/spec/bundle_utils_spec.rb
+++ b/spec/bundle_utils_spec.rb
@@ -31,7 +31,7 @@ describe Bundle do
     it "finds it when present" do
       allow(File).to receive(:directory?).with("#{HOMEBREW_PREFIX}/Caskroom").and_return(true)
       allow(File).to receive(:directory?)
-        .with("#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask")
+        .with("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask")
         .and_return(true)
       expect(described_class.cask_installed?).to be(true)
     end

--- a/spec/stub/global.rb
+++ b/spec/stub/global.rb
@@ -2,6 +2,7 @@
 
 HOMEBREW_PREFIX = Pathname("/usr/local").freeze
 HOMEBREW_REPOSITORY = Pathname("/usr/local/Homebrew").freeze
+HOMEBREW_LIBRARY = Pathname(HOMEBREW_REPOSITORY/"Library").freeze
 HOMEBREW_BREW_FILE = Pathname(HOMEBREW_PREFIX/"bin/brew").freeze
 HOMEBREW_VERSION = "2.6.0"
 


### PR DESCRIPTION
It's semantically more correct and also what's used [throughout](https://github.com/Homebrew/brew/blob/1f80e82dd72fce6642e4ea360f7a1feef5d78470/Library/Homebrew/brew.sh#L492) [brew](https://github.com/Homebrew/brew/blob/1f80e82dd72fce6642e4ea360f7a1feef5d78470/Library/Homebrew/cmd/update.sh#L581) (`$HOMEBREW_LIBRARY/Taps/*/*` for taps, `$HOMEBREW_REPOSITORY` for updating brew itself).