### PR TITLE
bundle/tap_dumper: check for installed taps.

### DIFF
--- a/lib/bundle/tap_dumper.rb
+++ b/lib/bundle/tap_dumper.rb
@@ -34,7 +34,7 @@ module Bundle
     def taps
       @taps ||= begin
         require "tap"
-        Tap.each.to_a
+        Tap.select(&:installed?).to_a
       end
     end
     private_class_method :taps

--- a/spec/bundle/tap_dumper_spec.rb
+++ b/spec/bundle/tap_dumper_spec.rb
@@ -33,7 +33,7 @@ describe Bundle::TapDumper do
       private_tap = instance_double(Tap, name: "privatebrew/private", custom_remote?: true,
         remote: "https://#{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN")}@github.com/privatebrew/homebrew-private")
 
-      allow(Tap).to receive(:each).and_return [bar, baz, foo, private_tap]
+      allow(Tap).to receive(:select).and_return [bar, baz, foo, private_tap]
     end
 
     after do

--- a/spec/stub/tap.rb
+++ b/spec/stub/tap.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Tap
-  def self.each
+  def self.select(*)
     []
   end
 


### PR DESCRIPTION
Otherwise we'll always output homebrew/core and homebrew/cask even when they aren't actually tapped.

CC @madAndroid 