### PR TITLE
Add --no-vscode and HOMEBREW_BUNDLE_DUMP_NO_VSCODE

### DIFF
--- a/lib/bundle/commands/dump.rb
+++ b/lib/bundle/commands/dump.rb
@@ -5,13 +5,9 @@ module Bundle
     module Dump
       module_function
 
-      def run(global: false, file: nil, describe: false, force: false, no_restart: false,
-              all: false, taps: false, brews: false, casks: false,
-              mas: false, whalebrew: false, vscode: false)
+      def run(global:, file:, describe:, force:, no_restart:, taps:, brews:, casks:, mas:, whalebrew:, vscode:)
         Bundle::Dumper.dump_brewfile(
-          global:, file:, describe:, force:, no_restart:,
-          all:, taps:, brews:, casks:,
-          mas:, whalebrew:, vscode:
+          global:, file:, describe:, force:, no_restart:, taps:, brews:, casks:, mas:, whalebrew:, vscode:,
         )
       end
     end

--- a/lib/bundle/commands/list.rb
+++ b/lib/bundle/commands/list.rb
@@ -5,12 +5,11 @@ module Bundle
     module List
       module_function
 
-      def run(global: false, file: nil, all: false, casks: false, taps: false, mas: false, whalebrew: false,
-              vscode: false, brews: false)
+      def run(global:, file:, brews:, casks:, taps:, mas:, whalebrew:, vscode:)
         parsed_entries = Brewfile.read(global:, file:).entries
         Bundle::Lister.list(
           parsed_entries,
-          all:, casks:, taps:, mas:, whalebrew:, vscode:, brews:,
+          brews:, casks:, taps:, mas:, whalebrew:, vscode:,
         )
       end
     end

--- a/lib/bundle/dumper.rb
+++ b/lib/bundle/dumper.rb
@@ -13,28 +13,22 @@ module Bundle
       true
     end
 
-    def build_brewfile(describe: false, no_restart: false,
-                       all: false, taps: false, brews: false, casks: false,
-                       mas: false, whalebrew: false, vscode: false)
-      all     ||= !(taps || brews || casks || mas || whalebrew || vscode)
+    def build_brewfile(describe:, no_restart:, brews:, taps:, casks:, mas:, whalebrew:, vscode:)
       content = []
-      content << TapDumper.dump if taps || all
-      content << BrewDumper.dump(describe:, no_restart:) if brews || all
-      content << CaskDumper.dump(describe:) if casks || all
-      content << MacAppStoreDumper.dump if mas || all
-      content << WhalebrewDumper.dump if whalebrew || all
-      content << VscodeExtensionDumper.dump if vscode || all
+      content << TapDumper.dump if taps
+      content << BrewDumper.dump(describe:, no_restart:) if brews
+      content << CaskDumper.dump(describe:) if casks
+      content << MacAppStoreDumper.dump if mas
+      content << WhalebrewDumper.dump if whalebrew
+      content << VscodeExtensionDumper.dump if vscode
       "#{content.reject(&:empty?).join("\n")}\n"
     end
 
-    def dump_brewfile(global: false, file: nil, describe: false, force: false, no_restart: false,
-                      all: false, taps: false, brews: false, casks: false,
-                      mas: false, whalebrew: false, vscode: false)
+    def dump_brewfile(global:, file:, describe:, force:, no_restart:, brews:, taps:, casks:, mas:, whalebrew:,
+                      vscode:)
       path = brewfile_path(global:, file:)
       can_write_to_brewfile?(path, force:)
-      content = build_brewfile(describe:, no_restart:,
-                               all:, taps:, brews:, casks:,
-                               mas:, whalebrew:, vscode:)
+      content = build_brewfile(describe:, no_restart:, taps:, brews:, casks:, mas:, whalebrew:, vscode:)
       write_file path, content
     end
 

--- a/lib/bundle/lister.rb
+++ b/lib/bundle/lister.rb
@@ -4,26 +4,19 @@ module Bundle
   module Lister
     module_function
 
-    def list(entries, all: false, casks: false, taps: false, mas: false, whalebrew: false,
-             vscode: false, brews: false)
+    def list(entries, brews:, casks:, taps:, mas:, whalebrew:, vscode:)
       entries.each do |entry|
-        if show?(entry.type, all:, casks:, taps:, mas:, whalebrew:, vscode:,
-brews:)
-          puts entry.name
-        end
+        puts entry.name if show?(entry.type, brews:, casks:, taps:, mas:, whalebrew:, vscode:)
       end
     end
 
-    def self.show?(type, all: false, casks: false, taps: false, mas: false, whalebrew: false,
-                   vscode: false, brews: false)
-      return true if all
+    def self.show?(type, brews:, casks:, taps:, mas:, whalebrew:, vscode:)
+      return true if brews && type == :brew
       return true if casks && type == :cask
       return true if taps && type == :tap
       return true if mas && type == :mas
       return true if whalebrew && type == :whalebrew
       return true if vscode && type == :vscode
-      return true if brews && type == :brew
-      return true if type == :brew && !casks && !taps && !mas && !whalebrew && !vscode
 
       false
     end

--- a/spec/bundle/commands/dump_command_spec.rb
+++ b/spec/bundle/commands/dump_command_spec.rb
@@ -3,6 +3,14 @@
 require "spec_helper"
 
 describe Bundle::Commands::Dump do
