### PR TITLE
Improve `brew bundle env --install` output

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -160,7 +160,7 @@ module Homebrew
             raise UsageError, "`--install` cannot be used with `install`, `upgrade` or no subcommand."
           end
 
-          Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, quiet: true)
+          Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, output: $stderr, quiet: true)
         end
 
         case subcommand

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -6,11 +6,12 @@ module Bundle
     module Install
       module_function
 
-      def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false, quiet: false)
+      def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false,
+              output: $stdout, quiet: false)
         @dsl = Brewfile.read(global:, file:)
         Bundle::Installer.install(
           @dsl.entries,
-          global:, file:, no_lock:, no_upgrade:, verbose:, force:, quiet:,
+          global:, file:, no_lock:, no_upgrade:, verbose:, force:, output:, quiet:,
         ) || exit(1)
       end
 

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -6,7 +6,7 @@ module Bundle
     module_function
 
     def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false,
-                quiet: false)
+                output: $stdout, quiet: false)
       success = 0
       failure = 0
 
@@ -42,10 +42,10 @@ module Bundle
         next if Bundle::Skipper.skip? entry
 
         preinstall = if cls.preinstall(*args, **options, no_upgrade:, verbose:)
-          puts Formatter.success("#{verb} #{name}")
+          output.puts Formatter.success("#{verb} #{name}")
           true
         else
-          puts "Using #{name}" unless quiet
+          output.puts "Using #{name}" unless quiet
           false
         end
 
@@ -53,20 +53,20 @@ module Bundle
                        preinstall:, no_upgrade:, verbose:, force:)
           success += 1
         else
-          puts Formatter.error("#{verb} #{name} has failed!")
+          $stderr.puts Formatter.error("#{verb} #{name} has failed!")
           failure += 1
         end
       end
 
       unless failure.zero?
-        puts Formatter.error "Homebrew Bundle failed! " \
-                             "#{failure} Brewfile #{Bundle::Dsl.pluralize_dependency(failure)} failed to install."
+        dependency = Bundle::Dsl.pluralize_dependency(failure)
+        $stderr.puts Formatter.error "Homebrew Bundle failed! #{failure} Brewfile #{dependency} failed to install"
         return false
       end
 
       unless quiet
-        puts Formatter.success "Homebrew Bundle complete! " \
-                               "#{success} Brewfile #{Bundle::Dsl.pluralize_dependency(success)} now installed."
+        dependency = Bundle::Dsl.pluralize_dependency(success)
+        output.puts Formatter.success "Homebrew Bundle complete! #{success} Brewfile #{dependency} now installed."
       end
 
       true


### PR DESCRIPTION
Use `$stderr` for `brew bundle env --install` output that we don't want to be e.g. `eval`ed.