### PR TITLE
Apply --force flag if set for taps

### DIFF
--- a/lib/bundle/tap_installer.rb
+++ b/lib/bundle/tap_installer.rb
@@ -18,6 +18,7 @@ module Bundle
 
       puts "Installing #{name} tap. It is not currently installed." if verbose
       args = []
+      args << "--force" if force
       args.append("--force-auto-update") if options[:force_auto_update]
 
       success = if options[:clone_target]


### PR DESCRIPTION
I have 
```ruby
tap "homebrew/core"
tap "homebrew/cask"
```
in my Brewfile and since those casks are no longer required, `brew bundle install` will receive and error via calling `brew tap :name`.

Passing `--force` flag in `brew bundle install` has no effect due to `TapInstaller.install()` `force` argument is ignored.

<img width="676" alt="appliance-of-force-flag" src="https://github.com/Homebrew/homebrew-bundle/assets/33671815/9de4ebb2-ffbf-45aa-8070-239e28dd4e52">
