### PR TITLE
Add support for e.g. `brew bundle env --install`

### DIFF
--- a/cmd/bundle.rbi
+++ b/cmd/bundle.rbi
@@ -37,10 +37,10 @@ class Homebrew::Cmd::BundleCmd::Args < Homebrew::CLI::Args
   def global?; end
 
   sig { returns(T::Boolean) }
-  def mas?; end
+  def install?; end
 
   sig { returns(T::Boolean) }
-  def no_lock?; end
+  def mas?; end
 
   sig { returns(T::Boolean) }
   def no_restart?; end

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -10,7 +10,7 @@ module Bundle
     module Exec
       module_function
 
-      def run(*args, global: false, file: nil)
+      def run(*args, global: false, file: nil, env: false)
         # Setup Homebrew's ENV extensions
         ENV.activate_extensions!
         raise UsageError, "No command to execute was specified!" if args.blank?
@@ -86,6 +86,13 @@ module Bundle
 
             ENV[key] = value.gsub(opt, "/Cellar/#{formula_name}/#{formula_version}\\1")
           end
+        end
+
+        if env
+          ENV.each do |key, value|
+            puts "export #{key}=\"#{value}\""
+          end
+          return
         end
 
         exec(*args)

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -64,8 +64,11 @@ module Bundle
         return false
       end
 
-      puts Formatter.success "Homebrew Bundle complete! " \
-                             "#{success} Brewfile #{Bundle::Dsl.pluralize_dependency(success)} now installed."
+      unless quiet
+        puts Formatter.success "Homebrew Bundle complete! " \
+                               "#{success} Brewfile #{Bundle::Dsl.pluralize_dependency(success)} now installed."
+      end
+
       true
     end
   end

--- a/spec/bundle/commands/exec_command_spec.rb
+++ b/spec/bundle/commands/exec_command_spec.rb
@@ -49,6 +49,15 @@ describe Bundle::Commands::Exec do
       end
     end
 
+    context "with env command" do
+      it "outputs the environment variables" do
+        ENV["HOMEBREW_PREFIX"] = "/opt/homebrew"
+
+        expect { described_class.run("env", env: true) }.to \
+          output(/HOMEBREW_PREFIX="#{ENV.fetch("HOMEBREW_PREFIX")}"/).to_stdout
+      end
+    end
+
     it "raises if called with a command that's not on the PATH" do
       allow(described_class).to receive_messages(exec: nil, which: nil)
       expect { described_class.run("bundle", "install") }.to raise_error(RuntimeError)


### PR DESCRIPTION
This should allow a one-liner in e.g. `eval $(brew bundle env --install)` to install all packages and setup the environment.

While we're here, also:
- make `--quiet` quieter by not outputting the success message
- remove the `--no-lock` flag as it's been hidden for a while