### PR TITLE
Fix some `brew typecheck homebrew/bundle` cases

### DIFF
--- a/spec/bundle/commands/check_command_spec.rbi
+++ b/spec/bundle/commands/check_command_spec.rbi
@@ -1,0 +1,2 @@
+class TestChecker < Bundle::Checker::Base
+end

--- a/spec/stub/formulary.rb
+++ b/spec/stub/formulary.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Formulary
+module Formulary
   def self.factory(name)
     Formula.new(name)
   end


### PR DESCRIPTION
- Add an RBI for a dynamically defined class
- Make `Formulary` a `module` like in Homebrew/brew