### PR TITLE
bundle/commands/exec: improve PATH handling.

### DIFF
--- a/spec/bundle/commands/exec_command_spec.rb
+++ b/spec/bundle/commands/exec_command_spec.rb
@@ -33,7 +33,8 @@ describe Bundle::Commands::Exec do
 
       it "uses the formula version from the environment variable" do
         openssl_version = "1.1.1"
-        ENV["PATH"] = "/opt/homebrew/opt/openssl/bin"
+        ENV["PATH"] = "/opt/homebrew/opt/openssl/bin:/usr/bin:/bin"
+        ENV["MANPATH"] = "/opt/homebrew/opt/openssl/man"
         ENV["HOMEBREW_BUNDLE_EXEC_FORMULA_VERSION_OPENSSL"] = openssl_version
         described_class.run("bundle", "install")
         expect(ENV.fetch("PATH")).to include("/Cellar/openssl/1.1.1/bin")
@@ -53,6 +54,7 @@ describe Bundle::Commands::Exec do
       it "outputs the environment variables" do
         ENV["HOMEBREW_PREFIX"] = "/opt/homebrew"
         ENV["HOMEBREW_PATH"] = "/usr/bin"
+        allow(OS).to receive(:linux?).and_return(true)
 
         expect { described_class.run("env", subcommand: "env") }.to \
           output(/HOMEBREW_PREFIX="#{ENV.fetch("HOMEBREW_PREFIX")}"/).to_stdout

--- a/spec/stub/PATH.rb
+++ b/spec/stub/PATH.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class PATH
+  def initialize(*paths)
+    @paths = parse(paths)
+  end
+
+  def prepend(*paths)
+    @paths = parse(paths + @paths)
+  end
+
+  def reject(&block)
+    self.class.new(@paths.reject(&block))
+  end
+
+  def to_s
+    @paths.join(File::PATH_SEPARATOR)
+  end
+
+  private
+
+  def parse(paths)
+    paths.flatten
+         .compact
+         .flat_map { |p| Pathname(p).to_path.split(File::PATH_SEPARATOR) }
+         .uniq
+  end
+end


### PR DESCRIPTION
- don't add `pkg-config` to the PATH on macOS, it's not needed as a shim already exists in Homebrew on macOS for this and we're overriding it here
- replace `pkg-config` references with `pkgconf` which we use instead now to avoid unnecessary redirection
- any package with a version specified in an environment variable should be prepended to PATH-like environment variables, not appended
