### PR TITLE
vscode_extension_dumper: downcase extension names.

### DIFF
--- a/lib/bundle/vscode_extension_dumper.rb
+++ b/lib/bundle/vscode_extension_dumper.rb
@@ -10,7 +10,7 @@ module Bundle
 
     def extensions
       @extensions ||= if Bundle.vscode_installed?
-        `code --list-extensions 2>/dev/null`.split("\n")
+        `code --list-extensions 2>/dev/null`.split("\n").map(&:downcase)
       else
         []
       end


### PR DESCRIPTION
VSCode seems to be doing this itself in newer versions so this will allow for some more consistency.

Fixes #1302