### PR TITLE
look for Brewfile in HOMEBREW_USER_CONFIG_HOME

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -56,8 +56,9 @@ module Homebrew
         flag "--file=",
              description: "Read the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout."
         switch "--global",
-               description: "Read the global `Brewfile`, from the homebrew config directory or `~/.Brewfile`. " \
-                            "Override this path with the `HOMEBREW_BUNDLE_FILE_GLOBAL` environment variable."
+               description: "Read the `Brewfile` from `~/.Brewfile`, " \
+                            "in the `HOMEBREW_USER_CONFIG_HOME` directory, " \
+                            "or the `HOMEBREW_BUNDLE_FILE_GLOBAL` environment variable, if set."
         switch "-v", "--verbose",
                description: "`install` prints output from commands as they are run. " \
                             "`check` lists all missing dependencies."

--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -56,8 +56,8 @@ module Homebrew
         flag "--file=",
              description: "Read the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout."
         switch "--global",
-               description: "Read the `Brewfile` from `~/.Brewfile` or " \
-                            "the `HOMEBREW_BUNDLE_FILE_GLOBAL` environment variable, if set."
+               description: "Read the global `Brewfile`, from the homebrew config directory or `~/.Brewfile`. " \
+                            "Override this path with the `HOMEBREW_BUNDLE_FILE_GLOBAL` environment variable."
         switch "-v", "--verbose",
                description: "`install` prints output from commands as they are run. " \
                             "`check` lists all missing dependencies."

--- a/lib/bundle/brewfile.rb
+++ b/lib/bundle/brewfile.rb
@@ -7,6 +7,7 @@ module Bundle
     def path(dash_writes_to_stdout: false, global: false, file: nil)
       env_bundle_file_global = ENV.fetch("HOMEBREW_BUNDLE_FILE_GLOBAL", nil)
       env_bundle_file = ENV.fetch("HOMEBREW_BUNDLE_FILE", nil)
+      user_config_home = ENV.fetch("HOMEBREW_USER_CONFIG_HOME", nil)
 
       filename = if global
         if env_bundle_file_global.present?
@@ -14,8 +15,12 @@ module Bundle
         else
           raise "'HOMEBREW_BUNDLE_FILE' cannot be specified with '--global'" if env_bundle_file.present?
 
-          Bundle.exchange_uid_if_needed! do
-            "#{Dir.home}/.Brewfile"
+          if user_config_home && File.exist?("#{user_config_home}/Brewfile")
+            "#{user_config_home}/Brewfile"
+          else
+            Bundle.exchange_uid_if_needed! do
+              "#{Dir.home}/.Brewfile"
+            end
           end
         end
       elsif file.present?

--- a/spec/bundle/brewfile_spec.rb
+++ b/spec/bundle/brewfile_spec.rb
@@ -11,8 +11,10 @@ describe Bundle::Brewfile do
     let(:dash_writes_to_stdout) { false }
     let(:env_bundle_file_global_value) { nil }
     let(:env_bundle_file_value) { nil }
+    let(:env_user_config_home_value) { "/Users/username/.homebrew" }
     let(:file_value) { nil }
     let(:has_global) { false }
+    let(:config_dir_brewfile_exist) { false }
 
     before do
       allow(ENV).to receive(:fetch).and_return(nil)
@@ -20,6 +22,11 @@ describe Bundle::Brewfile do
                                    .and_return(env_bundle_file_global_value)
       allow(ENV).to receive(:fetch).with("HOMEBREW_BUNDLE_FILE", any_args)
                                    .and_return(env_bundle_file_value)
+
+      allow(ENV).to receive(:fetch).with("HOMEBREW_USER_CONFIG_HOME", any_args)
+                                   .and_return(env_user_config_home_value)
+      allow(File).to receive(:exist?).with("/Users/username/.homebrew/Brewfile")
+                                     .and_return(config_dir_brewfile_exist)
     end
 
     context "when `file` is specified with a relative path" do
@@ -151,6 +158,15 @@ describe Bundle::Brewfile do
         let(:env_bundle_file_value) { "" }
 
         it "returns the value specified by `file` path" do
+          expect(path).to eq(expected_pathname)
+        end
+      end
+
+      context "when HOMEBREW_USER_CONFIG_HOME/Brewfile exists" do
+        let(:config_dir_brewfile_exist) { true }
+        let(:expected_pathname) { Pathname.new("#{env_user_config_home_value}/Brewfile") }
+
+        it "returns the expected path" do
           expect(path).to eq(expected_pathname)
         end
       end


### PR DESCRIPTION
Indirectly support XDG_CONFIG_HOME by leaning on `brew`'s support for it. 

when `--global` is set, we'll get the brewfile from:
- $HOMEBREW_BUNDLE_FILE_GLOBAL if set
- $XDG_CONFIG_HOME/homebrew/Brewfile (if XDG_CONFIG_HOME is set and file exists)
- $HOME/.homebrew/Brewfile (if XDG_CONFIG_HOME _is not_ set, and file exists)
- ~/.Brewfile (unconditional fallback, ~but if this doesn't exist either, we should probably use $HOMEBREW_USER_CONFIG_HOME/Brewfile as the new default~ [edit: per feedback])

Starting this as a draft because:
- looking for feedback on whether this change is welcome at all (I suspect so, per: https://github.com/Homebrew/homebrew-bundle/issues/1002#issuecomment-917613646)
- looking for feedback on what the fallback default should be if no file exists
- I still need to add tests. I'll need to add fixtures for a home dir, since currently tests are using the user's real $HOME, which we don't want to read or write from in rspec.
- need to update readme and `brew bundle --help` text