### PR TITLE
Add/use more environment variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,20 +36,16 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
-
-    - name: Install Bundler
-      run: gem install bundler -v "~>1"
-
-    - name: Install Homebrew/homebrew-bundle RubyGems
-      run: bundle install --jobs 4 --retry 3
+        bundler-cache: true
 
     - name: Run RSpec tests
       run: bundle exec rspec
+
+    - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      if: always()
 
     - name: Test that installing works
       run: |
         echo 'brew "hello"' > ./Brewfile
         brew bundle
         hello
-
-    - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -43,10 +43,11 @@ module Homebrew
 
         This sanitized build environment ignores unrequested dependencies, which makes sure that things you didn't specify in your `Brewfile` won't get picked up by commands like `bundle install`, `npm install`, etc. It will also add compiler flags which will help find keg-only dependencies like `openssl`, `icu4c`, etc.
       EOS
-      flag   "--file=",
-             description: "Read the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout."
+      flag "--file=",
+           description: "Read the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout."
       switch "--global",
-             description: "Read the `Brewfile` from `~/.Brewfile`."
+             description: "Read the `Brewfile` from `~/.Brewfile` or " \
+                          "the `HOMEBREW_BUNDLE_FILE_GLOBAL` environment variable, if set."
       switch "-v", "--verbose",
              description: "`install` prints output from commands as they are run. " \
                           "`check` lists all missing dependencies."
@@ -57,7 +58,9 @@ module Homebrew
              description: "`dump` overwrites an existing `Brewfile`. " \
                           "`cleanup` actually performs its cleanup operations."
       switch "--cleanup",
-             description: "`install` performs cleanup operation, same as running `cleanup --force`."
+             env:         :bundle_install_cleanup,
+             description: "`install` performs cleanup operation, same as running `cleanup --force`. " \
+                          "This is enabled by default if HOMEBREW_BUNDLE_INSTALL_CLEANUP is set."
       switch "--no-lock",
              description: "`install` won't output a `Brewfile.lock.json`."
       switch "--all",
@@ -75,8 +78,10 @@ module Homebrew
       switch "--vscode",
              description: "`list` VSCode extensions."
       switch "--describe",
+             env:         :bundle_dump_describe,
              description: "`dump` adds a description comment above each line, unless the " \
-                          "dependency does not have a description."
+                          "dependency does not have a description. " \
+                          "This is enabled by default if HOMEBREW_BUNDLE_DUMP_DESCRIBE is set."
       switch "--no-restart",
              description: "`dump` does not add `restart_service` to formula lines."
       switch "--zap",

--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -5,20 +5,24 @@ module Bundle
     module_function
 
     def path(dash_writes_to_stdout: false, global: false, file: nil)
+      env_bundle_file_global = ENV.fetch("HOMEBREW_BUNDLE_FILE_GLOBAL", nil)
       env_bundle_file = ENV.fetch("HOMEBREW_BUNDLE_FILE", nil)
 
-      filename =
-        if global
+      filename = if global
+        if env_bundle_file_global.present?
+          env_bundle_file_global
+        else
           raise "'HOMEBREW_BUNDLE_FILE' cannot be specified with '--global'" if env_bundle_file.present?
 
           "#{Dir.home}/.Brewfile"
-        elsif file.present?
-          handle_file_value(file, dash_writes_to_stdout)
-        elsif env_bundle_file.present?
-          env_bundle_file
-        else
-          "Brewfile"
         end
+      elsif file.present?
+        handle_file_value(file, dash_writes_to_stdout)
+      elsif env_bundle_file.present?
+        env_bundle_file
+      else
+        "Brewfile"
+      end
 
       Pathname.new(filename).expand_path(Dir.pwd)
     end

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -85,7 +85,13 @@ module Bundle
         lockfile.unlink if lockfile.exist?
         lockfile.write("#{json}\n")
       rescue Errno::EPERM, Errno::EACCES, Errno::ENOTEMPTY
