### PR TITLE
Don’t prefetch greedy outdated casks

### DIFF
--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -14,11 +14,19 @@ module Bundle
       @cask_names ||= casks.map(&:to_s)
     end
 
-    def outdated_cask_names(greedy: false)
+    def outdated_cask_names
       return [] unless Bundle.cask_installed?
 
-      casks.select { |c| c.outdated?(greedy: greedy) }
+      casks.select { |c| c.outdated?(greedy: false) }
            .map(&:to_s)
+    end
+
+    def cask_is_outdated_using_greedy(cask)
+      return [] unless Bundle.cask_installed?
+
+      casks.select { |c| c.to_s == cask }
+           .map { |c| c.outdated?(greedy: true) }
+           .first
     end
 
     def cask_versions

--- a/lib/bundle/cask_dumper.rb
+++ b/lib/bundle/cask_dumper.rb
@@ -21,12 +21,13 @@ module Bundle
            .map(&:to_s)
     end
 
-    def cask_is_outdated_using_greedy(cask)
-      return [] unless Bundle.cask_installed?
+    def cask_is_outdated_using_greedy?(cask_name)
+      return false unless Bundle.cask_installed?
 
-      casks.select { |c| c.to_s == cask }
-           .map { |c| c.outdated?(greedy: true) }
-           .first
+      cask = casks.find { |c| c.to_s == cask_name }
+      return false if cask.nil?
+
+      cask.outdated?(greedy: true)
     end
 
     def cask_versions

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -7,7 +7,6 @@ module Bundle
     def reset!
       @installed_casks = nil
       @outdated_casks = nil
-      @greedy_outdated_casks = nil
     end
 
     def upgrading?(no_upgrade, name, options)
@@ -15,7 +14,7 @@ module Bundle
       return true if outdated_casks.include?(name)
       return false unless options[:greedy]
 
-      greedy_outdated_casks.include?(name)
+      Bundle::CaskDumper.cask_is_outdated_using_greedy(name)
     end
 
     def preinstall(name, no_upgrade: false, verbose: false, **options)
@@ -82,10 +81,6 @@ module Bundle
 
     def outdated_casks
       @outdated_casks ||= Bundle::CaskDumper.outdated_cask_names
-    end
-
-    def greedy_outdated_casks
-      @greedy_outdated_casks ||= Bundle::CaskDumper.outdated_cask_names(greedy: true)
     end
   end
 end

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -14,7 +14,7 @@ module Bundle
       return true if outdated_casks.include?(name)
       return false unless options[:greedy]
 
-      Bundle::CaskDumper.cask_is_outdated_using_greedy(name)
+      Bundle::CaskDumper.cask_is_outdated_using_greedy?(name)
     end
 
     def preinstall(name, no_upgrade: false, verbose: false, **options)

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -35,15 +35,17 @@ describe Bundle::CaskDumper do
     it "dumps as empty string" do
       expect(dumper.dump).to eql("")
     end
+
+    it "doesn’t want to greedily update a non-installed cask" do
+      expect(dumper.cask_is_outdated_using_greedy?("foo")).to be(false)
+    end
   end
 
   context "when casks `foo`, `bar` and `baz` are installed, with `baz` being a formula requirement" do
-    before do
-      described_class.reset!
-
-      foo = instance_double(Cask::Cask, to_s: "foo", desc: nil, config: nil)
-      baz = instance_double(Cask::Cask, to_s: "baz", desc: "Software", config: nil)
-      bar = instance_double(
+    let(:foo) { instance_double(Cask::Cask, to_s: "foo", desc: nil, config: nil) }
+    let(:baz) { instance_double(Cask::Cask, to_s: "baz", desc: "Software", config: nil) }
+    let(:bar) do
+      instance_double(
         Cask::Cask, to_s:   "bar",
                     desc:   nil,
                     config: instance_double(Cask::Config,
@@ -53,6 +55,10 @@ describe Bundle::CaskDumper do
                                             },
                                             explicit_s: 'fontdir: "/Library/Fonts", language: "zh-TW"')
       )
+    end
+
+    before do
+      described_class.reset!
 
       allow(Bundle).to receive(:cask_installed?).and_return(true)
       allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar, baz])
@@ -70,6 +76,20 @@ describe Bundle::CaskDumper do
         cask "baz"
       EOS
       expect(dumper.dump(describe: true)).to eql(expected.chomp)
+    end
+
+    it "doesn’t want to greedily update a non-installed cask" do
+      expect(dumper.cask_is_outdated_using_greedy?("qux")).to be(false)
+    end
+
+    it "wants to greedily update foo if there is an update available" do
+      expect(foo).to receive(:outdated?).with(greedy: true).and_return(true)
+      expect(dumper.cask_is_outdated_using_greedy?("foo")).to be(true)
+    end
+
+    it "does not want to greedily update bar if there is no updated available" do
+      expect(bar).to receive(:outdated?).with(greedy: true).and_return(false)
+      expect(dumper.cask_is_outdated_using_greedy?("bar")).to be(false)
     end
   end
 

--- a/spec/bundle/cask_dumper_spec.rb
+++ b/spec/bundle/cask_dumper_spec.rb
@@ -87,7 +87,7 @@ describe Bundle::CaskDumper do
       expect(dumper.cask_is_outdated_using_greedy?("foo")).to be(true)
     end
 
-    it "does not want to greedily update bar if there is no updated available" do
+    it "does not want to greedily update bar if there is no update available" do
       expect(bar).to receive(:outdated?).with(greedy: true).and_return(false)
       expect(dumper.cask_is_outdated_using_greedy?("bar")).to be(false)
     end

--- a/spec/bundle/cask_installer_spec.rb
+++ b/spec/bundle/cask_installer_spec.rb
@@ -75,7 +75,7 @@ describe Bundle::CaskInstaller do
     context "when cask is outdated and uses auto-update" do
       before do
         allow(Bundle::CaskDumper).to receive_messages(cask_names: ["opera"], outdated_cask_names: [])
-        allow(Bundle::CaskDumper).to receive(:outdated_cask_names).with(greedy: true).and_return(["opera"])
+        allow(Bundle::CaskDumper).to receive(:cask_is_outdated_using_greedy).with("opera").and_return(true)
       end
 
       it "upgrades" do

--- a/spec/bundle/cask_installer_spec.rb
+++ b/spec/bundle/cask_installer_spec.rb
@@ -75,7 +75,7 @@ describe Bundle::CaskInstaller do
     context "when cask is outdated and uses auto-update" do
       before do
         allow(Bundle::CaskDumper).to receive_messages(cask_names: ["opera"], outdated_cask_names: [])
-        allow(Bundle::CaskDumper).to receive(:cask_is_outdated_using_greedy).with("opera").and_return(true)
+        allow(Bundle::CaskDumper).to receive(:cask_is_outdated_using_greedy?).with("opera").and_return(true)
       end
 
       it "upgrades" do

--- a/spec/stub/cask/cask.rb
+++ b/spec/stub/cask/cask.rb
@@ -25,5 +25,9 @@ module Cask
     def config
       nil
     end
+
+    def outdated?(greedy: false)
+      false
+    end
   end
 end


### PR DESCRIPTION
In some instances, calling `.outdated?(greedy: true)` causes additional network requests. (casks using `version :latest` and `sha256 :no_check` seem to trigger this)

Currently, this is done for *all installed packages* every time `brew bundle` wants to update *any* cask greedily.

This pull request changes `bundle`'s behavior to only check whether one cask is outdated at a time (for greedy updates).