### PR TITLE
Make `--force` take effect on install.

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -55,7 +55,8 @@ module Homebrew
              description: "`install` won't run `brew upgrade` on outdated dependencies. " \
                           "Note they may still be upgraded by `brew install` if needed."
       switch "-f", "--force",
-             description: "`dump` overwrites an existing `Brewfile`. " \
+             description: "`install` runs with `--force`/`--overwrite`. " \
+                          "`dump` overwrites an existing `Brewfile`. " \
                           "`cleanup` actually performs its cleanup operations."
       switch "--cleanup",
              env:         :bundle_install_cleanup,
@@ -82,11 +83,6 @@ module Homebrew
              description: "`dump` adds a description comment above each line, unless the " \
                           "dependency does not have a description. " \
                           "This is enabled by default if HOMEBREW_BUNDLE_DUMP_DESCRIBE is set."
-      switch "--cask-force",
-             env:         :bundle_dump_cask_force,
-             description: "`dump` adds a force argument to casks to overwrite existing files " \
-                          "(binaries and symlinks are excluded, unless originally from the same cask). " \
-                          "This is enabled by default if HOMEBREW_BUNDLE_DUMP_CASK_FORCE is set."
       switch "--no-restart",
              description: "`dump` does not add `restart_service` to formula lines."
       switch "--zap",
@@ -109,6 +105,7 @@ module Homebrew
           no_lock:    args.no_lock?,
           no_upgrade: args.no_upgrade?,
           verbose:    args.verbose?,
+          force:      args.force?,
         )
 
         if args.cleanup?

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -82,6 +82,11 @@ module Homebrew
              description: "`dump` adds a description comment above each line, unless the " \
                           "dependency does not have a description. " \
                           "This is enabled by default if HOMEBREW_BUNDLE_DUMP_DESCRIBE is set."
+      switch "--cask-force",
+             env:         :bundle_dump_cask_force,
+             description: "`dump` adds a force argument to casks to overwrite existing files " \
+                          "(binaries and symlinks are excluded, unless originally from the same cask). " \
+                          "This is enabled by default if HOMEBREW_BUNDLE_DUMP_CASK_FORCE is set."
       switch "--no-restart",
              description: "`dump` does not add `restart_service` to formula lines."
       switch "--zap",

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -32,17 +32,7 @@ module Bundle
     def dump(describe: false)
       casks.map do |cask|
         description = "# #{cask.desc}\n" if describe && cask.desc.present?
-        cask_config = cask.config.explicit_s if cask.config.present? && cask.config.explicit.present?
-        cask_args = if ENV.fetch("HOMEBREW_BUNDLE_DUMP_CASK_FORCE", false)
-          if cask_config.present?
-            "#{cask_config}, force: true}"
-          else
-            "force: true"
-          end
-        else
-          cask_config
-        end
-        config = ", args: { #{cask_args} }" if cask_args.present?
+        config = ", args: { #{cask.config.explicit_s} }" if cask.config.present? && cask.config.explicit.present?
         "#{description}cask \"#{cask}\"#{config}"
       end.join("\n")
     end

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -32,7 +32,17 @@ module Bundle
     def dump(describe: false)
       casks.map do |cask|
         description = "# #{cask.desc}\n" if describe && cask.desc.present?
-        config = ", args: { #{cask.config.explicit_s} }" if cask.config.present? && cask.config.explicit.present?
+        cask_config = cask.config.explicit_s if cask.config.present? && cask.config.explicit.present?
+        cask_args = if ENV.fetch("HOMEBREW_BUNDLE_DUMP_CASK_FORCE", false)
+          if cask_config.present?
+            "#{cask_config}, force: true}"
+          else
+            "force: true"
+          end
+        else
+          cask_config
+        end
+        config = ", args: { #{cask_args} }" if cask_args.present?
         "#{description}cask \"#{cask}\"#{config}"
       end.join("\n")
     end

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -27,7 +27,7 @@ module Bundle
       true
     end
 
-    def install(name, preinstall: true, no_upgrade: false, verbose: false, **options)
+    def install(name, preinstall: true, no_upgrade: false, verbose: false, force: false, **options)
       return true unless preinstall
 
       full_name = options.fetch(:full_name, name)
@@ -49,7 +49,11 @@ module Bundle
         end
       end.compact
 
-      puts "Installing #{name} cask. It is not currently installed." if verbose
+      args << "--force" if force
+      args.uniq!
+
+      with_args = " with #{args.join(" ")}" if args.present?
+      puts "Installing #{name} cask#{with_args}. It is not currently installed." if verbose
 
       return false unless Bundle.system HOMEBREW_BREW_FILE, "install", "--cask", full_name, *args, verbose: verbose
 

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -5,11 +5,11 @@ module Bundle
     module Install
       module_function
 
-      def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false)
+      def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false)
         parsed_entries = Bundle::Dsl.new(Brewfile.read(global: global, file: file)).entries
         Bundle::Installer.install(
           parsed_entries,
-          global: global, file: file, no_lock: no_lock, no_upgrade: no_upgrade, verbose: verbose,
+          global: global, file: file, no_lock: no_lock, no_upgrade: no_upgrade, verbose: verbose, force: force,
         ) || exit(1)
       end
     end

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -4,7 +4,7 @@ module Bundle
   module Installer
     module_function
 
-    def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false)
+    def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false)
       success = 0
       failure = 0
 
@@ -46,7 +46,8 @@ module Bundle
           false
         end
 
-        if cls.install(*args, **options, preinstall: preinstall, no_upgrade: no_upgrade, verbose: verbose)
+        if cls.install(*args, **options,
+                       preinstall: preinstall, no_upgrade: no_upgrade, verbose: verbose, force: force)
           success += 1
         else
           puts Formatter.error("#{verb} #{name} has failed!")

--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -32,7 +32,7 @@ module Bundle
       true
     end
 
-    def install(name, id, preinstall: true, no_upgrade: false, verbose: false)
+    def install(name, id, preinstall: true, no_upgrade: false, verbose: false, force: false)
       return true unless preinstall
 
       if app_id_installed?(id)

--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -13,7 +13,7 @@ module Bundle
       true
     end
 
-    def install(name, preinstall: true, verbose: false, **options)
+    def install(name, preinstall: true, verbose: false, force: false, **options)
       return true unless preinstall
 
       puts "Installing #{name} tap. It is not currently installed." if verbose

--- a/lib/bundle/vscode_extension_installer.rb
+++ b/lib/bundle/vscode_extension_installer.rb
@@ -24,7 +24,7 @@ module Bundle
       true
     end
 
-    def install(name, preinstall: true, no_upgrade: false, verbose: false)
+    def install(name, preinstall: true, no_upgrade: false, verbose: false, force: false)
       return true unless preinstall
       return true if extension_installed?(name)
 

--- a/lib/bundle/whalebrew_installer.rb
+++ b/lib/bundle/whalebrew_installer.rb
@@ -23,7 +23,7 @@ module Bundle
       true
     end
 
-    def install(name, preinstall: true, verbose: false, **_options)
+    def install(name, preinstall: true, verbose: false, force: false, **_options)
       return true unless preinstall
 
       puts "Installing #{name} image. It is not currently installed." if verbose


### PR DESCRIPTION
Allows passing `brew bundle --force` to make installed formulae run `brew install --formula --force --overwrite` and casks `brew install --cask --force` when installed.

This is useful in environments where it's common for casks to need to be overwritten.
