### PR TITLE
Use `redirect_stdout` with `--install` argument

### DIFF
--- a/cmd/bundle.rb
+++ b/cmd/bundle.rb
@@ -166,7 +166,9 @@ module Homebrew
             raise UsageError, "`--install` cannot be used with `install`, `upgrade` or no subcommand."
           end
 
-          Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, output: $stderr, quiet: true)
+          redirect_stdout($stderr) do
+            Bundle::Commands::Install.run(global:, file:, no_upgrade:, verbose:, force:, quiet: true)
+          end
         end
 
         case subcommand

--- a/lib/bundle/commands/install.rb
+++ b/lib/bundle/commands/install.rb
@@ -7,11 +7,11 @@ module Bundle
       module_function
 
       def run(global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false,
-              output: $stdout, quiet: false)
+              quiet: false)
         @dsl = Brewfile.read(global:, file:)
         Bundle::Installer.install(
           @dsl.entries,
-          global:, file:, no_lock:, no_upgrade:, verbose:, force:, output:, quiet:,
+          global:, file:, no_lock:, no_upgrade:, verbose:, force:, quiet:,
         ) || exit(1)
       end
 

--- a/lib/bundle/installer.rb
+++ b/lib/bundle/installer.rb
@@ -6,7 +6,7 @@ module Bundle
     module_function
 
     def install(entries, global: false, file: nil, no_lock: false, no_upgrade: false, verbose: false, force: false,
-                output: $stdout, quiet: false)
+                quiet: false)
       success = 0
       failure = 0
 
@@ -42,10 +42,10 @@ module Bundle
         next if Bundle::Skipper.skip? entry
 
         preinstall = if cls.preinstall(*args, **options, no_upgrade:, verbose:)
-          output.puts Formatter.success("#{verb} #{name}")
+          puts Formatter.success("#{verb} #{name}")
           true
         else
-          output.puts "Using #{name}" unless quiet
+          puts "Using #{name}" unless quiet
           false
         end
 
@@ -66,7 +66,7 @@ module Bundle
 
       unless quiet
         dependency = Bundle::Dsl.pluralize_dependency(success)
-        output.puts Formatter.success "Homebrew Bundle complete! #{success} Brewfile #{dependency} now installed."
+        puts Formatter.success "Homebrew Bundle complete! #{success} Brewfile #{dependency} now installed."
       end
 
       true

--- a/spec/stub/extend/kernel.rb
+++ b/spec/stub/extend/kernel.rb
@@ -4,4 +4,8 @@ module Kernel
   def with_env(_hash)
     yield if block_given?
   end
+
+  def redirect_stdout(_file)
+    yield if block_given?
+  end
 end


### PR DESCRIPTION
This is much cleaner than passing around `output` and catching every `puts` call both here and in Homebrew itself.