### PR TITLE
bundle: exchange euid/uid in more places as needed.

### DIFF
--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -14,7 +14,9 @@ module Bundle
         else
           raise "'HOMEBREW_BUNDLE_FILE' cannot be specified with '--global'" if env_bundle_file.present?
 
-          "#{Dir.home}/.Brewfile"
+          Bundle.exchange_uid_if_needed! do
+            "#{Dir.home}/.Brewfile"
+          end
         end
       elsif file.present?
         handle_file_value(file, dash_writes_to_stdout)

--- a/lib/bundle/bundle.rb
+++ b/lib/bundle/bundle.rb
@@ -57,7 +57,7 @@ module Bundle
       which(name).present?
     end
 
-    def exchange_uid(&block)
+    def exchange_uid_if_needed!(&block)
       euid = Process.euid
       uid = Process.uid
       return yield if euid == uid

--- a/lib/bundle/dumper.rb
+++ b/lib/bundle/dumper.rb
@@ -47,7 +47,9 @@ module Bundle
     end
 
     def write_file(file, content)
-      file.open("w") { |io| io.write content }
+      Bundle.exchange_uid_if_needed! do
+        file.open("w") { |io| io.write content }
+      end
     end
   end
 end

--- a/lib/bundle/locker.rb
+++ b/lib/bundle/locker.rb
@@ -82,8 +82,10 @@ module Bundle
 
       json = JSON.pretty_generate(lock)
       begin
-        lockfile.unlink if lockfile.exist?
-        lockfile.write("#{json}\n")
+        Bundle.exchange_uid_if_needed! do
+          lockfile.unlink if lockfile.exist?
+          lockfile.write("#{json}\n")
+        end
       rescue Errno::EPERM, Errno::EACCES, Errno::ENOTEMPTY
         unless ENV.fetch("HOMEBREW_BUNDLE_NO_LOCKFILE_WRITE_WARNING", false)
           opoo "Could not write to #{lockfile}!"

--- a/lib/bundle/vscode_extension_dumper.rb
+++ b/lib/bundle/vscode_extension_dumper.rb
@@ -10,7 +10,7 @@ module Bundle
 
     def extensions
       @extensions ||= if Bundle.vscode_installed?
-        Bundle.exchange_uid do
+        Bundle.exchange_uid_if_needed! do
           `code --list-extensions 2>/dev/null`
         end.split("\n").map(&:downcase)
       else

--- a/lib/bundle/vscode_extension_installer.rb
+++ b/lib/bundle/vscode_extension_installer.rb
@@ -30,7 +30,7 @@ module Bundle
 
       puts "Installing #{name} VSCode extension. It is not currently installed." if verbose
 
-      return false unless Bundle.exchange_uid do
+      return false unless Bundle.exchange_uid_if_needed! do
         Bundle.system("code", "--install-extension", name, verbose:)
       end
 


### PR DESCRIPTION
This is needed basically anywhere we read `$HOME` or write to files as that may be in `$HOME`.

While we're here, change name to `exchange_uid_if_needed!` to make it more obvious that it's only needed in some cases.