### PR TITLE
vscode_extension_dumper: also use exchange_uid.

### DIFF
--- a/lib/bundle/brew_services.rb
+++ b/lib/bundle/brew_services.rb
@@ -38,7 +38,7 @@ module Bundle
     def started_services
       @started_services ||= if Bundle.services_installed?
         states_to_skip = %w[stopped none]
-        Utils.safe_popen_read(HOMEBREW_BREW_FILE, "services", "list").lines.filter_map do |line|
+        Utils.safe_popen_read("brew", "services", "list").lines.filter_map do |line|
           name, state, _plist = line.split(/\s+/)
           next if states_to_skip.include? state
 

--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -56,6 +56,30 @@ module Bundle
       ENV["PATH"] = "#{formula.opt_bin}:#{ENV.fetch("PATH", nil)}" if formula.any_version_installed?
       which(name).present?
     end
+
+    def exchange_uid(&block)
+      euid = Process.euid
+      uid = Process.uid
+      return yield if euid == uid
+
+      old_euid = euid
+      process_reexchangeable = Process::UID.re_exchangeable?
+      if process_reexchangeable
+        Process::UID.re_exchange
+      else
+        Process::Sys.seteuid(uid)
+      end
+
+      return_value = with_env("HOME" => Etc.getpwuid(Process.uid).dir, &block)
+
+      if process_reexchangeable
+        Process::UID.re_exchange
+      else
+        Process::Sys.seteuid(old_euid)
+      end
+
+      return_value
+    end
   end
 end
 

--- a/lib/bundle/vscode_extension_dumper.rb
+++ b/lib/bundle/vscode_extension_dumper.rb
@@ -10,7 +10,9 @@ module Bundle
 
     def extensions
       @extensions ||= if Bundle.vscode_installed?
-        `code --list-extensions 2>/dev/null`.split("\n").map(&:downcase)
+        Bundle.exchange_uid do
+          `code --list-extensions 2>/dev/null`
+        end.split("\n").map(&:downcase)
       else
         []
       end

--- a/lib/bundle/vscode_extension_installer.rb
+++ b/lib/bundle/vscode_extension_installer.rb
@@ -24,37 +24,13 @@ module Bundle
       true
     end
 
-    def exchange_uid(&block)
-      euid = Process.euid
-      uid = Process.uid
-      return yield if euid == uid
-
-      old_euid = euid
-      process_reexchangeable = Process::UID.re_exchangeable?
-      if process_reexchangeable
-        Process::UID.re_exchange
-      else
-        Process::Sys.seteuid(uid)
-      end
-
-      return_value = with_env("HOME" => Etc.getpwuid(Process.uid).dir, &block)
-
-      if process_reexchangeable
-        Process::UID.re_exchange
-      else
-        Process::Sys.seteuid(old_euid)
-      end
-
-      return_value
-    end
-
     def install(name, preinstall: true, no_upgrade: false, verbose: false, force: false)
       return true unless preinstall
       return true if extension_installed?(name)
 
       puts "Installing #{name} VSCode extension. It is not currently installed." if verbose
 
-      return false unless exchange_uid do
+      return false unless Bundle.exchange_uid do
         Bundle.system("code", "--install-extension", name, verbose:)
       end
 


### PR DESCRIPTION
This requires moving it to `Bundle.exchange_uid` to be used by both `vscode_extension_dumper` and `vscode_extension_installer`.