### PR TITLE
cmd/bundle: use `~` instead of `${HOME}`

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -71,7 +71,7 @@ module Homebrew
         switch "--global",
                description: "Read the `Brewfile` from `$HOMEBREW_BUNDLE_FILE_GLOBAL` (if set), " \
                             "`${XDG_CONFIG_HOME}/homebrew/Brewfile` (if `$XDG_CONFIG_HOME` is set), " \
-                            "`${HOME}/.homebrew/Brewfile` or `${HOME}/.Brewfile` otherwise."
+                            "`~/.homebrew/Brewfile` or `~/.Brewfile` otherwise."
         switch "-v", "--verbose",
                description: "`install` prints output from commands as they are run. " \
                             "`check` lists all missing dependencies."


### PR DESCRIPTION
Partial revert of https://github.com/Homebrew/homebrew-bundle/pull/1579
See https://github.com/Homebrew/brew/pull/19153#discussion_r1930678587