### PR TITLE
{brew,cask}_installer: fix non-verbose postinstall.

### DIFF
--- a/lib/bundle/brew_installer.rb
+++ b/lib/bundle/brew_installer.rb
@@ -140,8 +140,8 @@ module Bundle
       return true if @postinstall.blank?
       return true unless changed?
 
-      puts "Running postinstall for #{@name}." if verbose
-      Bundle.system(@postinstall, verbose:)
+      puts "Running postinstall for #{@name}: #{@postinstall}" if verbose
+      Kernel.system(@postinstall)
     end
 
     def self.formula_installed_and_up_to_date?(formula, no_upgrade: false)

--- a/lib/bundle/cask_installer.rb
+++ b/lib/bundle/cask_installer.rb
@@ -75,8 +75,8 @@ module Bundle
       postinstall = options.fetch(:postinstall, nil)
       return true if postinstall.blank?
 
-      puts "Running postinstall for #{name}." if verbose
-      Bundle.system(postinstall, verbose:)
+      puts "Running postinstall for #{@name}: #{postinstall}" if verbose
+      Kernel.system(postinstall)
     end
 
     def self.cask_installed_and_up_to_date?(cask, no_upgrade: false)

--- a/spec/bundle/brew_installer_spec.rb
+++ b/spec/bundle/brew_installer_spec.rb
@@ -217,13 +217,13 @@ describe Bundle::BrewInstaller do
         end
 
         it "runs the postinstall command" do
-          expect(Bundle).to receive(:system).with("custom command", verbose: false).and_return(true)
+          expect(Kernel).to receive(:system).with("custom command").and_return(true)
           described_class.preinstall(formula, postinstall: "custom command")
           described_class.install(formula, postinstall: "custom command")
         end
 
         it "reports a failure" do
-          expect(Bundle).to receive(:system).with("custom command", verbose: false).and_return(false)
+          expect(Kernel).to receive(:system).with("custom command").and_return(false)
           described_class.preinstall(formula, postinstall: "custom command")
           expect(described_class.install(formula, postinstall: "custom command")).to be(false)
         end
@@ -235,7 +235,7 @@ describe Bundle::BrewInstaller do
         end
 
         it "does not run the postinstall command" do
-          expect(Bundle).not_to receive(:system)
+          expect(Kernel).not_to receive(:system)
           described_class.preinstall(formula, postinstall: "custom command")
           described_class.install(formula, postinstall: "custom command")
         end

--- a/spec/bundle/cask_installer_spec.rb
+++ b/spec/bundle/cask_installer_spec.rb
@@ -145,13 +145,13 @@ describe Bundle::CaskInstaller do
       end
 
       it "runs the postinstall command" do
-        expect(Bundle).to receive(:system).with("custom command", verbose: false).and_return(true)
+        expect(Kernel).to receive(:system).with("custom command").and_return(true)
         expect(described_class.preinstall("google-chrome", postinstall: "custom command")).to be(true)
         expect(described_class.install("google-chrome", postinstall: "custom command")).to be(true)
       end
 
       it "reports a failure when postinstall fails" do
-        expect(Bundle).to receive(:system).with("custom command", verbose: false).and_return(false)
+        expect(Kernel).to receive(:system).with("custom command").and_return(false)
         expect(described_class.preinstall("google-chrome", postinstall: "custom command")).to be(true)
         expect(described_class.install("google-chrome", postinstall: "custom command")).to be(false)
       end


### PR DESCRIPTION
This wasn't working as expected for multiple argument `postinstall`s unless in verbose mode so let's just use `Kernel.system` directly (which verbose mode was doing anyway and we already use in a few places).

Fixes https://github.com/Homebrew/homebrew-bundle/issues/1594