### PR TITLE
mas v1.8.7 updates

### DIFF
--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -33,14 +33,6 @@ module Bundle
       @whalebrew_installed ||= which_formula("whalebrew")
     end
 
-    def mas_signedin?
-      # mas account doesn't work on Monterey (yet)
-      # https://github.com/mas-cli/mas/issues/417#issuecomment-957963271
-      return true if MacOS.version >= :monterey
-
-      Kernel.system "mas account &>/dev/null"
-    end
-
     def cask_installed?
       @cask_installed ||= File.directory?("#{HOMEBREW_PREFIX}/Caskroom") &&
                           (File.directory?("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask") ||

--- a/lib/bundle/mac_app_store_installer.rb
+++ b/lib/bundle/mac_app_store_installer.rb
@@ -24,11 +24,6 @@ module Bundle
         return false
       end
 
-      unless Bundle.mas_signedin?
-        puts "Not signed in to Mac App Store." if verbose
-        raise "Unable to install #{name} app. mas not signed in to Mac App Store."
-      end
-
       true
     end
 
@@ -70,17 +65,13 @@ module Bundle
     end
 
     def outdated_app_ids
-      []
-
-      # TODO: can't be trusted right now.
-      # Uncomment when https://github.com/mas-cli/mas/pull/496 is merged.
-      # @outdated_app_ids ||= if Bundle.mas_installed?
-      #   `mas outdated 2>/dev/null`.split("\n").map do |app|
-      #     app.split(" ", 2).first.to_i
-      #   end
-      # else
-      #   []
-      # end
+      @outdated_app_ids ||= if Bundle.mas_installed?
+        `mas outdated 2>/dev/null`.split("\n").map do |app|
+          app.split(" ", 2).first.to_i
+        end
+      else
+        []
+      end
     end
   end
 end


### PR DESCRIPTION
- Once the next version of `mas` is released: we can again rely on `mas outdated`.
- `mas_signedin?` hasn't worked for a long time and isn't coming back so just delete the code to simplify things.