### PR TITLE
cmd/bundle: add HOMEBREW_BUNDLE_NO_UPGRADE.

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -63,7 +63,9 @@ module Homebrew
                description: "`install` prints output from commands as they are run. " \
                             "`check` lists all missing dependencies."
         switch "--no-upgrade",
+               env:         :bundle_no_upgrade,
                description: "`install` does not run `brew upgrade` on outdated dependencies. " \
+                            "`check` does not check for outdated dependencies. " \
                             "Note they may still be upgraded by `brew install` if needed."
         switch "-f", "--force",
                description: "`install` runs with `--force`/`--overwrite`. " \


### PR DESCRIPTION
This is already a `--no-upgrade` argument but let's add it as an environment variable for easier configuration.

While we're here, let's also correct the comment to note that it also affects `brew bundle check`.