### PR TITLE
fix tests if the user has a HOMEBREW_BUNDLE_FILE env var setup

### DIFF
--- a/spec/bundle/commands/dump_command_spec.rb
+++ b/spec/bundle/commands/dump_command_spec.rb
@@ -28,6 +28,7 @@ describe Bundle::Commands::Dump do
 
   context "when files existed and `--force` is passed" do
     before do
+      ENV["HOMEBREW_BUNDLE_FILE"] = ""
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
       allow(Bundle).to receive(:cask_installed?).and_return(true)
     end

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -7,6 +7,8 @@ describe Bundle::Dumper do
   subject(:dumper) { described_class }
 
   before do
+    ENV["HOMEBREW_BUNDLE_FILE"] = ""
+
     allow(Bundle).to receive_messages(cask_installed?: true, mas_installed?: false, whalebrew_installed?: false,
                                       vscode_installed?: false)
     Bundle::BrewDumper.reset!


### PR DESCRIPTION
I have an env var setup to point to the global `Brewfile`. If this is set, and following the contribution guidelines for this repo, then the tests fail. To circumvent that failure, this change in tests is required.