### PR TITLE
bundle dump: fix whalebrew dump output

### DIFF
--- a/lib/bundle/whalebrew_dumper.rb
+++ b/lib/bundle/whalebrew_dumper.rb
@@ -12,8 +12,8 @@ module Bundle
       return [] unless Bundle.whalebrew_installed?
 
       @images ||= `whalebrew list 2>/dev/null`.split("\n")
-                                              .reject { |image| image.start_with?("COMMAND ") }
-                                              .map { |image| image.sub(/\w*\s+/, "") }
+                                              .reject { |line| line.start_with?("COMMAND ") }
+                                              .map { |line| line.split(/\s+/).last }
                                               .uniq
     end
 


### PR DESCRIPTION
I have a few whalebrew packages installed
```bash
$ whalebrew list

COMMAND          IMAGE
figlet           whalebrew/figlet
graph-easy       nathanielvarona/graph-easy
octodns-compare  whalebrew/octodns-compare
whalesay         whalebrew/whalesay
```

However, if I use the Bundle Dump from Homebrew, the results look like:
```bash
whalebrew "whalebrew/figlet"
whalebrew "graph-nathanielvarona/graph-easy"
whalebrew "octodns-whalebrew/octodns-compare"
whalebrew "whalebrew/whalesay"
```

The expected output supposedly:
```bash
whalebrew "whalebrew/figlet"
whalebrew "nathanielvarona/graph-easy"
whalebrew "whalebrew/octodns-compare"
whalebrew "whalebrew/whalesay"
```

I created the PR to fix this issue of dumping the packages list from Whalebrew.

With the fixes, running the `brew bundle dump --no-lock --describe --force --file ./whalebrew.Brewfile --whalebrew` again and I get the expected output.

Here is the whalebrew dump output difference now:
```diff
diff --git a/whalebrew.Brewfile.with-error b/whalebrew.Brewfile
index e5a1878..bd0c6c3 100644
--- a/whalebrew.Brewfile.with-error
+++ b/whalebrew.Brewfile
@@ -1,4 +1,4 @@
 whalebrew "whalebrew/figlet"
-whalebrew "graph-nathanielvarona/graph-easy"
-whalebrew "octodns-whalebrew/octodns-compare"
+whalebrew "nathanielvarona/graph-easy"
+whalebrew "whalebrew/octodns-compare"
 whalebrew "whalebrew/whalesay"

```