### PR TITLE
commands/exec: don't use recursive deps.

### DIFF
--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -30,12 +30,11 @@ module Bundle
         require "formula"
         require "formulary"
 
-        ENV.deps = @dsl.entries.map do |entry|
+        ENV.deps = @dsl.entries.filter_map do |entry|
           next if entry.type != :brew
 
-          f = Formulary.factory(entry.name)
-          [f, f.recursive_dependencies.map(&:to_formula)]
-        end.flatten.compact
+          Formulary.factory(entry.name)
+        end
         ENV.keg_only_deps = ENV.deps.select(&:keg_only?)
         ENV.setup_build_environment
 


### PR DESCRIPTION
This (somewhat) makes sense when building formulae but doesn't make sense for `brew bundle exec`. The list should be fairly minimal and reflect actual project dependencies from the `Brewfile` rather than all recursive ones.