### PR TITLE
enforce limit of one subcommand, list named_args

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -92,13 +92,20 @@ module Homebrew
                description: "`dump` does not add `restart_service` to formula lines."
         switch "--zap",
                description: "`cleanup` casks using the `zap` command instead of `uninstall`."
+
+        named_args %w[install dump cleanup check exec list]
       end
 
       def run
         # Keep this inside `run` to keep --help fast.
         require_relative "../lib/bundle"
 
-        case subcommand = args.named.first.presence
+        subcommand = args.named.first.presence
+        if subcommand != "exec" && args.named.size > 1
+          raise UsageError, "This command does not take more than 1 subcommand argument."
+        end
+
+        case subcommand
         when nil, "install"
           Bundle::Commands::Install.run(
             global:     args.global?,


### PR DESCRIPTION
* Add `named_args` so Homebrew::Completions can discover subcommands
* `raise` an error if `args.named.size > 1`, unless we're running `brew bundle exec`: this fails loudly on some commands that are currently accepted and may appear valid but don't do what you'd expect. Each of the below commands currently execute the first subcommand and ignore the second silently:
  * `brew bundle install my_package`
  * `brew bundle install cleanup` (not to be confused with `brew bundle install --cleanup`!)
  * `brew bundle cleanup install`
* note: cannot use the `max: 1` annotation for named args because this would break `brew bundle exec`

I wrote this commit as part of my abortive effort on zsh completion. Sending the PR anyway, because imo it's still an improvement to usability and will be of some assistance if anyone continues working on completions for `brew bundle`.