### PR TITLE
gitignore: add vendor to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Brewfile
 Gemfile.lock
 coverage
+vendor


### PR DESCRIPTION
This avoids committing the `vendor` directory to the repository or having e.g. `ripgrep` or VSCode search this directory.