### PR TITLE
exec: support `nodenv`, `pyenv` and `rbenv`

### DIFF
--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -42,6 +42,16 @@ module Bundle
         # Enable compiler flag filtering
         ENV.refurbish_args
 
+        # Set up `nodenv`, `pyenv` and `rbenv` if present.
+        env_formulae = %w[nodenv pyenv rbenv]
+        ENV.deps.each do |dep|
+          dep_name = dep.name
+          next unless env_formulae.include?(dep_name)
+
+          dep_root = ENV.fetch("HOMEBREW_#{dep_name.upcase}_ROOT", "#{Dir.home}/.#{dep_name}")
+          ENV.prepend_path "PATH", Pathname.new(dep_root)/"shims"
+        end
+
         # Setup pkg-config, if present, to help locate packages
         pkgconfig = Formulary.factory("pkg-config")
         ENV.prepend_path "PATH", pkgconfig.opt_bin.to_s if pkgconfig.any_version_installed?

--- a/spec/bundle/commands/exec_command_spec.rb
+++ b/spec/bundle/commands/exec_command_spec.rb
@@ -80,5 +80,22 @@ describe Bundle::Commands::Exec do
         expect { described_class.run("/Users/admin/Downloads/command") }.not_to raise_error
       end
     end
+
+    describe "when the Brewfile contains rbenv" do
+      before { ENV["HOMEBREW_RBENV_ROOT"] = rbenv_root.to_s }
+
+      let(:rbenv_root) { Pathname.new("/tmp/.rbenv") }
+
+      it "prepends the path of the rbenv shims to PATH before running" do
+        allow_any_instance_of(Pathname).to receive(:read)
+          .and_return("brew 'rbenv'")
+        allow(ENV).to receive(:fetch).with(any_args).and_call_original
+        allow(ENV).to receive(:prepend_path).with(any_args).once.and_call_original
+
+        expect(ENV).to receive(:fetch).with("HOMEBREW_RBENV_ROOT", "#{Dir.home}/.rbenv").once.and_call_original
+        expect(ENV).to receive(:prepend_path).with("PATH", rbenv_root/"shims").once.and_call_original
+        described_class.run("/usr/bin/true")
+      end
+    end
   end
 end


### PR DESCRIPTION
If `nodenv`, `pyenv`, or `rbenv` are in the `Brewfile`, let's add their
`shims` directory to `PATH` during `brew bundle exec`.

This makes it so that `brew bundle exec` just works without relying on
the user adding the required `node`/`python3`/`ruby` formula to their
`Brewfile` and then doing `brew *env-sync`.
