### PR TITLE
Keep implicit taps

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -92,8 +92,7 @@ module Bundle
       def formulae_to_uninstall(global: false, file: nil)
         @dsl ||= Brewfile.read(global:, file:)
         kept_formulae = @dsl.entries.select { |e| e.type == :brew }.map(&:name)
-        kept_cask_formula_dependencies = Bundle::CaskDumper.formula_dependencies(kept_casks)
-        kept_formulae += kept_cask_formula_dependencies
+        kept_formulae += Bundle::CaskDumper.formula_dependencies(kept_casks)
         kept_formulae.map! do |f|
           Bundle::BrewDumper.formula_aliases[f] ||
             Bundle::BrewDumper.formula_oldnames[f] ||

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -153,7 +153,9 @@ module Bundle
 
       def taps_to_untap(global: false, file: nil)
         @dsl ||= Brewfile.read(global:, file:)
+        kept_formulae = self.kept_formulae(global:, file:).map(&Formulary.method(:factory))
         kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
+        kept_taps += kept_formulae.filter_map(&:tap).map(&:name)
         current_taps = Bundle::TapDumper.tap_names
         current_taps - kept_taps - IGNORED_TAPS
       end

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -11,6 +11,7 @@ module Bundle
       def reset!
         @dsl = nil
         @kept_casks = nil
+        @kept_formulae = nil
         Bundle::CaskDumper.reset!
         Bundle::BrewDumper.reset!
         Bundle::TapDumper.reset!
@@ -90,21 +91,29 @@ module Bundle
       end
 
       def formulae_to_uninstall(global: false, file: nil)
-        @dsl ||= Brewfile.read(global:, file:)
-        kept_formulae = @dsl.entries.select { |e| e.type == :brew }.map(&:name)
-        kept_formulae += Bundle::CaskDumper.formula_dependencies(kept_casks)
-        kept_formulae.map! do |f|
-          Bundle::BrewDumper.formula_aliases[f] ||
-            Bundle::BrewDumper.formula_oldnames[f] ||
-            f
-        end
+        kept_formulae = self.kept_formulae(global:, file:)
 
         current_formulae = Bundle::BrewDumper.formulae
-        kept_formulae += recursive_dependencies(current_formulae, kept_formulae)
         current_formulae.reject! do |f|
           Bundle::BrewInstaller.formula_in_array?(f[:full_name], kept_formulae)
         end
         current_formulae.map { |f| f[:full_name] }
+      end
+
+      def kept_formulae(global: false, file: nil)
+        @kept_formulae ||= begin
+          @dsl ||= Brewfile.read(global:, file:)
+
+          kept_formulae = @dsl.entries.select { |e| e.type == :brew }.map(&:name)
+          kept_formulae += Bundle::CaskDumper.formula_dependencies(kept_casks)
+          kept_formulae.map! do |f|
+            Bundle::BrewDumper.formula_aliases[f] ||
+              Bundle::BrewDumper.formula_oldnames[f] ||
+              f
+          end
+
+          kept_formulae + recursive_dependencies(Bundle::BrewDumper.formulae, kept_formulae)
+        end
       end
 
       def kept_casks(global: false, file: nil)

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -68,7 +68,7 @@ describe Bundle::Commands::Cleanup do
     end
 
     it "computes which tap to untap" do
-      allow(Bundle::TapDumper).to receive(:tap_names).and_return(%w[z homebrew/bundle homebrew/core])
+      allow(Bundle::TapDumper).to receive(:tap_names).and_return(%w[z homebrew/bundle homebrew/core homebrew/tap])
       expect(described_class.taps_to_untap).to eql(%w[z])
     end
 

--- a/spec/stub/formula.rb
+++ b/spec/stub/formula.rb
@@ -3,10 +3,16 @@
 require "ostruct"
 require "pathname"
 
+# This pattern is a slight remix of `HOMEBREW_TAP_FORMULA_NAME_REGEX` and
+# `HOMEBREW_TAP_FORMULA_REGEX`
+# https://github.com/Homebrew/brew/blob/4.4.4/Library/Homebrew/tap_constants.rb#L4-L10
+HOMEBREW_TAP_NAME_REGEX = %r{\A(?<tap>(?:[^/]+)/(?:[^/]+))/(?:[\w+\-.@]+)\Z}
+
 class Formula
   def initialize(name)
     @prefix = Pathname("/usr/local")
     @name = name
+    @tap_name = (match = HOMEBREW_TAP_NAME_REGEX.match(name)) && match[:tap]
   end
 
   def opt_prefix
@@ -92,7 +98,7 @@ class Formula
   end
 
   def tap
-    OpenStruct.new(official?: true)
+    OpenStruct.new(official?: true, name: @tap_name)
   end
 
   def stable


### PR DESCRIPTION
I have a Brewfile that contains the following line:

```ruby
brew "heroku/brew/heroku"
```

Running `brew bundle cleanup --verbose` includes the following output:

```
Would untap:
heroku/brew
```

However, this tap can't be removed as the fomula depends on it.

Considering you can install formulae without explicitly adding a `tap` declaration, it seems that these should be respected when computing which taps to keep.

This change does that: Any tap found in a `brew` declaration will automatically be kept.