-        opoo "Could not write to #{lockfile}!"
+        unless ENV.fetch("HOMEBREW_BUNDLE_NO_LOCKFILE_WRITE_WARNING", false)
+          opoo "Could not write to #{lockfile}!"
+          unless Homebrew::EnvConfig.no_env_hints?
+            puts "Hide this warning by setting HOMEBREW_BUNDLE_NO_LOCKFILE_WRITE_WARNING."
+            puts "Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`)."
+          end
+        end
         return false
       end
 

--- a/spec/bundle/brewfile_spec.rb
+++ b/spec/bundle/brewfile_spec.rb
@@ -9,12 +9,17 @@ describe Bundle::Brewfile do
     end
 
     let(:dash_writes_to_stdout) { false }
+    let(:env_bundle_file_global_value) { nil }
     let(:env_bundle_file_value) { nil }
     let(:file_value) { nil }
     let(:has_global) { false }
 
     before do
-      allow(ENV).to receive(:fetch).with("HOMEBREW_BUNDLE_FILE", any_args).and_return(env_bundle_file_value)
+      allow(ENV).to receive(:fetch).and_return(nil)
+      allow(ENV).to receive(:fetch).with("HOMEBREW_BUNDLE_FILE_GLOBAL", any_args)
+                                   .and_return(env_bundle_file_global_value)
+      allow(ENV).to receive(:fetch).with("HOMEBREW_BUNDLE_FILE", any_args)
+                                   .and_return(env_bundle_file_value)
     end
 
     context "when `file` is specified with a relative path" do
@@ -125,10 +130,19 @@ describe Bundle::Brewfile do
         expect(path).to eq(expected_pathname)
       end
 
+      context "when HOMEBREW_BUNDLE_FILE_GLOBAL is set" do
+        let(:env_bundle_file_global_value) { "/path/to/Brewfile" }
+        let(:expected_pathname) { Pathname.new(env_bundle_file_global_value) }
+
+        it "returns the value specified by the environment variable" do
+          expect(path).to eq(expected_pathname)
+        end
+      end
+
       context "when HOMEBREW_BUNDLE_FILE is set" do
         let(:env_bundle_file_value) { "/path/to/Brewfile" }
 
-        it "returns the value specified by `file` path" do
+        it "returns the value specified by the variable" do
           expect { path }.to raise_error(RuntimeError)
         end
       end

--- a/spec/bundle/locker_spec.rb
+++ b/spec/bundle/locker_spec.rb
@@ -102,8 +102,23 @@ describe Bundle::Locker do
 
         it "returns false on a permission error" do
           expect(lockfile).to receive(:write).and_raise(Errno::EPERM)
-          expect(locker).to receive(:opoo)
+          allow(locker).to receive(:opoo)
+          allow(locker).to receive(:puts)
           expect(locker.lock(entries)).to be false
+        end
+
+        it "outputs warning on a permission error" do
+          expect(lockfile).to receive(:write).and_raise(Errno::EPERM)
+          expect(locker).to receive(:opoo)
+          allow(locker).to receive(:puts)
+          locker.lock(entries)
+        end
+
+        it "outputs environment variable hint on a permission error" do
+          expect(lockfile).to receive(:write).and_raise(Errno::EPERM)
+          allow(locker).to receive(:opoo)
+          expect(locker).to receive(:puts).twice
+          locker.lock(entries)
         end
       end
 

--- a/spec/stub/env_config.rb
+++ b/spec/stub/env_config.rb
@@ -2,6 +2,10 @@
 
 module Homebrew
   class EnvConfig
+    def self.no_env_hints?
+      false
+    end
+
     def self.no_install_from_api?
       false
     end


### PR DESCRIPTION
Add the `HOMEBREW_BUNDLE_FILE_GLOBAL`, `HOMEBREW_BUNDLE_INSTALL_CLEANUP`, `HOMEBREW_BUNDLE_DUMP_DESCRIBE`, `HOMEBREW_BUNDLE_NO_LOCKFILE_WRITE_WARNING` environment variables and document their use.

Requires https://github.com/Homebrew/brew/pull/16043

While we're here, fix coverage uploading to help debug failures and update GitHub Actions to use the new `bundler-cache` option for `ruby/setup-ruby`.