### PR TITLE
Support `__FILE__` in Brewfiles

### DIFF
--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -30,7 +30,7 @@ module Bundle
     end
 
     def read(global: false, file: nil)
-      Brewfile.path(global:, file:).read
+      Bundle::Dsl.new(Brewfile.path(global:, file:))
     rescue Errno::ENOENT
       raise "No Brewfile found"
     end

--- a/lib/bundle/checker.rb
+++ b/lib/bundle/checker.rb
@@ -67,7 +67,7 @@ module Bundle
     }.freeze
 
     def check(global: false, file: nil, exit_on_first_error: false, no_upgrade: false, verbose: false)
-      @dsl ||= Bundle::Dsl.new(Brewfile.read(global:, file:))
+      @dsl ||= Brewfile.read(global:, file:)
 
       check_method_names = CHECKS.keys
 

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -83,7 +83,7 @@ module Bundle
       end
 
       def formulae_to_uninstall(global: false, file: nil)
-        @dsl ||= Bundle::Dsl.new(Brewfile.read(global:, file:))
+        @dsl ||= Brewfile.read(global:, file:)
         kept_formulae = @dsl.entries.select { |e| e.type == :brew }.map(&:name)
         kept_cask_formula_dependencies = Bundle::CaskDumper.formula_dependencies(kept_casks)
         kept_formulae += kept_cask_formula_dependencies
@@ -104,7 +104,7 @@ module Bundle
       def kept_casks(global: false, file: nil)
         return @kept_casks if @kept_casks
 
-        @dsl ||= Bundle::Dsl.new(Brewfile.read(global:, file:))
+        @dsl ||= Brewfile.read(global:, file:)
         @kept_casks = @dsl.entries.select { |e| e.type == :cask }.map(&:name)
       end
 
@@ -137,14 +137,14 @@ module Bundle
       IGNORED_TAPS = %w[homebrew/core homebrew/bundle].freeze
 
       def taps_to_untap(global: false, file: nil)
-        @dsl ||= Bundle::Dsl.new(Brewfile.read(global:, file:))
+        @dsl ||= Brewfile.read(global:, file:)
         kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
         current_taps = Bundle::TapDumper.tap_names
         current_taps - kept_taps - IGNORED_TAPS
       end
 
       def vscode_extensions_to_uninstall(global: false, file: nil)
-        @dsl ||= Bundle::Dsl.new(Brewfile.read(global:, file:))
+        @dsl ||= Brewfile.read(global:, file:)
         kept_extensions = @dsl.entries.select { |e| e.type == :vscode }.map { |x| x.name.downcase }
 
         # To provide a graceful migration from `Brewfile`s that don't yet or

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -25,7 +25,7 @@ module Bundle
           command_path = command_path.dirname.to_s
         end
 
-        brewfile = Bundle::Dsl.new(Brewfile.read(global:, file:))
+        brewfile = Brewfile.read(global:, file:)
 
         require "formula"
         require "formulary"

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -6,7 +6,7 @@ module Bundle
       module_function
 
       def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false, quiet: false)
-        parsed_entries = Bundle::Dsl.new(Brewfile.read(global:, file:)).entries
+        parsed_entries = Brewfile.read(global:, file:).entries
         Bundle::Installer.install(
           parsed_entries,
           global:, file:, no_lock:, no_upgrade:, verbose:, force:, quiet:,

--- a/lib/bundle/commands/list.rb
+++ b/lib/bundle/commands/list.rb
@@ -7,7 +7,7 @@ module Bundle
 
       def run(global: false, file: nil, all: false, casks: false, taps: false, mas: false, whalebrew: false,
               vscode: false, brews: false)
-        parsed_entries = Bundle::Dsl.new(Brewfile.read(global:, file:)).entries
+        parsed_entries = Brewfile.read(global:, file:).entries
         Bundle::Lister.list(
           parsed_entries,
           all:, casks:, taps:, mas:, whalebrew:, vscode:, brews:,

--- a/lib/bundle/dsl.rb
+++ b/lib/bundle/dsl.rb
@@ -18,8 +18,9 @@ module Bundle
 
     attr_reader :entries, :cask_arguments
 
-    def initialize(input)
-      @input = input
+    def initialize(path)
+      @path = path
+      @input = path.read
       @entries = []
       @cask_arguments = {}
 
@@ -33,7 +34,7 @@ module Bundle
     end
 
     def process
-      instance_eval(@input)
+      instance_eval(@input, @path.to_s)
     end
 
     def cask_args(args)

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -3,9 +3,13 @@
 require "spec_helper"
 
 describe Bundle::Dsl do
+  def dsl_from_string(string)
+    described_class.new(StringIO.new(string))
+  end
+
   context "with a DSL example" do
     subject(:dsl) do
-      described_class.new <<~EOS
+      dsl_from_string <<~EOS
         # frozen_string_literal: true
         cask_args appdir: '/Applications'
         tap 'homebrew/cask'
@@ -57,20 +61,20 @@ describe Bundle::Dsl do
 
   context "with invalid input" do
     it "handles completely invalid code" do
-      expect { described_class.new "abcdef" }.to raise_error(RuntimeError)
+      expect { dsl_from_string "abcdef" }.to raise_error(RuntimeError)
     end
 
     it "handles valid commands but with invalid options" do
-      expect { described_class.new "brew 1" }.to raise_error(RuntimeError)
-      expect { described_class.new "cask 1" }.to raise_error(RuntimeError)
-      expect { described_class.new "tap 1" }.to raise_error(RuntimeError)
-      expect { described_class.new "cask_args ''" }.to raise_error(RuntimeError)
+      expect { dsl_from_string "brew 1" }.to raise_error(RuntimeError)
+      expect { dsl_from_string "cask 1" }.to raise_error(RuntimeError)
+      expect { dsl_from_string "tap 1" }.to raise_error(RuntimeError)
+      expect { dsl_from_string "cask_args ''" }.to raise_error(RuntimeError)
     end
 
     it "errors on bad options" do
-      expect { described_class.new "brew 'foo', ['bad_option']" }.to raise_error(RuntimeError)
-      expect { described_class.new "cask 'foo', ['bad_option']" }.to raise_error(RuntimeError)
-      expect { described_class.new "tap 'foo', ['bad_clone_target']" }.to raise_error(RuntimeError)
+      expect { dsl_from_string "brew 'foo', ['bad_option']" }.to raise_error(RuntimeError)
+      expect { dsl_from_string "cask 'foo', ['bad_option']" }.to raise_error(RuntimeError)
+      expect { dsl_from_string "tap 'foo', ['bad_clone_target']" }.to raise_error(RuntimeError)
     end
   end
 


### PR DESCRIPTION
`__FILE__` in Brewfiles currently is set to `(eval at ...)`. Given we never read the Brewfile without creating a DSL class, we can simplify things to pass the path and use that in `instance_eval` to set the `__FILE__` to the real path.