### PR TITLE
Support `link: :overwrite` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ cask_args appdir: "~/Applications", require_sha: true
 
 # 'brew install'
 brew "imagemagick"
-# 'brew install --with-rmtp', 'brew services restart' on version changes
-brew "denji/nginx/nginx-full", args: ["with-rmtp"], restart_service: :changed
+# 'brew install --with-rmtp', 'brew link --overwrite', 'brew services restart' on version changes
+brew "denji/nginx/nginx-full", link: :overwrite, args: ["with-rmtp"], restart_service: :changed
 # 'brew install', always 'brew services restart', 'brew link', 'brew unlink mysql' (if it is installed)
 brew "mysql@5.6", restart_service: true, link: true, conflicts_with: ["mysql"]
 # install only on specified OS

--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -46,7 +46,7 @@ module Bundle
 
       if installed?
         service_change_state!(verbose:) if install_result
-        link_change_state!(verbose:, force:)
+        link_change_state!(verbose:)
       end
 
       install_result
@@ -97,29 +97,34 @@ module Bundle
       end
     end
 
-    def link_change_state!(verbose: false, force: false)
-      case @link
+    def link_change_state!(verbose: false)
+      link_args = []
+      link_args << "--force" if unlinked_and_keg_only?
+
+      cmd = case @link
+      when :overwrite
+        link_args << "--overwrite"
+        "link" unless linked?
       when true
-        unless linked_and_keg_only?
-          puts "Force-linking #{@name} formula." if verbose
-          Bundle.system(HOMEBREW_BREW_FILE, "link", "--force", @name, verbose:)
-        end
+        "link" unless linked?
       when false
-        unless unlinked_and_not_keg_only?
-          puts "Unlinking #{@name} formula." if verbose
-          Bundle.system(HOMEBREW_BREW_FILE, "unlink", @name, verbose:)
-        end
+        "unlink" if linked?
       when nil
-        if unlinked_and_not_keg_only?
-          puts "Linking #{@name} formula." if verbose
-          link_args = ["link"]
-          link_args << "--overwrite" if force
-          Bundle.system(HOMEBREW_BREW_FILE, *link_args, @name, verbose:)
-        elsif linked_and_keg_only?
-          puts "Unlinking #{@name} formula." if verbose
-          Bundle.system(HOMEBREW_BREW_FILE, "unlink", @name, verbose:)
+        if keg_only?
+          "unlink" if linked?
+        else
+          "link" unless linked?
         end
       end
+
+      if cmd
+        verb = "#{cmd}ing".capitalize
+        with_args = " with #{link_args.join(" ")}" if link_args.present?
+        puts "#{verb} #{@name} formula#{with_args}." if verbose
+        return Bundle.system(HOMEBREW_BREW_FILE, cmd, *link_args, @name, verbose:)
+      end
+
+      true
     end
 
     def self.formula_installed_and_up_to_date?(formula, no_upgrade: false)
@@ -150,21 +155,13 @@ module Bundle
       formula_in_array?(formula, installed_formulae)
     end
 
-    def self.formula_linked_and_keg_only?(formula)
-      formula_in_array?(formula, linked_and_keg_only_formulae)
-    end
-
-    def self.formula_unlinked_and_not_keg_only?(formula)
-      formula_in_array?(formula, unlinked_and_not_keg_only_formulae)
-    end
-
     def self.formula_upgradable?(formula)
       # Check local cache first and then authoratitive Homebrew source.
       formula_in_array?(formula, upgradable_formulae) && Formula[formula].outdated?
     end
 
     def self.installed_formulae
-      @installed_formulae ||= Bundle::BrewDumper.formulae.map { |f| f[:name] }
+      @installed_formulae ||= formulae.map { |f| f[:name] }
     end
 
     def self.upgradable_formulae
@@ -179,14 +176,6 @@ module Bundle
       @pinned_formulae ||= formulae.filter_map { |f| f[:name] if f[:pinned?] }
     end
 
-    def self.linked_and_keg_only_formulae
-      @linked_and_keg_only_formulae ||= formulae.filter_map { |f| f[:name] if f[:link?] == true }
-    end
-
-    def self.unlinked_and_not_keg_only_formulae
-      @unlinked_and_not_keg_only_formulae ||= formulae.filter_map { |f| f[:name] if f[:link?] == false }
-    end
-
     def self.formulae
       Bundle::BrewDumper.formulae
     end
@@ -197,12 +186,16 @@ module Bundle
       BrewInstaller.formula_installed?(@name)
     end
 
-    def linked_and_keg_only?
-      BrewInstaller.formula_linked_and_keg_only?(@name)
+    def linked?
+      Formula[@name].linked?
     end
 
-    def unlinked_and_not_keg_only?
-      BrewInstaller.formula_unlinked_and_not_keg_only?(@name)
+    def keg_only?
+      Formula[@name].keg_only?
+    end
+
+    def unlinked_and_keg_only?
+      !linked? && keg_only?
     end
 
     def upgradable?

--- a/spec/bundle/dsl_spec.rb
+++ b/spec/bundle/dsl_spec.rb
@@ -17,7 +17,7 @@ describe Bundle::Dsl do
         tap 'auto/update', 'https://bitbucket.org/auto/update.git', force_auto_update: true
         brew 'imagemagick'
         brew 'mysql@5.6', restart_service: true, link: true, conflicts_with: ['mysql']
-        brew 'emacs', args: ['with-cocoa', 'with-gnutls']
+        brew 'emacs', args: ['with-cocoa', 'with-gnutls'], link: :overwrite
         cask 'google-chrome'
         cask 'java' unless system '/usr/libexec/java_home --failfast'
         cask 'firefox', args: { appdir: '~/my-apps/Applications' }
@@ -47,7 +47,7 @@ describe Bundle::Dsl do
       expect(dsl.entries[4].name).to eql("mysql@5.6")
       expect(dsl.entries[4].options).to eql(restart_service: true, link: true, conflicts_with: ["mysql"])
       expect(dsl.entries[5].name).to eql("emacs")
-      expect(dsl.entries[5].options).to eql(args: ["with-cocoa", "with-gnutls"])
+      expect(dsl.entries[5].options).to eql(args: ["with-cocoa", "with-gnutls"], link: :overwrite)
       expect(dsl.entries[6].name).to eql("google-chrome")
       expect(dsl.entries[7].name).to eql("java")
       expect(dsl.entries[8].name).to eql("firefox")


### PR DESCRIPTION
- set `link: :overwrite` per formula
- uses `brew link --overwrite` to force linking and overwrite all conflicting files
- use the `linked?` and `keg_only?` predicates available from `Formula`
- `--force` should only be passed when it's keg-only
- check linked/unlinked state to avoid re-calling `brew link` / `brew unlink`

Closes https://github.com/Homebrew/homebrew-bundle/issues/1062
Resolves https://github.com/Homebrew/homebrew-bundle/pull/1116#discussion_r975223823, https://github.com/Homebrew/homebrew-bundle/pull/1116#discussion_r976260667