### PR TITLE
tap_dumper: filter HOMEBREW_GITHUB_API_TOKEN.

### DIFF
--- a/lib/bundle/tap_dumper.rb
+++ b/lib/bundle/tap_dumper.rb
@@ -13,6 +13,14 @@ module Bundle
     def dump
       taps.map do |tap|
         remote = if tap.custom_remote? && (tap_remote = tap.remote)
+          if (api_token = ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", false).presence)
+            # Replace the API token in the remote URL with interpolation.
+            # Rubocop's warning here is wrong; we intentionally want to not
+            # evaluate this string until the Brewfile is evaluated.
+            # rubocop:disable Lint/InterpolationCheck
+            tap_remote = tap_remote.gsub api_token, '#{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN")}'
+            # rubocop:enable Lint/InterpolationCheck
+          end
           ", \"#{tap_remote}\""
         end
         "tap \"#{tap.name}\"#{remote}"


### PR DESCRIPTION
If it's present in a tap's git remote: filter it out and replace it with a lookup for the environment variable instead.