### PR TITLE
vscode_extension_installer: use UID for installs

### DIFF
--- a/spec/stub/extend/kernel.rb
+++ b/spec/stub/extend/kernel.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Kernel
+  def with_env(_hash)
+    yield if block_given?
+  end
+end


### PR DESCRIPTION
This should make sense in the general case. VSCode should always install based on the calling user rather than the middle man.