### PR TITLE
Ignore taps of unavailable formulae

### DIFF
--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -153,7 +153,7 @@ module Bundle
 
       def taps_to_untap(global: false, file: nil)
         @dsl ||= Brewfile.read(global:, file:)
-        kept_formulae = self.kept_formulae(global:, file:).map(&method(:lookup_formula))
+        kept_formulae = self.kept_formulae(global:, file:).filter_map(&method(:lookup_formula))
         kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
         kept_taps += kept_formulae.filter_map(&:tap).map(&:name)
         current_taps = Bundle::TapDumper.tap_names
@@ -162,6 +162,9 @@ module Bundle
 
       def lookup_formula(formula)
         Formulary.factory(formula)
+      rescue TapFormulaUnavailableError
+        # ignore these as an unavailable formula implies there is no tap to worry about
+        nil
       end
 
       def vscode_extensions_to_uninstall(global: false, file: nil)

--- a/lib/bundle/commands/cleanup.rb
+++ b/lib/bundle/commands/cleanup.rb
@@ -153,11 +153,15 @@ module Bundle
 
       def taps_to_untap(global: false, file: nil)
         @dsl ||= Brewfile.read(global:, file:)
-        kept_formulae = self.kept_formulae(global:, file:).map(&Formulary.method(:factory))
+        kept_formulae = self.kept_formulae(global:, file:).map(&method(:lookup_formula))
         kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
         kept_taps += kept_formulae.filter_map(&:tap).map(&:name)
         current_taps = Bundle::TapDumper.tap_names
         current_taps - kept_taps - IGNORED_TAPS
+      end
+
+      def lookup_formula(formula)
+        Formulary.factory(formula)
       end
 
       def vscode_extensions_to_uninstall(global: false, file: nil)

--- a/spec/bundle/commands/cleanup_command_spec.rb
+++ b/spec/bundle/commands/cleanup_command_spec.rb
@@ -72,6 +72,12 @@ describe Bundle::Commands::Cleanup do
       expect(described_class.taps_to_untap).to eql(%w[z])
     end
 
+    it "ignores unavailable formulae when computing which taps to keep" do
+      allow(Formulary).to receive(:factory).and_raise(TapFormulaUnavailableError)
+      allow(Bundle::TapDumper).to receive(:tap_names).and_return(%w[z homebrew/bundle homebrew/core homebrew/tap])
+      expect(described_class.taps_to_untap).to eql(%w[z homebrew/tap])
+    end
+
     it "computes which VSCode extensions to uninstall" do
       allow(Bundle::VscodeExtensionDumper).to receive(:extensions).and_return(%w[z])
       expect(described_class.vscode_extensions_to_uninstall).to eql(%w[z])

--- a/spec/stub/exceptions.rb
+++ b/spec/stub/exceptions.rb
@@ -5,3 +5,6 @@ end
 
 class FormulaUnavailableError < RuntimeError
 end
+
+class TapFormulaUnavailableError < RuntimeError
+end


### PR DESCRIPTION
This addresses an issue in #1495.

I set up a new machine and ran `brew bundle cleanup --verbose` which then exited with the following error:

```
Error: No available formula with the name "heroku/brew/heroku".
Please tap it and then try again: brew tap heroku/brew
```

This is because I hadn't installed anything and therefore `Formulary.factory` couldn't find the formula.

With this change, I'm making an assumption that if we can't find the formula, we don't need to keep its associated tap and therefore it's fine to ignore the exception and consequently not include the tap in `kept_taps`.

~I would like to add a test case but `TapFormulaUnavailableError` isn't available and wasn't sure it was desired to define it for testing. Let me know if I should.~ I found [spec/stub/exceptions.rb](https://github.com/Homebrew/homebrew-bundle/blob/master/spec/stub/exceptions.rb).