### PR TITLE
Run tests on Ruby 3.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.6'
+        ruby-version: '3.1'
         bundler-cache: true
 
     - name: Run RSpec tests

--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -14,7 +14,7 @@ module Bundle
           logs << buf
         end
         Process.wait(pipe.pid)
-        success = $CHILD_STATUS.success?
+        success = $CHILD_STATUS.dup.success?
         pipe.close
       end
       puts logs.join unless success


### PR DESCRIPTION
Now that Homebrew 4.2.0 runs on Ruby 3.1, let's bump to that.

https://brew.sh/2023/12/18/homebrew-4.2.0/