### PR TITLE
Improve brew bundle env/sh PATH

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -207,7 +207,6 @@ module Homebrew
         when "check"
           Bundle::Commands::Check.run(global:, file:, no_upgrade:, verbose:)
         when "exec", "sh", "env"
-          env = false
           named_args = case subcommand
           when "exec"
             _subcommand, *named_args = args.named
@@ -226,10 +225,9 @@ module Homebrew
             ENV["HOMEBREW_FORCE_API_AUTO_UPDATE"] = nil
             [subshell]
           when "env"
-            env = true
             ["env"]
           end
-          Bundle::Commands::Exec.run(*named_args, global:, file:, env:)
+          Bundle::Commands::Exec.run(*named_args, global:, file:, subcommand:)
         when "list"
           Bundle::Commands::List.run(
             global:,

--- a/lib/bundle/commands/exec.rb
+++ b/lib/bundle/commands/exec.rb
@@ -43,7 +43,7 @@ module Bundle
         HOMEBREW_GITHUB_PACKAGES_AUTH
       ].freeze
 
-      def run(*args, global: false, file: nil, env: false)
+      def run(*args, global: false, file: nil, subcommand: "")
         # Cleanup Homebrew's global environment
         HOMEBREW_ENV_CLEANUP.each { |key| ENV.delete(key) }
 
@@ -124,7 +124,12 @@ module Bundle
           end
         end
 
-        if env
+        # Ensure brew bundle sh/env commands have access to other tools in the PATH
+        if ["sh", "env"].include?(subcommand) && (homebrew_path = ENV.fetch("HOMEBREW_PATH", nil))
+          ENV.append_path "PATH", homebrew_path
+        end
+
+        if subcommand == "env"
           ENV.each do |key, value|
             puts "export #{key}=\"#{value}\""
           end

--- a/spec/bundle/commands/exec_command_spec.rb
+++ b/spec/bundle/commands/exec_command_spec.rb
@@ -52,8 +52,9 @@ describe Bundle::Commands::Exec do
     context "with env command" do
       it "outputs the environment variables" do
         ENV["HOMEBREW_PREFIX"] = "/opt/homebrew"
+        ENV["HOMEBREW_PATH"] = "/usr/bin"
 
-        expect { described_class.run("env", env: true) }.to \
+        expect { described_class.run("env", subcommand: "env") }.to \
           output(/HOMEBREW_PREFIX="#{ENV.fetch("HOMEBREW_PREFIX")}"/).to_stdout
       end
     end

--- a/spec/stub/extend/ENV.rb
+++ b/spec/stub/extend/ENV.rb
@@ -20,4 +20,6 @@ ENV.instance_eval do
   def refurbish_args; end
 
   def prepend_path(*args); end
+
+  def append_path(*args); end
 end


### PR DESCRIPTION
Ensure brew bundle sh/env commands have access to other tools in the PATH.