### PR TITLE
Add `postinstall` support for `brew` and `cask`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,13 @@ cask_args appdir: "~/Applications", require_sha: true
 
 # 'brew install'
 brew "imagemagick"
-# 'brew install --with-rmtp', 'brew link --overwrite', 'brew services restart' on version changes
-brew "denji/nginx/nginx-full", link: :overwrite, args: ["with-rmtp"], restart_service: :changed
+# 'brew install --with-rmtp', 'brew link --overwrite', 'brew services restart' even if no install/upgrade
+brew "denji/nginx/nginx-full", link: :overwrite, args: ["with-rmtp"], restart_service: :always
 # 'brew install', always 'brew services restart', 'brew link', 'brew unlink mysql' (if it is installed)
-brew "mysql@5.6", restart_service: true, link: true, conflicts_with: ["mysql"]
+brew "mysql@5.6", restart_service: :changed, link: true, conflicts_with: ["mysql"]
+# 'brew install' and run a command if installer or upgraded.
+brew "postgresql@16",
+     postinstall: "${HOMEBREW_PREFIX}/opt/postgresql@16/bin/postgres -D ${HOMEBREW_PREFIX}/var/postgresql@16"
 # install only on specified OS
 brew "gnupg" if OS.mac?
 brew "glibc" if OS.linux?
@@ -55,6 +58,8 @@ cask "firefox", args: { no_quarantine: true }
 cask "opera", greedy: true
 # 'brew install --cask' only if '/usr/libexec/java_home --failfast' fails
 cask "java" unless system "/usr/libexec/java_home", "--failfast"
+# 'brew install --cask' and run a command if installer or upgraded.
+cask "google-cloud-sdk", postinstall: "${HOMEBREW_PREFIX}/bin/gcloud components update"
 
 # 'mas install'
 mas "1Password", id: 443_987_910

--- a/lib/bundle/brew_dumper.rb
+++ b/lib/bundle/brew_dumper.rb
@@ -65,7 +65,7 @@ module Bundle
 
         args = f[:args].map { |arg| "\"#{arg}\"" }.sort.join(", ")
         brewline += ", args: [#{args}]" unless f[:args].empty?
-        brewline += ", restart_service: true" if !no_restart && BrewServices.started?(f[:full_name])
+        brewline += ", restart_service: :changed" if !no_restart && BrewServices.started?(f[:full_name])
         brewline += ", link: #{f[:link?]}" unless f[:link?].nil?
         brewline
       end.join("\n")

--- a/spec/bundle/cask_installer_spec.rb
+++ b/spec/bundle/cask_installer_spec.rb
@@ -134,5 +134,27 @@ describe Bundle::CaskInstaller do
         end
       end
     end
+
+    context "when the postinstall option is provided" do
+      before do
+        Bundle::CaskDumper.reset!
+        allow(Bundle::CaskDumper).to receive_messages(cask_names:          ["google-chrome"],
+                                                      outdated_cask_names: ["google-chrome"])
+        allow(Bundle).to receive(:brew).and_return(true)
+        allow(described_class).to receive(:upgrading?).and_return(true)
+      end
+
+      it "runs the postinstall command" do
+        expect(Bundle).to receive(:system).with("custom command", verbose: false).and_return(true)
+        expect(described_class.preinstall("google-chrome", postinstall: "custom command")).to be(true)
+        expect(described_class.install("google-chrome", postinstall: "custom command")).to be(true)
+      end
+
+      it "reports a failure when postinstall fails" do
+        expect(Bundle).to receive(:system).with("custom command", verbose: false).and_return(false)
+        expect(described_class.preinstall("google-chrome", postinstall: "custom command")).to be(true)
+        expect(described_class.install("google-chrome", postinstall: "custom command")).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows `postinstall` to be used to run a command after a formula or cask is installed.

While we're here, also adjust the `restart_service` behaviour to correctly match the comment i.e. require `always` to restart every time and otherwise just restart on an install or upgrade of a formula.