### PR TITLE
--quiet silences "Using xyz" in `brew bundle install`

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -107,6 +107,7 @@ module Homebrew
             no_upgrade: args.no_upgrade?,
             verbose:    args.verbose?,
             force:      args.force?,
+            quiet:      args.quiet?,
           )
 
           cleanup = if ENV.fetch("HOMEBREW_BUNDLE_INSTALL_CLEANUP", nil)

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -5,11 +5,11 @@ module Bundle
     module Install
       module_function
 
-      def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false)
+      def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false, quiet: false)
         parsed_entries = Bundle::Dsl.new(Brewfile.read(global:, file:)).entries
         Bundle::Installer.install(
           parsed_entries,
-          global:, file:, no_lock:, no_upgrade:, verbose:, force:,
+          global:, file:, no_lock:, no_upgrade:, verbose:, force:, quiet:,
         ) || exit(1)
       end
     end

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -4,7 +4,8 @@ module Bundle
   module Installer
     module_function
 
-    def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false)
+    def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false,
+                quiet: false)
       success = 0
       failure = 0
 
@@ -42,7 +43,7 @@ module Bundle
           puts Formatter.success("#{verb} #{name}")
           true
         else
-          puts "Using #{name}"
+          puts "Using #{name}" unless quiet
           false
         end
 


### PR DESCRIPTION
This is intended to resolve #1202. Only addresses the `brew bundle install` subcommand because I don't see any other subcommands where `--quiet` makes sense. I don't think it's desirable to suppress other non-error output (e.g. "Homebrew Bundle complete!..." and "Downloading https://formulae.brew.sh/api/cask.jws.json") unless we added a -qq option, which would require more far reaching changes to how arg parsing works (`--quiet` is parsed by code in `homebrew/brew`, not this repo).

Fixes #1202 