### PR TITLE
Error out with `--mas` for `brew bundle add`

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -240,11 +240,12 @@ module Homebrew
             vscode:    args.vscode? || args.all?,
           )
         when "add"
+          raise UsageError, "`add` does not support `--mas`." if args.mas?
+
           # We intentionally omit the `s` from `brews` and `casks` for ease of handling later.
           type_hash = {
             brew:      args.brews? || no_type_args,
             cask:      args.casks?,
-            mas:       args.mas?,
             whalebrew: args.whalebrew?,
             vscode:    args.vscode?,
           }


### PR DESCRIPTION
`mas` entries require an `id`, and it's not clear how to best handle
that right now. Let's just error out instead.

See discussion at #1632.
