### PR TITLE
fix(bundle): dump installed casks on Linux

### DIFF
--- a/lib/bundle/extend/os/linux/bundle.rb
+++ b/lib/bundle/extend/os/linux/bundle.rb
@@ -6,9 +6,5 @@ module Bundle
     def mas_installed?
       false
     end
-
-    def cask_installed?
-      false
-    end
   end
 end


### PR DESCRIPTION
Adds cask dump support to Linux, by removing the default cask_installed? return. Fixes part of #1620.