### PR TITLE
Fix `brew bundle --cleanup` from `stdin`

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -129,6 +129,7 @@ module Homebrew
               file:   args.file,
               force:  true,
               zap:    args.zap?,
+              dsl:    Bundle::Commands::Install.dsl,
             )
           end
         when "dump"

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -18,7 +18,9 @@ module Bundle
         Bundle::BrewServices.reset!
       end
 
-      def run(global: false, file: nil, force: false, zap: false)
+      def run(global: false, file: nil, force: false, zap: false, dsl: nil)
+        @dsl ||= dsl
+
         casks = casks_to_uninstall(global:, file:)
         formulae = formulae_to_uninstall(global:, file:)
         taps = taps_to_untap(global:, file:)

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -25,12 +25,12 @@ module Bundle
           command_path = command_path.dirname.to_s
         end
 
-        brewfile = Brewfile.read(global:, file:)
+        @dsl = Brewfile.read(global:, file:)
 
         require "formula"
         require "formulary"
 
-        ENV.deps = brewfile.entries.map do |entry|
+        ENV.deps = @dsl.entries.map do |entry|
           next if entry.type != :brew
 
           f = Formulary.factory(entry.name)

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -6,11 +6,15 @@ module Bundle
       module_function
 
       def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false, quiet: false)
-        parsed_entries = Brewfile.read(global:, file:).entries
+        @dsl = Brewfile.read(global:, file:)
         Bundle::Installer.install(
-          parsed_entries,
+          @dsl.entries,
           global:, file:, no_lock:, no_upgrade:, verbose:, force:, quiet:,
         ) || exit(1)
+      end
+
+      def dsl
+        @dsl
       end
     end
   end

--- a/spec/bundle/commands/install_command_spec.rb
+++ b/spec/bundle/commands/install_command_spec.rb
@@ -38,6 +38,18 @@ describe Bundle::Commands::Install do
       expect { described_class.run }.not_to raise_error
     end
 
+    it "#dsl returns a valid DSL" do
+      allow(Bundle::TapInstaller).to receive(:preinstall).and_return(false)
+      allow(Bundle::WhalebrewInstaller).to receive(:preinstall).and_return(false)
+      allow(Bundle::VscodeExtensionInstaller).to receive(:preinstall).and_return(false)
+      allow(Bundle::BrewInstaller).to receive_messages(preinstall: true, install: true)
+      allow(Bundle::CaskInstaller).to receive_messages(preinstall: true, install: true)
+      allow(Bundle::MacAppStoreInstaller).to receive_messages(preinstall: true, install: true)
+      allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
+      described_class.run
+      expect(described_class.dsl.entries.first.name).to eql("phinze/cask")
+    end
+
     it "does not raise an error when skippable" do
       expect(Bundle::BrewInstaller).not_to receive(:install)
 


### PR DESCRIPTION
This was previously failing to read a valid `Brewfile` on repeated reads so attempting to cleanup everything.

Instead, cache the `Brewfile` DSL in the `install` command and pass it to the `cleanup` command.

While we're here, make some `dsl` usage elsewhere a little more consistent.

Fixes #1378