### PR TITLE
vscode_extension cleanup: downcase extension names before comparison while evaluating for cleanup

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -143,7 +143,7 @@ module Bundle
 
       def vscode_extensions_to_uninstall(global: false, file: nil)
         @dsl ||= Bundle::Dsl.new(Brewfile.read(global: global, file: file))
-        kept_extensions = @dsl.entries.select { |e| e.type == :vscode }.map(&:name).map(&:downcase)
+        kept_extensions = @dsl.entries.select { |e| e.type == :vscode }.map { |x| x.name.downcase }
 
         # To provide a graceful migration from `Brewfile`s that don't yet or
         # don't want to use `vscode`: don't remove any extensions if we don't

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -143,7 +143,7 @@ module Bundle
 
       def vscode_extensions_to_uninstall(global: false, file: nil)
         @dsl ||= Bundle::Dsl.new(Brewfile.read(global: global, file: file))
-        kept_extensions = @dsl.entries.select { |e| e.type == :vscode }.map(&:name)
+        kept_extensions = @dsl.entries.select { |e| e.type == :vscode }.map(&:name).map(&:downcase)
 
         # To provide a graceful migration from `Brewfile`s that don't yet or
         # don't want to use `vscode`: don't remove any extensions if we don't
@@ -151,7 +151,7 @@ module Bundle
         return [].freeze if kept_extensions.empty?
 
         current_extensions = Bundle::VscodeExtensionDumper.extensions
-        current_extensions.map(&:downcase) - kept_extensions.map(&:downcase)
+        current_extensions - kept_extensions
       end
 
       def system_output_no_stderr(cmd, *args)

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -151,7 +151,7 @@ module Bundle
         return [].freeze if kept_extensions.empty?
 
         current_extensions = Bundle::VscodeExtensionDumper.extensions
-        current_extensions - kept_extensions
+        current_extensions.map(&:downcase) - kept_extensions.map(&:downcase)
       end
 
       def system_output_no_stderr(cmd, *args)

--- a/lib/bundle/vscode_extension_dumper.rb
+++ b/lib/bundle/vscode_extension_dumper.rb
@@ -10,7 +10,7 @@ module Bundle
 
     def extensions
       @extensions ||= if Bundle.vscode_installed?
-        `code --list-extensions 2>/dev/null`.split("\n").map(&:downcase)
+        `code --list-extensions 2>/dev/null`.split("\n")
       else
         []
       end

--- a/lib/bundle/vscode_extension_dumper.rb
+++ b/lib/bundle/vscode_extension_dumper.rb
@@ -10,7 +10,7 @@ module Bundle
 
     def extensions
       @extensions ||= if Bundle.vscode_installed?
-        `code --list-extensions 2>/dev/null`.split("\n")
+        `code --list-extensions 2>/dev/null`.split("\n").map(&:downcase)
       else
         []
       end

--- a/lib/bundle/vscode_extension_installer.rb
+++ b/lib/bundle/vscode_extension_installer.rb
@@ -38,7 +38,7 @@ module Bundle
     end
 
     def extension_installed?(name)
-      installed_extensions.include? name
+      installed_extensions.include? name.downcase
     end
 
     def installed_extensions

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -76,6 +76,11 @@ describe Bundle::Commands::Cleanup do
       allow(Bundle::VscodeExtensionDumper).to receive(:extensions).and_return(%w[z])
       expect(described_class.vscode_extensions_to_uninstall).to eql(%w[z])
     end
+
+    it "computes which VSCode extensions to uninstall irrespective of case of the extension name" do
+      allow(Bundle::VscodeExtensionDumper).to receive(:extensions).and_return(%w[z Ab VsCodeExtension1])
+      expect(described_class.vscode_extensions_to_uninstall).to eql(%w[z ab])
+    end
   end
 
   context "when there are no formulae to uninstall and no taps to untap" do

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -21,7 +21,7 @@ describe Bundle::Commands::Cleanup do
         brew 'hasbuilddependency1'
         brew 'hasbuilddependency2'
         mas 'appstoreapp1', id: 1
-        vscode 'vscodeextension1'
+        vscode 'VsCodeExtension1'
       EOS
     end
 
@@ -78,8 +78,8 @@ describe Bundle::Commands::Cleanup do
     end
 
     it "computes which VSCode extensions to uninstall irrespective of case of the extension name" do
-      allow(Bundle::VscodeExtensionDumper).to receive(:extensions).and_return(%w[z Ab VsCodeExtension1])
-      expect(described_class.vscode_extensions_to_uninstall).to eql(%w[z ab])
+      allow(Bundle::VscodeExtensionDumper).to receive(:extensions).and_return(%w[z vscodeextension1])
+      expect(described_class.vscode_extensions_to_uninstall).to eql(%w[z])
     end
   end
 

--- a/spec/bundle/vscode_extension_installer_spec.rb
+++ b/spec/bundle/vscode_extension_installer_spec.rb
@@ -27,6 +27,11 @@ describe Bundle::VscodeExtensionInstaller do
         allow(described_class).to receive(:installed_extensions).and_return(["foo"])
       end
 
+      it "skips" do
+        expect(Bundle).not_to receive(:system)
+        expect(described_class.preinstall("foo")).to be(false)
+      end
+
       it "skips ignoring case" do
         expect(Bundle).not_to receive(:system)
         expect(described_class.preinstall("Foo")).to be(false)

--- a/spec/bundle/vscode_extension_installer_spec.rb
+++ b/spec/bundle/vscode_extension_installer_spec.rb
@@ -27,9 +27,9 @@ describe Bundle::VscodeExtensionInstaller do
         allow(described_class).to receive(:installed_extensions).and_return(["foo"])
       end
 
-      it "skips" do
+      it "skips ignoring case" do
         expect(Bundle).not_to receive(:system)
-        expect(described_class.preinstall("foo")).to be(false)
+        expect(described_class.preinstall("Foo")).to be(false)
       end
     end
 


### PR DESCRIPTION
fixes #1302 in a consistent manner such that cleanup doesn't uninstall if the case mismatch occurs