### PR TITLE
brew_installer: use `brew link --overwrite` when appropriate.

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -113,7 +113,7 @@ module Bundle
         if unlinked_and_not_keg_only?
           puts "Linking #{@name} formula." if verbose
           link_args = "link"
-          link_args << "--force" if force
+          link_args << "--overwrite" if force
           Bundle.system(HOMEBREW_BREW_FILE, *link_args, @name, verbose: verbose)
         elsif linked_and_keg_only?
           puts "Unlinking #{@name} formula." if verbose


### PR DESCRIPTION
I should have checked the manpage here; in #1257 it should have been `--overwrite` to enable the similar "forcing" behaviour.