+  subject(:dump) do
+    described_class.run(global:, file: nil, describe: false, force:, no_restart: false, taps: true, brews: true,
+                        casks: true, mas: true, whalebrew: true, vscode: true)
+  end
+
+  let(:force) { false }
+  let(:global) { false }
+
   context "when files existed" do
     before do
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
@@ -11,7 +19,7 @@ describe Bundle::Commands::Dump do
 
     it "raises error" do
       expect do
-        described_class.run
+        dump
       end.to raise_error(RuntimeError)
     end
 
@@ -21,12 +29,15 @@ describe Bundle::Commands::Dump do
       expect(Bundle::CaskDumper).not_to receive(:dump)
       expect(Bundle::WhalebrewDumper).not_to receive(:dump)
       expect do
-        described_class.run
+        dump
       end.to raise_error(RuntimeError)
     end
   end
 
-  context "when files existed and `--force` is passed" do
+  context "when files existed and `--force` and `--global` are passed" do
+    let(:force) { true }
+    let(:global) { true }
+
     before do
       ENV["HOMEBREW_BUNDLE_FILE"] = ""
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
@@ -38,7 +49,7 @@ describe Bundle::Commands::Dump do
       expect_any_instance_of(Pathname).to receive(:open).with("w").and_yield(io)
       expect(io).to receive(:write)
       expect do
-        described_class.run(force: true, global: true)
+        dump
       end.not_to raise_error
     end
   end

--- a/spec/bundle/commands/exec_command_spec.rb
+++ b/spec/bundle/commands/exec_command_spec.rb
@@ -87,6 +87,7 @@ describe Bundle::Commands::Exec do
       let(:rbenv_root) { Pathname.new("/tmp/.rbenv") }
 
       it "prepends the path of the rbenv shims to PATH before running" do
+        allow(described_class).to receive(:exec).with("/usr/bin/true").and_return(0)
         allow_any_instance_of(Pathname).to receive(:read)
           .and_return("brew 'rbenv'")
         allow(ENV).to receive(:fetch).with(any_args).and_call_original

--- a/spec/bundle/commands/list_command_spec.rb
+++ b/spec/bundle/commands/list_command_spec.rb
@@ -3,9 +3,14 @@
 require "spec_helper"
 
 describe Bundle::Commands::List do
-  subject(:list) { described_class.run(**options) }
+  subject(:list) { described_class.run(global: false, file: nil, brews:, casks:, taps:, mas:, whalebrew:, vscode:) }
 
-  let(:options) { {} }
+  let(:brews) { true }
+  let(:casks) { false }
+  let(:taps) { false }
+  let(:mas) { false }
+  let(:whalebrew) { false }
+  let(:vscode) { false }
 
   before do
     allow_any_instance_of(IO).to receive(:puts)
@@ -20,6 +25,7 @@ describe Bundle::Commands::List do
           cask 'google-chrome'
           mas '1Password', id: 443987910
           whalebrew 'whalebrew/imagemagick'
+          vscode 'shopify.ruby-lsp'
         EOS
       )
     end
@@ -35,6 +41,7 @@ describe Bundle::Commands::List do
         casks:     "google-chrome",
         mas:       "1Password",
         whalebrew: "whalebrew/imagemagick",
+        vscode:    "shopify.ruby-lsp",
       }
 
       combinations = 1.upto(types_and_deps.length).flat_map do |i|
@@ -48,7 +55,12 @@ describe Bundle::Commands::List do
         verb = (options_list.length == 1 && "is") || "are"
 
         context "when #{opts} #{verb} passed" do
-          let(:options) { args_hash }
+          let(:brews) { args_hash[:brews] }
+          let(:casks) { args_hash[:casks] }
+          let(:taps) { args_hash[:taps] }
+          let(:mas) { args_hash[:mas] }
+          let(:whalebrew) { args_hash[:whalebrew] }
+          let(:vscode) { args_hash[:vscode] }
 
           it "shows only #{words}" do
             expected = options_list.map { |opt| types_and_deps[opt] }.join("\n")

--- a/spec/bundle/dumper_spec.rb
+++ b/spec/bundle/dumper_spec.rb
@@ -36,7 +36,10 @@ describe Bundle::Dumper do
   end
 
   it "generates output" do
-    expect(dumper.build_brewfile).to eql("cask \"google-chrome\"\ncask \"java\"\ncask \"iterm2-beta\"\n")
+    expect(dumper.build_brewfile(
+             describe: false, no_restart: false, brews: true, taps: true, casks: true, mas: true,
+             whalebrew: true, vscode: true
+           )).to eql("cask \"google-chrome\"\ncask \"java\"\ncask \"iterm2-beta\"\n")
   end
 
   it "determines the brewfile correctly" do


### PR DESCRIPTION
This allows excluding VSCode output from `brew bundle dump` with a flag or environment variable.

While we're here
- generally refactor how we handle command arguments so this logic is pushed into `cmd/bundle` and made more consistent
- fix early RSpec failure due to an unstubbed `exec` call
- refactor some specs to be more idiomatic

Fixes https://github.com/Homebrew/homebrew-bundle/issues/1209
Fixes https://github.com/Homebrew/homebrew-bundle/issues/1212
Fixes https://github.com/Homebrew/homebrew-bundle/issues/1456