### PR TITLE
cleanup: exit 1 when any action would have been taken

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -32,7 +32,7 @@ module Homebrew
 
           This workflow is useful for maintainers or testers who regularly install lots of formulae.
 
-          Unless `--force` is passed, this returns with an unsuccessful exit code if changes would be made, making it useful for scripting.
+          Unless `--force` is passed, this returns a 1 exit code if anything would be removed.
 
           `brew bundle check`:
           Check if all dependencies present in the `Brewfile` are installed.

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -32,6 +32,8 @@ module Homebrew
 
           This workflow is useful for maintainers or testers who regularly install lots of formulae.
 
+          Unless `--force` is passed, this returns with an unsuccessful exit code if changes would be made, making it useful for scripting.
+
           `brew bundle check`:
           Check if all dependencies present in the `Brewfile` are installed.
 

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -48,24 +48,30 @@ module Bundle
           cleanup = system_output_no_stderr(HOMEBREW_BREW_FILE, "cleanup")
           puts cleanup unless cleanup.empty?
         else
+          would_uninstall = false
+
           if casks.any?
             puts "Would uninstall casks:"
             puts Formatter.columns casks
+            would_uninstall = true
           end
 
           if formulae.any?
             puts "Would uninstall formulae:"
             puts Formatter.columns formulae
+            would_uninstall = true
           end
 
           if taps.any?
             puts "Would untap:"
             puts Formatter.columns taps
+            would_uninstall = true
           end
 
           if vscode_extensions.any?
             puts "Would uninstall VSCode extensions:"
             puts Formatter.columns vscode_extensions
+            would_uninstall = true
           end
 
           cleanup = system_output_no_stderr(HOMEBREW_BREW_FILE, "cleanup", "--dry-run")
@@ -74,9 +80,8 @@ module Bundle
             puts cleanup
           end
 
-          if casks.any? || formulae.any? || taps.any? || !cleanup.empty?
-            puts "Run `brew bundle cleanup --force` to make these changes."
-          end
+          puts "Run `brew bundle cleanup --force` to make these changes." if would_uninstall || !cleanup.empty?
+          exit 1 if would_uninstall
         end
       end
 

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -194,7 +194,8 @@ describe Bundle::Commands::Cleanup do
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
       expect do
         described_class.run
-      end.to output(/Would uninstall formulae:.*Would untap:.*Would uninstall VSCode extensions:/m).to_stdout
+      end.to raise_error(SystemExit)
+        .and output(/Would uninstall formulae:.*Would untap:.*Would uninstall VSCode extensions:/m).to_stdout
     end
   end
 


### PR DESCRIPTION
Closes #1418 

The exception is for `brew cleanup` action, since it's just an extra step that's
not really related to the Brewfile contents.

I think this also fixes an issue where `vscode` uninstalls would not have printed the `--force` message — now they will also be considered for printing the message and the exit code.