### PR TITLE
Use full names for linked and keg_only checks

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -187,11 +187,11 @@ module Bundle
     end
 
     def linked?
-      Formula[@name].linked?
+      Formula[@full_name].linked?
     end
 
     def keg_only?
-      Formula[@name].keg_only?
+      Formula[@full_name].keg_only?
     end
 
     def unlinked_and_keg_only?


### PR DESCRIPTION
---

#### Commits _(oldest to newest)_

9dfc103 fix(install): use full names for linked and keg_only checks

Minimal repro:

```console
❯ brew bundle --file - <<<'tap "gibfahn/tap", "https://github.com/gibfahn/homebrew-tap"
tap "gibfahn/tap2", "https://github.com/gibfahn/homebrew-tap"

brew "gibfahn/tap/check-sieve"'

Using gibfahn/tap
Using gibfahn/tap2
Using gibfahn/tap/check-sieve
Error: Formulae found in multiple taps:
       * gibfahn/tap/check-sieve
       * gibfahn/tap2/check-sieve

Please use the fully-qualified name (e.g. gibfahn/tap/check-sieve) to refer to a specific formula.
```

If you run with `HOMEBREW_DEBUG=1` you can see that the cause of this is
using the `@name` rather than the `@full_name` in the checks run after
the installation is complete.

<br/>